### PR TITLE
Add note about default session to Help

### DIFF
--- a/frescobaldi_app/preferences/prefshelp.py
+++ b/frescobaldi_app/preferences/prefshelp.py
@@ -61,6 +61,8 @@ class preferences_general(help.page):
             "to load if Frescobaldi is started without a filename. "
             "You can choose whether to start with one empty document, with the "
             "last used session, or with a specific session. "
+            "Please note that this only works when you have explicitly created "
+            "a session and set it to automatically add files on save to it."
             "See also {link}.").format(
             startup=_("Session to load if Frescobaldi is started without arguments"),
             link=help.contents.sessions.link()),


### PR DESCRIPTION
I only now have understood how this works, and this addition documents the current behaviour.
But I'll open a feature request to update the default behaviour.
