### PR TITLE
Rename "Document" menu to "Documents"

### DIFF
--- a/frescobaldi_app/documentmenu.py
+++ b/frescobaldi_app/documentmenu.py
@@ -39,7 +39,7 @@ class DocumentMenu(QMenu):
         app.translateUI(self)
     
     def translateUI(self):
-        self.setTitle(_('menu title', '&Document'))
+        self.setTitle(_('menu title', '&Documents'))
     
     def populate(self):
         self.clear()


### PR DESCRIPTION
A "Document" window suggests finding commands related to the current document while this menu actually is a list of all open documents
