### PR TITLE
Plural forms working in Python 3

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -110,7 +110,7 @@ copy_plugins('iconengines')
 
 # copy the frescobaldi_app directory
 subprocess.call([sys.executable, 'setup.py', 'build_py',
-	'--build-lib', target_dir, '--compile'])
+                 '--build-lib', target_dir, '--compile'])
 
 # make an Inno Setup installer
 inno_script = b'''

--- a/frescobaldi_app/charmap/widget.py
+++ b/frescobaldi_app/charmap/widget.py
@@ -37,8 +37,8 @@ import listmodel
 
 # avoid handling characters above 0xFFFF in narrow Python builds
 _blocks = tuple(itertools.takewhile(
-	lambda block: block.end < sys.maxunicode,
-	unicode_blocks.blocks()))
+    lambda block: block.end < sys.maxunicode,
+        unicode_blocks.blocks()))
 
 
 class Widget(QWidget):

--- a/frescobaldi_app/file_import/__init__.py
+++ b/frescobaldi_app/file_import/__init__.py
@@ -45,7 +45,7 @@ class FileImport(plugin.MainWindowPlugin):
     def importMusicXML(self):
         """ Opens a MusicXML file. Converts it to ly by using musicxml2ly """
         filetypes = '{0} (*.xml);;{1} (*.mxl);;{2} (*)'.format(
-			_("XML Files"), _("MXL Files"), _("All Files"))
+            _("XML Files"), _("MXL Files"), _("All Files"))
         caption = app.caption(_("dialog title", "Import a MusicXML file"))
         directory = os.path.dirname(self.mainwindow().currentDocument().url().toLocalFile()) or app.basedir()
         importfile = QFileDialog.getOpenFileName(self.mainwindow(), caption, directory, filetypes)
@@ -91,13 +91,12 @@ class FileImport(plugin.MainWindowPlugin):
         
     def postImport(self, settings, doc):
         """Adaptations of the source after running musicxml2ly
-		
-		Present settings: 
-		Reformat source
+
+        Present settings:
+        Reformat source
         Remove superfluous durations
         Remove duration scaling
         Engrave directly
-		
         """
         cursor = QTextCursor(doc)		
         if settings[0]:

--- a/frescobaldi_app/file_import/musicxml.py
+++ b/frescobaldi_app/file_import/musicxml.py
@@ -93,22 +93,22 @@ class Dialog(QDialog):
         self.langLabel = QLabel()
         
         self.impChecks = [self.noartCheck,
-						  self.norestCheck,
-						  self.nolayoutCheck,
-						  self.nobeamCheck,
-						  self.useAbsCheck,
-						  self.commMidiCheck]
-		
+                          self.norestCheck,
+                          self.nolayoutCheck,
+                          self.nobeamCheck,
+                          self.useAbsCheck,
+                          self.commMidiCheck]
+
         self.formatCheck = QCheckBox()
         self.trimDurCheck = QCheckBox()
         self.removeScalesCheck = QCheckBox()
         self.runEngraverCheck = QCheckBox()
-						   
+
         self.postChecks = [self.formatCheck,
-						   self.trimDurCheck,
-						   self.removeScalesCheck,
-						   self.runEngraverCheck]								  
-        
+                           self.trimDurCheck,
+                           self.removeScalesCheck,
+                           self.runEngraverCheck]
+
         self.commandLineLabel = QLabel()
         self.commandLine = QTextEdit(acceptRichText=False)
         
@@ -212,7 +212,7 @@ class Dialog(QDialog):
             cmd.append('-m')
         index = self.langCombo.currentIndex()
         if index > 0:
-			cmd.append('--language=' + _langlist[index-1])
+            cmd.append('--language=' + _langlist[index - 1])
 
         cmd.append("$filename")
         self.commandLine.setText(' '.join(cmd))

--- a/frescobaldi_app/po/mofile.py
+++ b/frescobaldi_app/po/mofile.py
@@ -102,19 +102,19 @@ class MoFile(NullMoFile):
         self._plural = lambda n: int(n != 1)
         self._info = {}
         for context, msgs, tmsgs in parse_mo_split(buf):
-            if msgs[0] == '':
+            if msgs[0] == b'':
                 # header
                 info = parse_header(tmsgs[0])
                 try:
-                    charset = info.get('content-type', '').split('charset=')[1]
+                    charset = info.get(b'content-type', b'').split(b'charset=')[1].decode('ascii')
                 except IndexError:
                     pass
                 try:
-                    plural = info.get('plural-forms', '').split(';')[1].split('plural=')[1]
+                    plural = info.get(b'plural-forms', b'').split(b';')[1].split(b'plural=')[1]
                 except IndexError:
                     pass
                 else:
-                    f = parse_plural_expr(plural)
+                    f = parse_plural_expr(plural.decode(charset))
                     if f:
                         self._plural = f
                 # store as well
@@ -239,8 +239,8 @@ def parse_header(data):
     for line in data.splitlines():
         line = line.strip()
         if line:
-            if ':' in line:
-                key, val = line.split(':', 1)
+            if b':' in line:
+                key, val = line.split(b':', 1)
                 key = key.strip().lower()
                 val = val.strip()
                 info[key] = val
@@ -271,10 +271,10 @@ def parse_mo_decode(buf, default_charset="UTF-8"):
     """Parses and splits, returns three-tuples like parse_mo_split but decoded to unicode."""
     charset = default_charset
     for context, msgs, tmsgs in parse_mo_split(buf):
-        if msgs[0] == '':
+        if msgs[0] == b'':
             info = parse_header(tmsgs[0])
             try:
-                charset = info.get('content-type', '').split('charset=')[1]
+                charset = info.get(b'content-type', '').split(b'charset=')[1].decode("ascii")
             except IndexError:
                 pass
         yield (context.decode(charset) if context else None,

--- a/frescobaldi_app/po/mofile.py
+++ b/frescobaldi_app/po/mofile.py
@@ -322,9 +322,6 @@ def parse_plural_expr(text):
     py_expression = ' '.join(_expr())
     if py_expression:
         code = "lambda n: int({0})".format(py_expression)
-        try:
-            compiled_code = compile(code, '<plural_expression>', 'eval')
-        except Exception:
-            return
+        compiled_code = compile(code, '<plural_expression>', 'eval')
         return eval(compiled_code, {}, {})
 

--- a/frescobaldi_app/po/molint.py
+++ b/frescobaldi_app/po/molint.py
@@ -34,7 +34,9 @@ def molint(filename):
     
     """
     correct = True
-    for context, messages, translations in mofile.parse_mo_decode(open(filename, 'rb').read()):
+    with open(filename, 'rb') as f:
+        buf = f.read()
+    for context, messages, translations in mofile.parse_mo_decode(buf):
 
         # collect fields in messages
         s = set()

--- a/frescobaldi_app/po/setup.py
+++ b/frescobaldi_app/po/setup.py
@@ -92,11 +92,8 @@ def _setup():
     if language != "C":
         mo = find(language)
         if mo:
-            try:
-                install(mo)
-                return
-            except Exception:
-                pass
+            install(mo)
+            return
     install(None)
 
 @app.oninit


### PR DESCRIPTION
We have two places where all exceptions related to language files are silently ignored. That's wrong. The robustness principle says: "Be conservative in what you do, be liberal in what you accept from others". Language files is what we do, even if translations are done by third parties.

Removing those exception handlers immediately exposed problems in *.mo header handling in Python 3. They have been fixed, including functions called by molint.py. The later was also failing to close *.mo files.

The visible result is that plural forms work with Russian translation under Python 3 now (at the moment, they are only used when exporting snippets).

Tabs used for code indentation cause exceptions in Python 3. I've replaced them with spaces using formatting suggested by autopep8.