### PR TITLE
Browse recursively for include from include path

### DIFF
--- a/frescobaldi_app/autocomplete/documentdata.py
+++ b/frescobaldi_app/autocomplete/documentdata.py
@@ -120,8 +120,8 @@ class DocumentDataSource(plugin.DocumentPlugin):
         If the document has a local filename, looks in that directory,
         also in a subdirectory of it, if the directory argument is given.
         
-        Then looks in the user-set include paths, and finally in LilyPond's
-        own ly/ folder.
+        Then looks recursively in the user-set include paths, 
+        and finally in LilyPond's own ly/ folder.
         
         """
         names = []
@@ -139,7 +139,12 @@ class DocumentDataSource(plugin.DocumentPlugin):
         # names in specified include paths
         import documentinfo
         for basedir in documentinfo.info(self.document()).includepath():
-            names.extend(sorted(get_filenames(basedir)))
+            
+            # store dir relative to specified include path root
+            reldir = directory if directory else ""
+            # look for files in the current relative directory
+            for f in sorted(get_filenames(os.path.join(basedir, reldir), True)):
+                names.append(os.path.join(reldir, f))
         
         # names from LilyPond itself
         import engrave.command


### PR DESCRIPTION
This is something I was missing for a long time: I have by now a number of include paths specified in the preferences, but autocompetion of `\include` did not recursively search these directories, making autocompletion practically useless for that purpose. (For example I always had to look up when including a snippet from the openLilyLib snippets.

Now autocompletion
also suggest files from below the user-set include paths.

TODO:
- if the include paths contain identically named directories
  (I have several includes roots with a "layout" folder in it,
  other situations are quite plausible) then the next level will
  display a mixed (i.e. alphabetically sorted) list from all
  sources, which can be confusing).
  A suggestion is to group the autocompletion pop-up
  (something that would be good for other purposes too).
  There should be non-selectable group headers specifying
  - local files (relative to the document)
  - files from include paths
    - subheading for each include path
  - files from lilypond itself
    Group headings should only appear if there _are_ entries
    from it.
