### PR TITLE
display path to lilypond command in "engrave custom" dialog

### DIFF
--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -40,6 +40,7 @@ import lilypondinfo
 import listmodel
 import widgets
 import qutil
+import util
 
 from . import command
 
@@ -152,7 +153,9 @@ class Dialog(QDialog):
         self.versionCombo.clear()
         for i in infos:
             icon = 'lilypond-run' if i.version() else 'dialog-error'
-            text = _("LilyPond {version}").format(version=i.versionString())
+            text = _("LilyPond {version} ({command})").format(
+                version=i.versionString(),
+                command=util.homify(i.command))
             self.versionCombo.addItem(icons.get(icon), text)
         self.versionCombo.setCurrentIndex(index)
     


### PR DESCRIPTION
As a LilyPond developer, i have multiple (>20) lilypond builds
in separate directories, with different patches applied etc.
Lilypond version number is not enough to tell them apart in the
"engrave custom" dialog, so i made the actual paths visible
there.  A more elegant solution would be to give builds names,
but i don't think it's worth the trouble.
