### PR TITLE
add absolute path of Python executable to restart command

### DIFF
--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -107,6 +107,9 @@ def run():
 def restart():
     """Restarts Frescobaldi."""
     args = [os.path.abspath(sys.argv[0])] + sys.argv[1:]
+    python_executable = sys.executable
+    if python_executable:
+        args = [python_executable] + args
     import subprocess
     subprocess.Popen(args)
     


### PR DESCRIPTION
otherwise, Frescobaldi would always be restarted using /usr/bin/python
as the Python executable, instead of the actual executable used to start
it the first time

(e.g. on Mac OS X the most convenient way to start Frescobaldi is using MacPorts to manage its dependencies; this means that the Python executable provided by MacPorts must be used, and not the one provided by the system in /usr/bin/python)
