### PR TITLE
Eliminating unichr

### DIFF
--- a/frescobaldi_app/autocomplete/documentdata.py
+++ b/frescobaldi_app/autocomplete/documentdata.py
@@ -23,6 +23,11 @@ Completions data harvested from a Document.
 
 from __future__ import unicode_literals
 
+try:
+    str = unicode
+except NameError:
+    pass
+
 import itertools
 import os
 
@@ -53,7 +58,7 @@ class DocumentDataSource(plugin.DocumentPlugin):
         """Scheme names, including those harvested from document."""
         schemewords = set(itertools.chain(
             ly.data.all_scheme_words(),
-            (unicode(t)
+            (str(t)
                 for t in harvest.schemewords(self.document())
                 if len(t) > 2),
             ))

--- a/frescobaldi_app/docbrowser/sourceviewer.py
+++ b/frescobaldi_app/docbrowser/sourceviewer.py
@@ -23,6 +23,10 @@ A dialog to view LilyPond source.
 
 from __future__ import unicode_literals
 
+try:
+    str = unicode
+except NameError:
+    pass
 
 from PyQt4.QtCore import QSettings, QSize, Qt
 from PyQt4.QtGui import QDialog, QLabel, QSizePolicy, QTextBrowser, QVBoxLayout
@@ -78,6 +82,6 @@ class SourceViewer(QDialog):
         self._reply.deleteLater()
         del self._reply
         self.textbrowser.clear()
-        self.textbrowser.setText(unicode(data, 'utf-8', 'replace'))
+        self.textbrowser.setText(str(data, 'utf-8', 'replace'))
         highlighter.highlight(self.textbrowser.document())
 

--- a/frescobaldi_app/hyphenator.py
+++ b/frescobaldi_app/hyphenator.py
@@ -17,6 +17,11 @@ License: LGPL. More info: http://python-hyphenator.googlecode.com/
 from __future__ import unicode_literals
 from __future__ import print_function
 
+try:
+    chr = unichr
+except NameError:
+    pass
+
 import codecs
 import re
 
@@ -34,7 +39,7 @@ parse = re.compile(r'(\d?)(\D?)').findall
 _hex_re = re.compile(r'\^{2}([0-9a-f]{2})')
 
 # replace the matched hex string with the corresponding unicode character
-_hex_repl = lambda matchObj: unichr(int(matchObj.group(1), 16))
+_hex_repl = lambda matchObj: chr(int(matchObj.group(1), 16))
 
 def replace_hex(text):
     """Replaces ^^xx (where xx is a two-digit hexadecimal value) occurrences
@@ -97,12 +102,12 @@ class HyphenationDictionary(object):
     """
     def __init__(self, filename):
         self.patterns = {}
-        with open(filename) as f:
+        with open(filename, 'rb') as f:
             # use correct encoding, specified in first line
             for encoding in f.readline().split():
-                if encoding != "charset":
+                if encoding != b"charset":
                     try:
-                        decoder = codecs.getreader(encoding)
+                        decoder = codecs.getreader(encoding.decode('ascii'))
                         break
                     except LookupError:
                         pass
@@ -259,10 +264,13 @@ class Hyphenator(object):
 if __name__ == "__main__":
     import sys
     dict_file = sys.argv[1]
-    word = sys.argv[2].decode('latin1')
+    word = sys.argv[2]
+    if not isinstance(word, type("")):
+        import locale
+        word = word.decode(locale.getpreferredencoding())
 
     h = Hyphenator(dict_file, left=1, right=1)
 
     for i in h(word):
-        print(i)
+        print(" \u2013 ".join(i))
 

--- a/frescobaldi_app/hyphendialog.py
+++ b/frescobaldi_app/hyphendialog.py
@@ -118,7 +118,7 @@ class HyphenDialog(QDialog):
     def load(self):
         current = po.setup.current()
         self._langs = [(language_names.languageName(lang, current), lang, dic)
-                       for lang, dic in findDicts().iteritems()]
+                       for lang, dic in findDicts().items()]
         self._langs.sort()
         for name, lang, dic in self._langs:
             self.listWidget.addItem("{0}  ({1})".format(name, lang))

