### PR TITLE
Mac OS X: fix application bundle detection to set MenuRoles

### DIFF
--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -1021,7 +1021,9 @@ class ActionCollection(actioncollection.ActionCollection):
         
         # roles
         if sys.platform.startswith('darwin'):
-            if '.app/Contents/MacOS' in os.path.abspath(os.path.dirname(sys.argv[0])):
+            frozen = getattr(sys, 'frozen', '')
+            if (frozen == 'macosx_app') \
+            or ('.app/Contents/MacOS' in os.path.abspath(os.path.dirname(sys.argv[0]))):
                 self.file_quit.setMenuRole(QAction.QuitRole)
                 self.edit_preferences.setMenuRole(QAction.PreferencesRole)
                 self.help_about.setMenuRole(QAction.AboutRole)


### PR DESCRIPTION
Using py2app, sys.argv[0] is the original script instead of the
executable inside the application bundle.
To check if the script is executed from the application bundle, py2app
sets sys.frozen to "macosx_app".
The sys.argv[0] check is kept to maintain compatibility with other ways
of creating the application bundle (cx_Freeze, Platypus?).
