### PR TITLE
Python 3 issues with MusicXML import/export

### DIFF
--- a/frescobaldi_app/file_import/musicxml.py
+++ b/frescobaldi_app/file_import/musicxml.py
@@ -235,7 +235,6 @@ class Dialog(QDialog):
         cmd = self.getCmd()
         directory = os.path.dirname(self._document)
         proc = subprocess.Popen(cmd, cwd=directory,
-            universal_newlines = True,
             stdin = subprocess.PIPE,
             stdout = subprocess.PIPE,
             stderr = subprocess.PIPE)

--- a/frescobaldi_app/ly/musicxml/create_musicxml.py
+++ b/frescobaldi_app/ly/musicxml/create_musicxml.py
@@ -561,15 +561,15 @@ class MusicXML(object):
     def write(self, file, encoding='UTF-8', doctype=True):
         """ write XML to a file (file obj or filename) """
         if doctype:
-            f = open(file,'w')
-            f.write(xml_decl_txt+"\n")
-            f.write(doctype_txt+"\n")
-            self.tree.write(f, encoding=encoding, xml_declaration=False)
+            with open(file,'wb') as f:
+                f.write((xml_decl_txt + "\n").format(encoding=encoding).encode(encoding))
+                f.write((doctype_txt + "\n").encode(encoding))
+                self.tree.write(f, encoding=encoding, xml_declaration=False)
         else:
             self.tree.write(file, encoding=encoding, xml_declaration=True, method="xml")
 
 
-xml_decl_txt = """<?xml version="1.0" encoding="UTF-8"?>"""
+xml_decl_txt = """<?xml version="1.0" encoding="{encoding}"?>"""
 
 doctype_txt = """<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN"
                                 "http://www.musicxml.org/dtds/partwise.dtd">"""


### PR DESCRIPTION
Both commits involve changing files from text to binary mode. Text mode is may be convenient to read ASCII-only output. It may be a good choice for the code that only runs in Python 2 or Python 3. But if we want to support both versions of Python and deal with non-ASCII data (such as a non-latin filename in error output). Text files deal with different types on Python 2 and Python 3, even though both are called "str". Python 3 does the encoding/decoding for us, Python 2 doesn't. That's too much trouble and too little control over the encoding.

Another case of unclosed file has been caught. Python 3 is good at catching such errors.