### PR TITLE
Yet another kinetic srolling fix fix...

### DIFF
--- a/frescobaldi_app/qpopplerview/surface.py
+++ b/frescobaldi_app/qpopplerview/surface.py
@@ -483,7 +483,7 @@ class Surface(QWidget):
                     self._kineticData._maxSpeed = 64 #limit speed.
                     
                 elif self._kineticData._state == KineticData.AutoScroll:
-                    self._dragging = False
+                    self._dragging = True
                     self._kineticData._state = KineticData.Stop
                     self._kineticData._speed = QPoint(0,0)
             else:


### PR DESCRIPTION
Bad state change when left mouse down is sent while kinetic scrolling takes place. Not only it halts it abruptly, ut it also requires another click to start a new drag.

Regards,
Richard.
