### PR TITLE
Fix link to lilypond-version-predicates.ily

### DIFF
--- a/frescobaldi_app/preview_mode/display-control-points.ily
+++ b/frescobaldi_app/preview_mode/display-control-points.ily
@@ -64,7 +64,7 @@
 #(cond ((not (defined? 'debug-control-points-color))
         (define debug-control-points-color red)))
 
-\include "lilypond-version-switch.ily"
+\include "lilypond-version-predicates.ily"
 
 #(define (make-cross-stencil coords cross-thickness arm-offset)
    ;; coords are the coordinates of the center of the cross


### PR DESCRIPTION
I replaced lilypond-version-switch through a more general
set of functions. Obviously I forgot to update all references.
