### PR TITLE
Empty strings

### DIFF
--- a/frescobaldi_app/help/cnt_engraving.py
+++ b/frescobaldi_app/help/cnt_engraving.py
@@ -212,16 +212,16 @@ class eng_preview_conf(page):
              var_descriptions([
                 ("debug-control-points-color", 
                     "red", 
-                    _("color of the debug control points")), 
+                    ""), 
                 ("debug-control-points-line-thickness", 
                     "0.05", 
-                    _("thickness of the control points lines")), 
+                    ""), 
                 ("debug-control-points-cross-thickness", 
                    "0.1", 
-                   _("thickness of the control points crosses")), 
+                   ""), 
                 ("debug-control-points-cross-size", 
                     "0.7", 
-                    _("size of the control points crosses"))])), 
+                    "")])), 
              (_("Color \\voiceXXX"),
              _("These Variables currently can't be redefined in input files.") + "<br />" +
              var_descriptions([


### PR DESCRIPTION
This is an alternative to your modification in 4fa392f59c78cf5dce6b38f8a28eb40f97b394be

I prefer empty non-translatable strings over redundant ones. I did it like this in the subsequent mode description and obviously missed that one in my original commit.l
