### PR TITLE
use /usr/bin/env

### DIFF
--- a/frescobaldi
+++ b/frescobaldi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 import frescobaldi_app.main
 import app


### PR DESCRIPTION
this improves the situation in my mac os / macports setup where some modules are only installed for the python configured in env.
