### PR TITLE
Fix traceback on magnifier use in Python 3

### DIFF
--- a/frescobaldi_app/qpopplerview/magnifier.py
+++ b/frescobaldi_app/qpopplerview/magnifier.py
@@ -81,7 +81,7 @@ class Magnifier(QWidget):
         pagePos = pos - page.pos()
         
         newPage = Page(page, self._scale)
-        if newPage != self._page:
+        if not newPage.same_page(self._page):
             if self._page:
                 self._page.magnifier = None
             self._page = newPage
@@ -121,8 +121,9 @@ class Page(object):
         self._rotation = page.rotation()
         self.magnifier = None
         
-    def __eq__(self, other):
+    def same_page(self, other):
         return (
+            other is not None and
             self._document() == other._document() and
             self._pageNumber == other._pageNumber and
             self._width == other._width and


### PR DESCRIPTION
Don't define `__eq__` for class Magnifier, it becomes unhashable. Rename
`__eq__` to `same_page`, check that its argument is not None.

---
I want it to be reviewed.

python3 passes None to `__eq__`, which causes a traceback:

```
Traceback (most recent call last):
  File "/home/proskin/src/frescobaldi/frescobaldi_app/qpopplerview/magnifier.py", line 84, in paintEvent
    if newPage != self._page:
  File "/home/proskin/src/frescobaldi/frescobaldi_app/qpopplerview/magnifier.py", line 126, in __eq__
    self._document() == other._document() and
AttributeError: 'NoneType' object has no attribute '_document'
```

python2 doesn't do that, it evaluates comparisons to None as False on its own. But simply adding protection against None is not enough. Python 3 gives another traceback:

```
Traceback (most recent call last):
  File "/home/proskin/src/frescobaldi/frescobaldi_app/qpopplerview/magnifier.py", line 96, in paintEvent
    cache.generate(self._page)
  File "/home/proskin/src/frescobaldi/frescobaldi_app/qpopplerview/cache.py", line 119, in generate
    scheduler.schedulejob(page)
  File "/home/proskin/src/frescobaldi/frescobaldi_app/qpopplerview/cache.py", line 235, in schedulejob
    self._waiting[page] = job
  File "/usr/lib/python3.4/weakref.py", line 365, in __setitem__
    self.data[ref(key, self._remove)] = value
TypeError: unhashable type: 'Page'
```

I noticed that "python2 -3 -Wall frescobaldi" warns about `__eq__` redefinition:

```
/home/proskin/src/frescobaldi/frescobaldi_app/qpopplerview/magnifier.py:106: DeprecationWarning: Overriding __eq__ blocks inheritance of __hash__ in 3.x
  class Page(object):
```

In case of Magnifier, it appears to be an actual problem, so I replaced `__eq__` with `same_page`.