### PR TITLE
highlight-timing: Restore one-second default

### DIFF
--- a/frescobaldi_app/matcher.py
+++ b/frescobaldi_app/matcher.py
@@ -49,7 +49,7 @@ class AbstractMatcher(object):
         from PyQt4.QtCore import QSettings
         s = QSettings()
         s.beginGroup("editor_highlighting")
-        self._match_duration = s.value("match", 0, type(0)) * 1000
+        self._match_duration = s.value("match", 1, type(0)) * 1000
 
     def setView(self, view):
         """Set the current View (to monitor for cursor position changes)."""


### PR DESCRIPTION
I think this update should be enough to restore the default
behaviour from existing Frescobaldi.

IISC AbstractMatcher is only used in this context, so I can simply
hard-code 1 second here.
