### PR TITLE
Fix color in 'git branch' command

### DIFF
--- a/frescobaldi_app/vcs/gitrepo.py
+++ b/frescobaldi_app/vcs/gitrepo.py
@@ -133,6 +133,7 @@ class GitRepo(AbstractVCSRepo):
         If local == False also return 'remote' branches.
         """
         args = [] if local else ['-a']
+        args.append('--color=never')
         return [line.strip() for line in self._run_git_command('branch', args)]
         
     def checkout(self, branch):


### PR DESCRIPTION
As Janek reported colored git output (user setting)
shows up as color codes in the GUI.
disabling coloring for the current command does fix it.
