### PR TITLE
ly/util.py: Add range check for int2roman

### DIFF
--- a/frescobaldi_app/ly/util.py
+++ b/frescobaldi_app/ly/util.py
@@ -64,6 +64,8 @@ _roman_numerals = (("M", 1000), ("CM", 900), ("D", 500), ("CD", 400),
 ("IV", 4), ("I", 1))
 
 def int2roman(n):
+    if n < 1:
+        raise ValueError, 'Roman numerals must be positive integers, got %s' %n
     roman = []
     for ltr, num in _roman_numerals:
         k, n = divmod(n, num)


### PR DESCRIPTION
roman numerals must be positive integers, but the current implementation
of int2roman processed negative numbers without complaining (returning an erroneous result).

Now the function immediately returns an empty string if input < 1.
Not sure if raising an exception would be better.
