### PR TITLE
use absolutecmd() also for compilation

### DIFF
--- a/frescobaldi_app/engrave/command.py
+++ b/frescobaldi_app/engrave/command.py
@@ -47,7 +47,7 @@ def defaultJob(document, preview):
     i = info(document)
     j = job.Job()
     
-    command = [i.command]
+    command = [i.abscommand()]
     s = QSettings()
     s.beginGroup("lilypond_settings")
     if s.value("delete_intermediate_files", True, bool):


### PR DESCRIPTION
The absolutecmd() function of class LilyPondInfo was used to construct
LilyPond command lines in every case (version check, datadir check, ...)
except compilation.
This had the effect that the default LilyPond binary on Mac OS X and
Windows was shown as found and working in the Preferences, but failed
with a path/permissions error at the compilation stage.
Thus commits 9ae468e6511c50b5bc75b38bbf9dc9370e197698,
e413f6cec3957ce81dbb692e9adaf8dc60c6604e and
f2caa7334734a3d1a9e330f4417a40cf8609f423 were useless.

After this commit, abscommand() is used also to construct the
compilation command lines and the probable default paths on Mac OS X and
Windows are properly considered.

Thanks to Stefan Vollmar for his help in debugging this issue.
