### PR TITLE
Comment out Object Editor for public release

### DIFF
--- a/frescobaldi_app/panelmanager.py
+++ b/frescobaldi_app/panelmanager.py
@@ -59,7 +59,7 @@ class PanelManager(plugin.MainWindowPlugin):
         self.loadPanel("layoutcontrol.LayoutControlOptions")
         # The Object editor is highly experimental and should be
         # commented out for stable releases.
-        self.loadPanel("objecteditor.ObjectEditor")
+#        self.loadPanel("objecteditor.ObjectEditor")
         
         self.createActions()
         


### PR DESCRIPTION
This should not go into the release version.

@pbjuhr: What about the preliminary text dragging functions?
I thought this might cause troubles without the object inspector (because I thought it would try to access it), but it seems we have already installed a guard that it is only accessed if it actually exists.
