### PR TITLE
MIDI input: add key signature alterations mapping

### DIFF
--- a/frescobaldi_app/midiinput/__init__.py
+++ b/frescobaldi_app/midiinput/__init__.py
@@ -79,7 +79,8 @@ class MidiIn:
         targetchannel = self.widget().channel()
         if channel == targetchannel or targetchannel == 0:    # '0' captures all
             if notetype == 9 and value > 0:    # note on with velocity > 0
-                note = elements.Note(notenumber, self.widget().accidentals()==0)
+                notemapping = elements.NoteMapping(self.widget().keysignature(), self.widget().accidentals()==0)
+                note = elements.Note(notenumber, notemapping)
                 if self.widget().chordmode():
                     if not self._chord:    # no Chord instance?
                         self._chord = elements.Chord()

--- a/frescobaldi_app/midiinput/elements.py
+++ b/frescobaldi_app/midiinput/elements.py
@@ -6,14 +6,7 @@ import ly.pitch
 
 
 class Note:
-    def __init__(self, midinote, sharps=True):
-        if sharps:
-            # sharps
-            notemapping = notemapping_sharps
-        else:
-            # flats
-            notemapping = notemapping_flats
-        
+    def __init__(self, midinote, notemapping):
         # get correct note 0...11 = c...b
         # and octave corresponding to octave modifiers ',' & '''
         self._midinote = midinote
@@ -46,28 +39,73 @@ class Chord:
             return '<' + chord[:-1] + '>'    # strip last space
 
 
-notemapping_sharps = [(0, 0),    # c
-                      (0, 0.5),  # cis
-                      (1, 0),    # d
-                      (1, 0.5),  # dis
-                      (2, 0),    # e 
-                      (3, 0),    # f
-                      (3, 0.5),  # fis
-                      (4, 0),    # g
-                      (4, 0.5),  # gis
-                      (5, 0),    # a
-                      (5, 0.5),  # ais
-                      (6, 0)]    # b
+class NoteMappings:
+    def __init__(self):
+        self.key_order_sharp = [6, 1, 8, 3, 10, 5, 0]
+        self.key_order_flat = [10, 3, 8, 1, 6, 11, 4]
 
-notemapping_flats = [(0, 0),     # c
-                     (1, -0.5),  # des
-                     (1, 0),     # d
-                     (2, -0.5),  # es
-                     (2, 0),     # e 
-                     (3, 0),     # f
-                     (4, -0.5),  # ges
-                     (4, 0),     # g
-                     (5, -0.5),  # aes
-                     (5, 0),     # a
-                     (6, -0.5),  # bes
-                     (6, 0)]     # b
+        self.sharps = [(0, 0),    # c
+                       (0, 0.5),  # cis
+                       (1, 0),    # d
+                       (1, 0.5),  # dis
+                       (2, 0),    # e
+                       (3, 0),    # f
+                       (3, 0.5),  # fis
+                       (4, 0),    # g
+                       (4, 0.5),  # gis
+                       (5, 0),    # a
+                       (5, 0.5),  # ais
+                       (6, 0)]    # b
+
+        self.flats = [(0, 0),     # c
+                      (1, -0.5),  # des
+                      (1, 0),     # d
+                      (2, -0.5),  # es
+                      (2, 0),     # e
+                      (3, 0),     # f
+                      (4, -0.5),  # ges
+                      (4, 0),     # g
+                      (5, -0.5),  # aes
+                      (5, 0),     # a
+                      (6, -0.5),  # bes
+                      (6, 0)]     # b
+        # Construct all possible mappings using some replacement logic
+
+        # keysignature with sharps and flat accidentals
+        self.flat_mappings = [self.flats]
+        for i in range(len(self.key_order_sharp)):
+            mapping = list(self.flats) # copy existing list
+            for k in self.key_order_sharp[:i+1]:
+                n = mapping[k][0]
+                mapping[k] = (n-1 if k > 0 else 11, 0.5)
+            self.flat_mappings.append(mapping)
+
+        # keysignature with flatss and sharp accidentals
+        self.sharp_mappings = []
+        for i in range(len(self.key_order_flat)):
+            mapping = list(self.sharps) # copy existing list
+            for k in self.key_order_flat[:i+1]:
+                n = mapping[k][0]
+                mapping[k] = (n+1 if k < 11 else 0, -0.5)
+            self.sharp_mappings.append(mapping)
+
+class NoteMapping:
+    mappings = NoteMappings()
+
+    def __init__(self, keysignature, sharps=True):
+        if keysignature >= 0:
+            if sharps:
+                self.mapping = NoteMapping.mappings.sharps
+            else:
+                self.mapping = NoteMapping.mappings.flat_mappings[keysignature]
+        else:
+            if sharps:
+                self.mapping = NoteMapping.mappings.sharp_mappings[-keysignature-1]
+            else:
+                self.mapping = NoteMapping.mappings.flats
+
+    def __len__(self):
+        return len(self.mapping)
+
+    def __getitem__(self, index):
+        return self.mapping[index]

