### PR TITLE
Basic setup of mode shifter, see issue #538

### DIFF
--- a/frescobaldi_app/ly/pitch/transpose.py
+++ b/frescobaldi_app/ly/pitch/transpose.py
@@ -68,6 +68,34 @@ class Transposer(object):
             pitch.alter += doct * -6 + self.scale[pitch.note] - self.scale[note]
             pitch.octave += doct
             pitch.note = note
+            
+            
+class ModeShifter(Transposer):
+    """
+    Shift pitches to the optional mode.
+    
+    The scale should be formatted in analogy to the scale in the Transposer
+    parent class.
+    
+    The key should be an instance of ly.pitch.Pitch. 
+    """
+    def __init__(self, key, scale):
+        self.octave = 0
+        self.modpitches = [0] * 7
+        for i, s in enumerate(scale):
+            p = key.copy()
+            self.steps = i
+            self.alter = s
+            super(ModeShifter, self).transpose(p)
+            self.modpitches[p.note] = p
+        
+    def transpose(self, pitch):
+        mp = self.modpitches[pitch.note]
+        if pitch.note != mp.note or pitch.alter != mp.alter:
+            self.steps = mp.note - pitch.note
+            self.alter = (self.scale[mp.note] + mp.alter -
+                          self.scale[pitch.note] - pitch.alter)            
+            super(ModeShifter, self).transpose(pitch)
 
 
 class ModalTransposer(object):

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -324,6 +324,8 @@ def menu_tools_pitch(mainwindow):
     m.addSeparator()
     m.addAction(ac.pitch_transpose)
     m.addAction(ac.pitch_modal_transpose)
+    if vcs.app_is_git_controlled() or QSettings().value("experimental-features", False, bool):
+        m.addAction(ac.pitch_mode_shift)
     return m
 
 

--- a/frescobaldi_app/pitch/__init__.py
+++ b/frescobaldi_app/pitch/__init__.py
@@ -53,6 +53,7 @@ class Pitch(plugin.MainWindowPlugin):
         ac.pitch_abs2rel.triggered.connect(self.abs2rel)
         ac.pitch_transpose.triggered.connect(self.transpose)
         ac.pitch_modal_transpose.triggered.connect(self.modalTranspose)
+        ac.pitch_mode_shift.triggered.connect(self.modeShift)
     
     def rel2abs(self):
         from . import pitch
@@ -75,6 +76,13 @@ class Pitch(plugin.MainWindowPlugin):
         from . import pitch
         cursor = self.mainwindow().textCursor()
         transposer = pitch.getModalTransposer(cursor.document(), self.mainwindow())
+        if transposer:
+            pitch.transpose(cursor, transposer, self.mainwindow())
+            
+    def modeShift(self):
+        from . import pitch
+        cursor = self.mainwindow().textCursor()
+        transposer = pitch.getModeShifter(cursor.document(), self.mainwindow())
         if transposer:
             pitch.transpose(cursor, transposer, self.mainwindow())
     
@@ -102,10 +110,12 @@ class Actions(actioncollection.ActionCollection):
         self.pitch_abs2rel = QAction(parent)
         self.pitch_transpose = QAction(parent)
         self.pitch_modal_transpose = QAction(parent)
+        self.pitch_mode_shift = QAction(parent)
 
         self.pitch_language.setIcon(icons.get('tools-pitch-language'))
         self.pitch_transpose.setIcon(icons.get('tools-transpose'))
         self.pitch_modal_transpose.setIcon(icons.get('tools-transpose'))
+        self.pitch_mode_shift.setIcon(icons.get('tools-transpose'))
         
     def translateUI(self):
         self.pitch_language.setText(_("Pitch Name &Language"))
@@ -126,4 +136,7 @@ class Actions(actioncollection.ActionCollection):
         self.pitch_modal_transpose.setText(_("&Modal Transpose..."))
         self.pitch_modal_transpose.setToolTip(_(
             "Transposes all notes in the document or selection within a given mode."))
+        self.pitch_mode_shift.setText(_("Mode shift..."))
+        self.pitch_mode_shift.setToolTip(_(
+            "Transforms all notes in the document or selection to an optional mode."))
         


### PR DESCRIPTION
A function that in analogy with a transpose can change the pitches to adapt to an optional scale/mode. Example, change from C major to C Dorian, C Phrygian, C Lydian, C Mixolydian or C Aeolian (natural minor).

Present support for major, (harmonic) minor, natural minor and dorian modes.
