### PR TITLE
Windows fixes and git robustness

### DIFF
--- a/frescobaldi_app/portmidi/__init__.py
+++ b/frescobaldi_app/portmidi/__init__.py
@@ -299,6 +299,10 @@ def _do_import_pypm():
     
     """
     import pypm
+    # Reject incompatible API, such as ActiveState PyPM
+    if not hasattr(pypm, "CountDevices"):
+        del pypm
+        raise ImportError("Unsupported pypm API")
     return pypm
 
 def _do_import_pyportmidi():

--- a/frescobaldi_app/vcs/gitrepo.py
+++ b/frescobaldi_app/vcs/gitrepo.py
@@ -43,61 +43,10 @@ class GitRepo(AbstractVCSRepo):
             raise GitError(_("The given directory '{rootdir} "
                              "doesn't seem to be a Git repository.".format(rootdir=root)))
         self.rootDir = root
-        self._read_config()
     
     # #########################
     # Internal helper functions
     
-    def _key_value(self, line):
-        """
-        Return a tuple with the key and value parts of a
-        .git/config section entry.
-        """
-        line = line.strip()
-        sep = line.find('=')
-        return (line[:sep-1], line[sep+2:])
-        
-    def _read_config(self):
-        """
-        Produce a hierarchical dictionary representing the
-        .git/config file.
-        Currently we will only use the 'branch' and 'remote'
-        dictionaries:
-        - self.config['branch']
-        - self.config['remote']
-        """
-        
-        # The Git object can only be instantiated with a valid repo.
-        # So we can assume .git/config to be present 
-        fin = open(os.path.join(self.rootDir, '.git', 'config'))
-        lines = fin.read().split('\n')
-        
-        # reset config dictionary
-        cf = self.config = {}
-        # target will be the (sub-)dictionary to add keys to
-        target = {}
-        # parse file
-        for line in lines:
-            if line == '' or line.strip().startswith('#'):
-                continue
-            elif line.startswith('['):
-                # add new section
-                items = line.strip('[').strip(']').split()
-                if not items[0] in cf:
-                    cf[items[0]] = {}
-                target = cf[items[0]]
-                if len(items) > 1:
-                    name = items[1].strip('"')
-                    if not name in target:
-                        target[name] = {}
-                    target = target[name]
-            else:
-                # add new key-value pair
-                key, value = self._key_value(line)
-                target[key] = value        
-        fin.close()
-        return
-                
     def _run_git_command(self, cmd, args = []): 
         """
         run a git command and return its output

--- a/frescobaldi_app/vcs/gitrepo.py
+++ b/frescobaldi_app/vcs/gitrepo.py
@@ -141,7 +141,9 @@ class GitRepo(AbstractVCSRepo):
         """
         args = [] if local else ['-a']
         args.append('--color=never')
-        return [line.strip() for line in self._run_git_command('branch', args)]
+        branches = [line.strip() for line in self._run_git_command('branch', args)]
+        branches = [line for line in branches if not line.endswith('.stgit')]
+        return branches
         
     def checkout(self, branch):
         """

--- a/frescobaldi_app/vcs/gitrepo.py
+++ b/frescobaldi_app/vcs/gitrepo.py
@@ -61,13 +61,9 @@ class GitRepo(AbstractVCSRepo):
         git_cmd = s.value("git", "git", type(""))
         git_cmd = git_cmd if git_cmd else "git"
         cmd = [git_cmd, cmd]
-        if isinstance(args, str) or isinstance(args, type("")):
-            cmd.append(args)
-        else:
-            cmd.extend(args)
-        pr = subprocess.Popen(' '.join(cmd), cwd = self.rootDir, 
-                              shell = True, 
-                              stdout = subprocess.PIPE, 
+        cmd.extend(args)
+        pr = subprocess.Popen(cmd, cwd = self.rootDir,
+                              stdout = subprocess.PIPE,
                               stderr = subprocess.PIPE,
                               universal_newlines = True)
         (out, error) = pr.communicate()
@@ -134,7 +130,7 @@ class GitRepo(AbstractVCSRepo):
         
     def remotes(self):
         """Return a string list with registered remote names"""
-        return self._run_git_command('remote show')
+        return self._run_git_command('remote', ['show'])
         
     def tracked_remote(self, branch):
         """

--- a/frescobaldi_app/vcs/gitrepo.py
+++ b/frescobaldi_app/vcs/gitrepo.py
@@ -174,7 +174,7 @@ class GitRepo(AbstractVCSRepo):
     
     def has_remote(self, remote):
         """Returns True if the given remote name is registered."""
-        return remote in self.config['remote']
+        return remote in self.remotes()
         
     def has_remote_branch(self, branch):
         """


### PR DESCRIPTION
I tried Frescobaldi on Windows under ActivePython 2.7.8.10. There were two fatal problems: pypm.Initialize() was missing and there was no "remote" section in .git/config - git for Windows forgot to create it. It turns out "import pypm" imports "PyPM", an ActiveState package manager. I used a simple hasattr() trick to reject it.

As for git, I was tired of errors due to .git/config, so I completely eliminated parsing that file. "git config" provides all that functionality and it's documented. While at that, I fixed running git in shell and disallowed passing strings as arguments - only lists are allowed now. Finally, STGit branches are fully hidden from view now. They don't contain the source tree; checking them out would remove the sources.