### PR TITLE
.gitignore: ignore some Mac OS X generated hidden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.pyc
 *~
 build/
-
+.DS_Store


### PR DESCRIPTION
On Mac OS X, [.DS_Store](http://en.wikipedia.org/wiki/.DS_Store) files are used by the Finder (file manager) to store some visual appearance settings of files and directories. They are created in (almost) every directory that the Finder accesses, so they are quite annoying when working with version control. They can be safely ignored.