--- a/frescobaldi_app/install/update.py
+++ b/frescobaldi_app/install/update.py
@@ -23,6 +23,11 @@ Performs upgrades in the settings structure.
 
 from __future__ import unicode_literals
 
+try:
+    string_types = basestring
+except NameError:
+    string_types = str
+
 from PyQt4.QtCore import QSettings
 
 import info
@@ -41,7 +46,7 @@ def moveSettingsToNewRoot():
     """Move all settings to one application file."""
     movelist = [[info.name, info.url, False], "metainfo", "snippets", "sessions", "sessiondata"]
     for moveitem in movelist:
-        if isinstance(moveitem, basestring):
+        if isinstance(moveitem, string_types):
             moveitem = [moveitem, info.name, True]
         o = QSettings(moveitem[1], moveitem[0])
         o.setFallbacksEnabled(False)

--- a/frescobaldi_app/ly/dom.py
+++ b/frescobaldi_app/ly/dom.py
@@ -38,6 +38,11 @@ Note: elements keep a weak reference to their parent.
 from __future__ import unicode_literals
 from __future__ import absolute_import # prevent picking old stale node.py from package
 
+try:
+    string_types = basestring
+except NameError:
+    string_types = str
+
 import fractions
 import re
 
@@ -219,7 +224,7 @@ class HandleVars(object):
         Otherwise the same method from the super class is called.
         """
         def newfunc(obj, name, *args):
-            if isinstance(name, type("")):
+            if isinstance(name, string_types):
                 return func(obj, name, *args)
             else:
                 f = getattr(super(HandleVars, obj), func.__name__)

--- a/frescobaldi_app/preferences/fontscolors.py
+++ b/frescobaldi_app/preferences/fontscolors.py
@@ -26,6 +26,11 @@ from __future__ import unicode_literals
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
 
+try:
+    str = unicode
+except NameError:
+    pass
+
 import app
 import icons
 import preferences
@@ -291,7 +296,7 @@ class FontsColors(preferences.Page):
 
 class BaseColors(QGroupBox):
     
-    changed = pyqtSignal(unicode)
+    changed = pyqtSignal(str)
     
     def __init__(self, parent=None):
         super(BaseColors, self).__init__(parent)

--- a/frescobaldi_app/preferences/shortcuts.py
+++ b/frescobaldi_app/preferences/shortcuts.py
@@ -79,7 +79,7 @@ class Shortcuts(preferences.Page):
                 allactions[action] = (collection, name)
         
         # keep a list of actions not in the menu structure
-        left = allactions.keys()
+        left = list(allactions.keys())
         
         def add_actions(menuitem, actions):
             """Add actions to a QTreeWidgetItem."""

--- a/frescobaldi_app/slexer.py
+++ b/frescobaldi_app/slexer.py
@@ -118,11 +118,10 @@ for t in s.tokens(
 from __future__ import unicode_literals
 from __future__ import print_function
 
-import sys
-if sys.version_info[0] < 3:
+try:
     str = unicode
-del sys
-
+except NameError:
+    pass
 
 import re
 

--- a/frescobaldi_app/widgets/charmap.py
+++ b/frescobaldi_app/widgets/charmap.py
@@ -26,6 +26,12 @@ When a character is clicked, a signal is emitted.
 
 from __future__ import unicode_literals
 
+try:
+    chr = unichr
+    str = unicode
+except NameError:
+    pass
+
 import unicodedata
 
 from PyQt4.QtCore import *
@@ -34,8 +40,8 @@ from PyQt4.QtGui import *
 
 class CharMap(QWidget):
     """A widget displaying a table of characters."""
-    characterSelected = pyqtSignal(unicode)
-    characterClicked = pyqtSignal(unicode)
+    characterSelected = pyqtSignal(str)
+    characterClicked = pyqtSignal(str)
     
     def __init__(self, parent=None):
         super(CharMap, self).__init__(parent)
@@ -68,13 +74,13 @@ class CharMap(QWidget):
             charcode = -1
         if self._selected != charcode:
             self._selected = charcode
-            self.characterSelected.emit(unichr(charcode))
+            self.characterSelected.emit(chr(charcode))
             self.update()
     
     def character(self):
         """Returns the currently selected character, if any."""
         if self._selected != -1:
-            return unichr(self._selected)
+            return chr(self._selected)
     
     def setDisplayFont(self, font):
         self._font.setFamily(font.family())
@@ -117,8 +123,8 @@ class CharMap(QWidget):
     def paintEvent(self, ev):
         rect = ev.rect()
         s = self._square
-        rows = range(rect.top() / s, rect.bottom() / s + 1)
-        cols = range(rect.left() / s, rect.right() / s + 1)
+        rows = range(rect.top() // s, rect.bottom() // s + 1)
+        cols = range(rect.left() // s, rect.right() // s + 1)
         
         painter = QPainter(self)
         painter.setPen(QPen(self.palette().color(QPalette.Window)))
@@ -148,8 +154,8 @@ class CharMap(QWidget):
                 elif printable:
                     painter.fillRect(col * s + 1, row * s + 1, s - 2, s - 2, tile)
                 painter.setPen(text_pen if printable else disabled_pen)
-                t = unichr(char)
-                x = col * s + s / 2 - metrics.width(t) / 2
+                t = chr(char)
+                x = col * s + s // 2 - metrics.width(t) // 2
                 y = row * s + 4 + metrics.ascent()
                 painter.drawText(x, y, t)
             else:
@@ -175,7 +181,7 @@ class CharMap(QWidget):
         if charcode != -1 and self.isprint(charcode):
             self.select(charcode)
             if ev.button() != Qt.RightButton:
-                self.characterClicked.emit(unichr(charcode))
+                self.characterClicked.emit(chr(charcode))
     
     def charcodeRect(self, charcode):
         """Returns the rectangular box around the given charcode, if any."""
@@ -222,17 +228,17 @@ class CharMap(QWidget):
     
     def getToolTipText(self, charcode):
         try:
-            return unicodedata.name(unichr(charcode))
+            return unicodedata.name(chr(charcode))
         except ValueError:
             pass
     
     def getWhatsThisText(self, charcode):
         try:
-            name = unicodedata.name(unichr(charcode))
+            name = unicodedata.name(chr(charcode))
         except ValueError:
             return
         return whatsthis_html.format(
-            self._font.family(), unichr(charcode), name, charcode)
+            self._font.family(), chr(charcode), name, charcode)
     
     def setShowToolTips(self, enabled):
         self._showToolTips = bool(enabled)
@@ -253,7 +259,7 @@ class CharMap(QWidget):
 
 def isprint(charcode):
     """Returns True if the given charcode is printable."""
-    return unicodedata.category(unichr(charcode)) not in ('Cc', 'Cn')
+    return unicodedata.category(chr(charcode)) not in ('Cc', 'Cn')
 
 
 whatsthis_html = """\

