### PR TITLE
viewhighlighter.py: Fix indentation error

### DIFF
--- a/frescobaldi_app/viewhighlighter.py
+++ b/frescobaldi_app/viewhighlighter.py
@@ -74,7 +74,7 @@ class ViewHighlighter(widgets.arbitraryhighlighter.ArbitraryHighlighter, plugin.
         
         """
         if view is None:
-			view = self.parent()
+            view = self.parent()
         # sometimes in the destruction phase, view is a generic QWidget...
         try:
             cursor = view.textCursor()


### PR DESCRIPTION
The line was indented using tabs instead of spaces.
