### PR TITLE
Fix double dot in default filename

### DIFF
--- a/frescobaldi_app/documentinfo.py
+++ b/frescobaldi_app/documentinfo.py
@@ -96,7 +96,7 @@ def defaultfilename(document):
     if not filename:
         filename = document.documentName()
     ext = ly.lex.extensions[i.mode()]
-    return filename + "." + ext
+    return filename + ext
     
     
 class DocumentInfo(plugin.DocumentPlugin):


### PR DESCRIPTION
ly.lex.extensions items already contain the dot, so
it doesn't have to be concatenated explicitly.

Closes #472
