### PR TITLE
More changes needed after renaming info.py to appinfo.py

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -29,7 +29,7 @@ import sys
 from cx_Freeze import Executable, Freezer
 
 # access meta-information such as version, etc.
-from frescobaldi_app import info
+from frescobaldi_app import appinfo
 
 # find pypm by adding the dir of pygame to sys.path
 sys.path.append(imp.find_module('pygame')[1])
@@ -160,10 +160,10 @@ Filename: "{{app}}\\frescobaldi.exe";\
  Flags: postinstall nowait skipifsilent;
 
 '''.format(
-    version=info.version,
-    homepage=info.url,
-    author=info.maintainer,
-    comments=info.description,
+    version=appinfo.version,
+    homepage=appinfo.url,
+    author=appinfo.maintainer,
+    comments=appinfo.description,
     target=target_dir,
 )
 

--- a/frescobaldi-wininst.py
+++ b/frescobaldi-wininst.py
@@ -27,9 +27,9 @@ except ImportError:
 
 # Frescobaldi meta info (Possibly not accessible anymore on uninstall):
 try:
-    from frescobaldi_app import info
+    from frescobaldi_app import appinfo
 except ImportError:
-    info = None
+    appinfo = None
 
 
 # Icon:
@@ -80,7 +80,7 @@ def install_startmenu():
             get_special_folder_path('CSIDL_COMMON_STARTMENU'),
             get_special_folder_path('CSIDL_STARTMENU'),
             ):
-        menudir = os.path.join(startmenu, info.appname)
+        menudir = os.path.join(startmenu, appinfo.appname)
         if os.path.isdir(menudir):
             shortcut(menudir)
             break
@@ -96,22 +96,22 @@ def install_startmenu():
 
 def shortcut(directory):
     """Makes the Frescobaldi shortcut in the specified directory."""
-    lnk = os.path.join(directory, info.appname + ".lnk")
+    lnk = os.path.join(directory, appinfo.appname + ".lnk")
     create_shortcut(
-        python,             # path
-        info.description,   # description
-        lnk,                # link name
-        script,             # arguments
-        "",                 # workdir
-        icon,               # icon
-        0,                  # icon index
+        python,              # path
+        appinfo.description, # description
+        lnk,                 # link name
+        script,              # arguments
+        "",                  # workdir
+        icon,                # icon
+        0,                   # icon index
     )
     file_created(lnk)
-    print("* Added \"{0}\" to Start Menu".format(info.appname))
+    print("* Added \"{0}\" to Start Menu".format(appinfo.appname))
 
 def welcome():
     """Prints a nice welcome message in the installer."""
-    print("\nWelcome to {0} {1}!".format(info.appname, info.version))
+    print("\nWelcome to {0} {1}!".format(appinfo.appname, appinfo.version))
     
 
 ### Main:

--- a/frescobaldi_app/preferences/import_export.py
+++ b/frescobaldi_app/preferences/import_export.py
@@ -41,7 +41,7 @@ def exportTheme(widget, schemeName, filename):
     tfd = widget.currentSchemeData()
     root = ET.Element('frescobaldi-theme')
     root.set('name', schemeName)
-    comment = ET.Comment(_comment.format(info=info))
+    comment = ET.Comment(_comment.format(appinfo=appinfo))
     root.append(comment)
     d = ET.ElementTree(root)
     
@@ -139,7 +139,7 @@ def exportShortcut(widget, scheme, schemeName, filename):
         
     root = ET.Element('frescobaldi-shortcut')
     root.set('name', schemeName)
-    comment = ET.Comment(_comment.format(info=info))
+    comment = ET.Comment(_comment.format(appinfo=appinfo))
     root.append(comment)
     d = ET.ElementTree(root)
     

--- a/frescobaldi_app/snippet/import_export.py
+++ b/frescobaldi_app/snippet/import_export.py
@@ -51,7 +51,7 @@ def save(names, filename):
     root.tail = '\n'
     d = ET.ElementTree(root)
     
-    comment = ET.Comment(_comment.format(info=info))
+    comment = ET.Comment(_comment.format(appinfo=appinfo))
     comment.tail = '\n\n'
     root.append(comment)
     

--- a/frescobaldi_app/userguide/util.py
+++ b/frescobaldi_app/userguide/util.py
@@ -36,7 +36,7 @@ class Formatter(object):
     def html(self, name):
         """Return a full userguide page HTML."""
         page = Page(name)
-        from info import appname, version
+        from appinfo import appname, version
         
         parents = cache.parents(name) if name != 'index' else []
         children = cache.children(name)

--- a/macosx/build-dmg.sh
+++ b/macosx/build-dmg.sh
@@ -66,8 +66,8 @@ echo
 
 VERSION=`${MPPREFIX}/bin/python2.7 -c 'import os
 os.chdir("..")
-from frescobaldi_app import info
-print info.version'`
+from frescobaldi_app import appinfo
+print appinfo.version'`
 
 if git rev-parse --git-dir > /dev/null 2>&1
 then

--- a/macosx/mac-app.py
+++ b/macosx/mac-app.py
@@ -28,14 +28,14 @@ root = os.path.dirname(macosx)
 
 sys.path.insert(0, root)
 
-from frescobaldi_app import info
+from frescobaldi_app import appinfo
 try:
     from frescobaldi_app.portmidi import pm_ctypes
     dylib_name = pm_ctypes.dll_name
 except ImportError:
     dylib_name = None
 
-icon = '{0}/icons/{1}.icns'.format(macosx, info.name)
+icon = '{0}/icons/{1}.icns'.format(macosx, appinfo.name)
 ipstrings = '{0}/app_resources/InfoPlist.strings'.format(macosx)
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -43,11 +43,11 @@ parser.add_argument('-f', '--force', action = 'store_true', \
   help = 'force execution even if SCRIPT does not exist')
 parser.add_argument('-v', '--version', \
   help = 'version string for the application bundle, \
-  visible e.g. in \'Get Info\' and in \'Open with...\'', default = info.version)
+  visible e.g. in \'Get Info\' and in \'Open with...\'', default = appinfo.version)
 parser.add_argument('-s', '--script', \
   help = 'path of {0}\'s main script; you should use an absolute path, \
   so that the application bundle can be moved to another \
-  directory'.format(info.appname), default = '{0}/{1}'.format(root, info.name))
+  directory'.format(appinfo.appname), default = '{0}/{1}'.format(root, appinfo.name))
 parser.add_argument('-a', '--standalone', action = 'store_true', \
   help = 'build a standalone application bundle \
   (WARNING: some manual steps are required after the execution of this script)')
@@ -69,13 +69,13 @@ if args.standalone and not (isinstance(args.portmidi, string_types) and os.path.
     sys.exit('Error: \'{0}\' does not exist or is not a file.'.format(args.portmidi))
 
 plist = dict(
-    CFBundleName                  = info.appname,
-    CFBundleDisplayName           = info.appname,
+    CFBundleName                  = appinfo.appname,
+    CFBundleDisplayName           = appinfo.appname,
     CFBundleShortVersionString    = args.version,
     CFBundleVersion               = args.version,
-    CFBundleExecutable            = info.appname,
-    CFBundleIdentifier            = 'org.{0}.{0}'.format(info.name),
-    CFBundleIconFile              = '{0}.icns'.format(info.name),
+    CFBundleExecutable            = appinfo.appname,
+    CFBundleIdentifier            = 'org.{0}.{0}'.format(appinfo.name),
+    CFBundleIconFile              = '{0}.icns'.format(appinfo.name),
     NSHumanReadableCopyright      = u'Copyright © 2008-2014 Wilbert Berendsen.',
     CFBundleDocumentTypes         = [
         {
@@ -151,14 +151,14 @@ else:
 
 setup(
     app = [args.script],
-    name = info.appname,
+    name = appinfo.appname,
     options = {'py2app': options},
     setup_requires = ['py2app'],
     script_args = ['py2app']
 )
 
-app_resources = 'dist/{0}.app/Contents/Resources'.format(info.appname)
-icon_dest = '{0}/{1}.icns'.format(app_resources, info.name)
+app_resources = 'dist/{0}.app/Contents/Resources'.format(appinfo.appname)
+icon_dest = '{0}/{1}.icns'.format(app_resources, appinfo.name)
 print('copying file {0} -> {1}'.format(icon, icon_dest))
 shutil.copyfile(icon, icon_dest)
 os.chmod(icon_dest, 0o0644)
@@ -179,7 +179,7 @@ if args.standalone:
                 Popen(["patch", "-R", "-d..", "-p0"], stdin=input)
     print('removing file {0}/qt.conf'.format(app_resources))
     os.remove('{0}/qt.conf'.format(app_resources))
-    imageformats_dest = 'dist/{0}.app/Contents/PlugIns/imageformats'.format(info.appname)
+    imageformats_dest = 'dist/{0}.app/Contents/PlugIns/imageformats'.format(appinfo.appname)
     print('creating directory {0}'.format(imageformats_dest))
     os.makedirs(imageformats_dest, 0o0755)
     print("""
@@ -189,4 +189,4 @@ you need to perform the following steps manually:
 - copy libqsvg.dylib from Qt's 'plugins/imageformats' directory to '{1}',
 - execute Qt's macdeployqt tool on dist/{0}.app \
 (you can safely ignore the error about the failed copy of libqsvg.dylib).
-""".format(info.appname, imageformats_dest))
+""".format(appinfo.appname, imageformats_dest))


### PR DESCRIPTION
Renaming modules is hard, but this one was needed. There are many "info" variables around the source, it was confusing to have a module of the same name.

Some references to info.py were left after your patch. Some were found with regexes, some were found by pylint, some were found accidentally. I hope I didn't miss anything.