--- a/frescobaldi_app/midiinput/widget.py
+++ b/frescobaldi_app/midiinput/widget.py
@@ -25,6 +25,9 @@ class Widget(QWidget):
         self._midichannel = QComboBox()
         self._midichannel.addItems(['all']+[str(i) for i in range(1,17)])
         
+        self._labelkeysignature = QLabel()
+        self._keysignature = QComboBox()
+        
         self._labelaccidentals = QLabel()
         self._accidentals = QComboBox()
         
@@ -53,16 +56,18 @@ class Widget(QWidget):
         
         grid.addWidget(self._labelmidichannel, 0, 0)
         grid.addWidget(self._midichannel, 0, 1)
-        grid.addWidget(self._labelaccidentals, 1, 0)
-        grid.addWidget(self._accidentals, 1, 1)
-        grid.addWidget(self._labelchordmode, 2, 0)
-        grid.addWidget(self._chordmode, 2, 1)
-        grid.addWidget(self._labeldamper, 3, 0)
-        grid.addWidget(self._damper, 3, 1)
-        grid.addWidget(self._labelsostenuto, 4, 0)
-        grid.addWidget(self._sostenuto, 4, 1)
-        grid.addWidget(self._labelsoft, 5, 0)
-        grid.addWidget(self._soft, 5, 1)
+        grid.addWidget(self._labelkeysignature, 1, 0)
+        grid.addWidget(self._keysignature, 1, 1)
+        grid.addWidget(self._labelaccidentals, 2, 0)
+        grid.addWidget(self._accidentals, 2, 1)
+        grid.addWidget(self._labelchordmode, 3, 0)
+        grid.addWidget(self._chordmode, 3, 1)
+        grid.addWidget(self._labeldamper, 4, 0)
+        grid.addWidget(self._damper, 4, 1)
+        grid.addWidget(self._labelsostenuto, 5, 0)
+        grid.addWidget(self._sostenuto, 5, 1)
+        grid.addWidget(self._labelsoft, 6, 0)
+        grid.addWidget(self._soft, 6, 1)
         
         layout.addWidget(self._capture)
         
@@ -73,6 +78,9 @@ class Widget(QWidget):
     
     def channel(self):
         return self._midichannel.currentIndex()
+    
+    def keysignature(self):
+        return self._keysignature.currentIndex()-7
     
     def accidentals(self):
         return self._accidentals.currentIndex()
@@ -96,6 +104,25 @@ class Widget(QWidget):
 
     def translateUI(self):
         self._labelmidichannel.setText(_("MIDI channel"))
+        self._labelkeysignature.setText(_("Key signature"))
+        self._keysignature.addItems([
+            _("Ces major (7 flats)"),
+            _("Ges major (6 flats)"),
+            _("Des major (5 flats)"),
+            _("Aes major (4 flats)"),
+            _("Ees major (3 flats)"),
+            _("Bes major (2 flats)"),
+            _("F major (1 flat)"),
+            _("no key"),
+            _("G major (1 sharp)"),
+            _("D major (2 sharps)"),
+            _("A major (3 sharps)"),
+            _("E major (4 sharps)"),
+            _("B major (5 sharps)"),
+            _("Fis major (6 sharps)"),
+            _("Cis major (7 sharps)")
+            ])
+        self._keysignature.setCurrentIndex(7)
         self._labelaccidentals.setText(_("Accidentals"))
         self._accidentals.addItems([_("sharps"), _("flats")])
         self._labelchordmode.setText(_("Chord mode"))


### PR DESCRIPTION
Some times ago, I wanted to enter some music in G minor (or Bes major with sharps accidentals).
Using the current MIDI input, I have to continuously switch the accidentals combo box from sharps to flats.

To solve this, I added a key signature combo box to the Midi input panel, and modified the notes mapping according to a combination of the key signature and the value of the accidentals combo box.

For example, to enter Gminor music, you should choose "Bes Major (2 flats)" in the key signature combo box and sharps in the accidentals combo box. That way, when pressing the correct keyboard key, you will get flats for B and E accidentals, and sharps for the other accidentals (C, D, F, G).

Another side effect is that if you choose a Fes Major signature, pressing the B key will result in a "ces" note, which is what should be expected when using that kind of signature.
