### PR TITLE
Ensure selected key signature alteration are always applied.

### DIFF
--- a/frescobaldi_app/midiinput/widget.py
+++ b/frescobaldi_app/midiinput/widget.py
@@ -80,7 +80,7 @@ class Widget(QWidget):
         return self._midichannel.currentIndex()
     
     def keysignature(self):
-        return self._keysignature.currentIndex()-7
+        return self._keysignature.currentIndex()
     
     def accidentals(self):
         return self._accidentals.currentIndex()


### PR DESCRIPTION
As a followup of PR #353, I modified the note mapping to ensure the key signature is always applied. 
This solves the corner case where if you selected Fes signature with flat alterations, entering a "b" gave you a "b" note instead of "ces".
