### PR TITLE
python-ly compatibility with Python 3

### DIFF
--- a/frescobaldi_app/ly/barcheck.py
+++ b/frescobaldi_app/ly/barcheck.py
@@ -153,6 +153,6 @@ def insert(cursor, music=None):
         measure_pos = 0
         
         for time, evt in event_list:
-            print time, evt
+            print(time, evt)
 
 


### PR DESCRIPTION
Now it installs without errors using Python 2.6, 2.7, 3.2, 3.3.
