### PR TITLE
Add option to copy (colored) document body only

### DIFF
--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -711,8 +711,10 @@ class MainWindow(QMainWindow):
         number_lines = QSettings().value("source_export/number_lines", False, bool)
         inline_style = QSettings().value("source_export/inline_copy", True, bool)
         as_plain_text = QSettings().value("source_export/copy_html_as_plain_text", False, bool)
+        document_body_only = QSettings().value("source_export/copy_document_body_only", False, bool)
         import highlight2html
-        html = highlight2html.html_inline(cursor, inline=inline_style, number_lines=number_lines)
+        html = highlight2html.html_inline(cursor, inline=inline_style, number_lines=number_lines,
+            full_html=not document_body_only)
         data = QMimeData()
         data.setText(html) if as_plain_text else data.setHtml(html)
         QApplication.clipboard().setMimeData(data)

--- a/frescobaldi_app/preferences/editor.py
+++ b/frescobaldi_app/preferences/editor.py
@@ -218,12 +218,14 @@ class SourceExport(preferences.Group):
         self.inlineStyleCopy = QCheckBox(toggled=self.changed)
         self.copyHtmlAsPlainText = QCheckBox(toggled=self.changed)
         self.inlineStyleExport = QCheckBox(toggled=self.changed)
-        
+        self.copyDocumentBodyOnly = QCheckBox(toggled=self.changed)
+
         layout.addWidget(self.numberLines)
         layout.addWidget(self.inlineStyleCopy)
         layout.addWidget(self.inlineStyleExport)
         layout.addWidget(self.copyHtmlAsPlainText)
-        
+        layout.addWidget(self.copyDocumentBodyOnly)
+
         app.translateUI(self)
     
     def translateUI(self):
@@ -248,6 +250,13 @@ class SourceExport(preferences.Group):
             "If enabled, HTML is copied to the clipboard as plain text. "
             "Use this when you want to type HTML formatted code in a "
             "plain text editing environment."))
+        self.copyDocumentBodyOnly.setText(_("Copy <pre> element only"))
+        self.copyDocumentBodyOnly.setToolTip('<qt>' + _(
+            "If enabled, only the content will be exported and enclosed "
+            "in a PRE tag. Otherwise, a full document will be created. "
+            "May be used in conjunction with using CSS and the plain text "
+            "option, to copy highlighted code in a text editor "
+            "when an external style sheet is already available."))
 
     def loadSettings(self):
         s = QSettings()
@@ -256,7 +265,8 @@ class SourceExport(preferences.Group):
         self.inlineStyleCopy.setChecked(s.value("inline_copy", True, bool))
         self.inlineStyleExport.setChecked(s.value("inline_export", False, bool))
         self.copyHtmlAsPlainText.setChecked(s.value("copy_html_as_plain_text", False, bool))
-    
+        self.copyDocumentBodyOnly.setChecked(s.value("copy_document_body_only", False, bool))
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup("source_export")
@@ -264,5 +274,6 @@ class SourceExport(preferences.Group):
         s.setValue("inline_copy", self.inlineStyleCopy.isChecked())
         s.setValue("inline_export", self.inlineStyleExport.isChecked())
         s.setValue("copy_html_as_plain_text", self.copyHtmlAsPlainText.isChecked())
+        s.setValue("copy_document_body_only", self.copyDocumentBodyOnly.isChecked())
 
 


### PR DESCRIPTION
Add an option that allows to export colored source code
- using CSS
- but only export the `<pre>...</pre>` element
- without a complete document

This makes sense in an environment where the CSS is already present as
an external style sheet (e.g. in the Lilypond blog ...)

This was present in my own earlier implementation of the source export dialog, and while I'm not sure if there are _that_ many users having that situation I think it _is_ a good addition.
