### PR TITLE
fix QAction MenuRoles issues on Mac OS X

### DIFF
--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -25,6 +25,7 @@ from __future__ import unicode_literals
 
 import itertools
 import os
+import sys
 import weakref
 
 from PyQt4.QtCore import *
@@ -986,6 +987,17 @@ class ActionCollection(actioncollection.ActionCollection):
         self.window_fullscreen.setShortcuts([QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_F), QKeySequence(Qt.Key_F11)])
         
         self.help_manual.setShortcuts(QKeySequence.HelpContents)
+        
+        # roles
+        if sys.platform.startswith('darwin'):
+            if '.app/Contents/MacOS' in os.path.abspath(os.path.dirname(sys.argv[0])):
+                self.file_quit.setMenuRole(QAction.QuitRole)
+                self.edit_preferences.setMenuRole(QAction.PreferencesRole)
+                self.help_about.setMenuRole(QAction.AboutRole)
+            else:
+                self.file_quit.setMenuRole(QAction.NoRole)
+                self.edit_preferences.setMenuRole(QAction.NoRole)
+                self.help_about.setMenuRole(QAction.NoRole)
         
     def translateUI(self):
         self.file_new.setText(_("action: new document", "&New"))


### PR DESCRIPTION
Followup to issue #170 and commit 610932fd3c178aad34c596bca46163f94a15d0ed.

This commit explicitly assigns proper QAction MenuRoles to "Quit", "Preferences", "About" when Frescobaldi is run from an application bundle and explicitly assigns NoRole when it is run from the command line.
This is done only on Mac OS X.
(This should anyway be irrelevant, because MenuRoles should concern only Mac OS X.)

This way, when Frescobaldi is run from command line (and the application menu is named "Python"), those menu entries are in their respective menus, like on other platform.
On the other hand, when Frescobaldi is run from the application bundle (and the application menu is named "Frescobaldi"), those menu entries are in the application menu, as is expected for application bundles.

The only drawback is that when the entries are in the application menu, they are not localized.
Quoting from a comment of mine on issue #170:

> I would prefer the second option anyway, because the entries, although non localized, are in the place Mac users expect them to be; also, it is not infrequent to use non-localized applications, so this shouldn't confuse Mac users.

On the other hand users could see the "mixed localization", i.e. the fact that all menus but one are localized and one is still in English, as a bug.

What do you think?

The current situation is indeed inconsistent (even when Frescobaldi is run from command line): if the system language is English, menu entries are moved to application menu, while this is not the case if the system language is not English.
If you prefer not to have unlocalized menu entries and retain the menu entries in their respective menus, just tell me and I'll upload a new patch unconditionally setting NoRole on Mac OS X, like this:

```
        if sys.platform.startswith('darwin'):
            self.file_quit.setMenuRole(QAction.NoRole)
            self.edit_preferences.setMenuRole(QAction.NoRole)
            self.help_about.setMenuRole(QAction.NoRole)
```

(Maybe the check for 'darwin' operating system is unnecessary, since MenuRoles should not affect other systems.)
Explicitly setting NoRole at least makes all languages behave the same way.