--- a/macosx/mac-app.py
+++ b/macosx/mac-app.py
@@ -20,10 +20,10 @@ from subprocess import Popen
 # See https://docs.python.org/3/howto/pyporting.html for details.
 # The following code is the same used in package six to define a
 # version independent string type for isinstance() tests.
-if sys.version_info[0] >= 3:
-    string_types = str
-else:
+try:
     string_types = basestring
+except NameError:
+    string_types = str
 
 macosx = os.path.realpath(os.path.dirname(__file__))
 root = os.path.dirname(macosx)


### PR DESCRIPTION
Python 3 doesn't understand `unichr` and `unicode`. I tend to use the approach where we code for Python 3 and make Python 2 "thoroughly-unicodized" using try-except construct. Thanks to separate namespaces, such tricks don't affect other modules.

The output of hyphenator has be greatly improved. It can deal with non-latin encodings on the command line.

python3 hyphenator.py /home/proskin/src/frescobaldi/frescobaldi_app/hyphdicts/hyph_ru_RU.dic попарнопротивопоставленные
попарнопротивопоставленны – е
попарнопротивопоставлен – ные
попарнопротивопостав – ленные
попарнопротивопо – ставленные
попарнопротиво – поставленные
попарнопроти – вопоставленные
попарнопро – тивопоставленные
попарно – противопоставленные
попар – нопротивопоставленные
по – парнопротивопоставленные

python3 hyphenator.py /home/proskin/src/frescobaldi/frescobaldi_app/hyphdicts/hyph_sv_SE.dic utställningsföremål
utställningsföre – mål
utställnings – föremål
utställ – ningsföremål
ut – ställningsföremål
