### PR TITLE
Fix typo in mode shift dialog

### DIFF
--- a/frescobaldi_app/pitch/pitch.py
+++ b/frescobaldi_app/pitch/pitch.py
@@ -197,7 +197,7 @@ def getModeShifter(document, mainwindow):
         return one and sec
     
     text = inputdialog.getText(mainwindow, _("Shift mode"), _(
-        "Please enter the mode to shift to. (i.e. \"D major\")"
+        "Please enter the mode to shift to. (e.g. \"d major\")"
         ), icon = icons.get('tools-transpose'),
         help = "mode_shift", validate = validate)
     if text:


### PR DESCRIPTION
The key has to be lower case, so the dialog should propose it right.
And I think "e.g." is more appropriate than "i.e." here.