### PR TITLE
Adding assumed path to python-ly as mentioned in issue #592

### DIFF
--- a/frescobaldi_app/debug.py
+++ b/frescobaldi_app/debug.py
@@ -60,6 +60,11 @@ def modules():
 
 
 
+# include python-ly if possible
+import os
+lypath = os.path.realpath('../python-ly')
+if os.path.isdir(lypath):
+    sys.path.insert(1, lypath)
 
 # avoid builtins._ being overwritten
 sys.displayhook = app.displayhook


### PR DESCRIPTION
If we can assume a setup where python-ly and frescobaldi are next to each other in a directory, this will facilitate debugging latest version of both packages.