### PR TITLE
Adding abc2ly and midi2ly imports

### DIFF
--- a/frescobaldi_app/file_import/__init__.py
+++ b/frescobaldi_app/file_import/__init__.py
@@ -41,6 +41,7 @@ class FileImport(plugin.MainWindowPlugin):
         ac = self.actionCollection = Actions()
         actioncollectionmanager.manager(mainwindow).addActionCollection(ac)
         ac.import_musicxml.triggered.connect(self.importMusicXML)
+        ac.import_midi.triggered.connect(self.importMidi)
         ac.import_abc.triggered.connect(self.importAbc)
 
     def importMusicXML(self):
@@ -58,6 +59,25 @@ class FileImport(plugin.MainWindowPlugin):
         except AttributeError:
             from . import musicxml
             dlg = self._importDialog = musicxml.Dialog(self.mainwindow())
+            dlg.addAction(self.mainwindow().actionCollection.help_whatsthis)
+            dlg.setWindowModality(Qt.WindowModal)
+        self.runImport()
+        
+    def importMidi(self):
+        """Opens an midi file. Converts it to ly by using midi2ly."""
+        filetypes = '{0} (*.midi);;{1} (*.mid);;{2} (*)'.format(
+            _("Midi Files"), _("Midi Files"), _("All Files"))
+        caption = app.caption(_("dialog title", "Import a midi file"))
+        directory = os.path.dirname(self.mainwindow().currentDocument().url().toLocalFile()) or app.basedir()
+        self.importfile = QFileDialog.getOpenFileName(self.mainwindow(), caption, directory, filetypes)
+        if not self.importfile:
+            return # the dialog was cancelled by user
+
+        try:
+            dlg = self._importDialog
+        except AttributeError:
+            from . import midi
+            dlg = self._importDialog = midi.Dialog(self.mainwindow())
             dlg.addAction(self.mainwindow().actionCollection.help_whatsthis)
             dlg.setWindowModality(Qt.WindowModal)
         self.runImport()
@@ -144,11 +164,14 @@ class Actions(actioncollection.ActionCollection):
     name = "file_import"
     def createActions(self, parent):
         self.import_musicxml = QAction(parent)
+        self.import_midi = QAction(parent)
         self.import_abc = QAction(parent)
 
     def translateUI(self):
         self.import_musicxml.setText(_("Import MusicXML..."))
         self.import_musicxml.setToolTip(_("Import a MusicXML file using musicxml2ly."))
+        self.import_midi.setText(_("Import Midi..."))
+        self.import_midi.setToolTip(_("Import a Midi file using midi2ly."))
         self.import_abc.setText(_("Import abc..."))
         self.import_abc.setToolTip(_("Import an abc file using abc2ly."))
 

--- a/frescobaldi_app/file_import/__init__.py
+++ b/frescobaldi_app/file_import/__init__.py
@@ -41,6 +41,7 @@ class FileImport(plugin.MainWindowPlugin):
         ac = self.actionCollection = Actions()
         actioncollectionmanager.manager(mainwindow).addActionCollection(ac)
         ac.import_musicxml.triggered.connect(self.importMusicXML)
+        ac.import_abc.triggered.connect(self.importAbc)
 
     def importMusicXML(self):
         """Opens a MusicXML file. Converts it to ly by using musicxml2ly."""
@@ -57,6 +58,25 @@ class FileImport(plugin.MainWindowPlugin):
         except AttributeError:
             from . import musicxml
             dlg = self._importDialog = musicxml.Dialog(self.mainwindow())
+            dlg.addAction(self.mainwindow().actionCollection.help_whatsthis)
+            dlg.setWindowModality(Qt.WindowModal)
+        self.runImport()
+        
+    def importAbc(self):
+        """Opens an abc file. Converts it to ly by using abc2ly."""
+        filetypes = '{0} (*.abc);;{1} (*)'.format(
+            _("ABC Files"), _("All Files"))
+        caption = app.caption(_("dialog title", "Import an abc file"))
+        directory = os.path.dirname(self.mainwindow().currentDocument().url().toLocalFile()) or app.basedir()
+        self.importfile = QFileDialog.getOpenFileName(self.mainwindow(), caption, directory, filetypes)
+        if not self.importfile:
+            return # the dialog was cancelled by user
+
+        try:
+            dlg = self._importDialog
+        except AttributeError:
+            from . import abc
+            dlg = self._importDialog = abc.Dialog(self.mainwindow())
             dlg.addAction(self.mainwindow().actionCollection.help_whatsthis)
             dlg.setWindowModality(Qt.WindowModal)
         self.runImport()
@@ -124,8 +144,11 @@ class Actions(actioncollection.ActionCollection):
     name = "file_import"
     def createActions(self, parent):
         self.import_musicxml = QAction(parent)
+        self.import_abc = QAction(parent)
 
     def translateUI(self):
         self.import_musicxml.setText(_("Import MusicXML..."))
         self.import_musicxml.setToolTip(_("Import a MusicXML file using musicxml2ly."))
+        self.import_abc.setText(_("Import abc..."))
+        self.import_abc.setToolTip(_("Import an abc file using abc2ly."))
 

--- a/frescobaldi_app/file_import/abc.py
+++ b/frescobaldi_app/file_import/abc.py
@@ -1,0 +1,88 @@
+# This file is part of the Frescobaldi project, http://www.frescobaldi.org/
+#
+# Copyright (c) 2008 - 2014 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Import ABC dialog.
+Uses abc2ly to create ly file from abc.
+In the dialog the options of abc2ly can be set. 
+"""
+
+from __future__ import unicode_literals
+
+from PyQt4.QtCore import QSettings, QSize
+from PyQt4.QtGui import (QCheckBox, QComboBox, QDialogButtonBox, QLabel)
+
+import app
+import qutil
+
+from . import toly_dialog
+
+
+class Dialog(toly_dialog.ToLyDialog):
+	
+    def __init__(self, parent=None):
+        
+        self.imp_prgm = "abc2ly"
+        self.userg = "abc_import"
+        
+        self.nobeamCheck = QCheckBox()
+        
+        self.impChecks = [self.nobeamCheck]
+        
+        self.nobeamCheck.setObjectName("import-beaming")
+        
+        self.impExtra = []
+        
+        super(Dialog, self).__init__(parent)
+        
+        app.translateUI(self)
+        qutil.saveDialogSize(self, "abc_import/dialog/size", QSize(480, 160))
+        
+        self.makeCommandLine()
+        
+        self.loadSettings()
+        
+    def translateUI(self):
+        self.nobeamCheck.setText(_("Import beaming"))
+        
+        self.buttons.button(QDialogButtonBox.Ok).setText(_("Run abc2ly"))
+        
+        super(Dialog, self).translateUI()
+    
+    def makeCommandLine(self):
+        """Reads the widgets and builds a command line."""
+        cmd = ["$abc2ly"]
+        if self.nobeamCheck.isChecked():
+            cmd.append('-b')
+
+        cmd.append("$filename")
+        self.commandLine.setText(' '.join(cmd))
+        
+    def loadSettings(self):
+        """Get users previous settings."""
+        self.imp_default = [True]
+        self.settings = QSettings()
+        self.settings.beginGroup('abc_import')
+        super(Dialog, self).loadSettings()
+        
+    def saveSettings(self):
+        """Save users last settings."""
+        self.settings = QSettings()
+        self.settings.beginGroup('abc_import')
+        super(Dialog, self).saveSettings()

--- a/frescobaldi_app/file_import/midi.py
+++ b/frescobaldi_app/file_import/midi.py
@@ -1,0 +1,89 @@
+# This file is part of the Frescobaldi project, http://www.frescobaldi.org/
+#
+# Copyright (c) 2008 - 2014 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Import Midi dialog.
+Uses midi2ly to create ly file from midi.
+In the dialog the options of midi2ly can be set. 
+"""
+
+from __future__ import unicode_literals
+
+from PyQt4.QtCore import QSettings, QSize
+from PyQt4.QtGui import (QCheckBox, QComboBox, QDialogButtonBox, QLabel)
+
+import app
+import qutil
+
+from . import toly_dialog
+
+
+
+class Dialog(toly_dialog.ToLyDialog):
+	
+    def __init__(self, parent=None):
+        
+        self.imp_prgm = "midi2ly"
+        self.userg = "midi_import"
+        
+        self.useAbsCheck = QCheckBox()
+        
+        self.impChecks = [self.useAbsCheck]
+        
+        self.useAbsCheck.setObjectName("absolute-mode")
+        
+        self.impExtra = []
+        
+        super(Dialog, self).__init__(parent)
+        
+        app.translateUI(self)
+        qutil.saveDialogSize(self, "midi_import/dialog/size", QSize(480, 260))
+        
+        self.makeCommandLine()
+        
+        self.loadSettings()
+        
+    def translateUI(self):
+        self.useAbsCheck.setText(_("Pitches in absolute mode"))
+        
+        self.buttons.button(QDialogButtonBox.Ok).setText(_("Run midi2ly"))
+        
+        super(Dialog, self).translateUI()
+    
+    def makeCommandLine(self):
+        """Reads the widgets and builds a command line."""
+        cmd = ["$midi2ly"]
+        if self.useAbsCheck.isChecked():
+            cmd.append('-a')
+
+        cmd.append("$filename")
+        self.commandLine.setText(' '.join(cmd))
+        
+    def loadSettings(self):
+        """Get users previous settings."""
+        self.imp_default = [False]
+        self.settings = QSettings()
+        self.settings.beginGroup('midi_import')
+        super(Dialog, self).loadSettings()
+        
+    def saveSettings(self):
+        """Save users last settings."""
+        self.settings = QSettings()
+        self.settings.beginGroup('midi_import')
+        super(Dialog, self).saveSettings()

--- a/frescobaldi_app/file_import/musicxml.py
+++ b/frescobaldi_app/file_import/musicxml.py
@@ -19,31 +19,19 @@
 
 """
 Import Music XML dialog.
-Uses musicxml2ly to create ly fil from xml
-In the dialog the options of musicxml2ly can be set 
+Uses musicxml2ly to create ly file from xml.
+In the dialog the options of musicxml2ly can be set. 
 """
 
 from __future__ import unicode_literals
 
-import os
-import subprocess
-import collections
-
 from PyQt4.QtCore import QSettings, QSize
-from PyQt4.QtGui import (QCheckBox, QComboBox, QDialog, QDialogButtonBox,
-    QGridLayout, QLabel, QTabWidget, QTextEdit, QWidget)
+from PyQt4.QtGui import (QCheckBox, QComboBox, QDialogButtonBox, QLabel)
 
 import app
-import documentinfo
-import userguide
-import icons
-import job
-import jobmanager
-import lilypondinfo
-import listmodel
-import widgets
 import qutil
-import util
+
+from . import toly_dialog
 
 # language names musicxml2ly allows
 _langlist = [
@@ -61,26 +49,12 @@ _langlist = [
 ]
 
 
-class Dialog(QDialog):
+class Dialog(toly_dialog.ToLyDialog):
 	
     def __init__(self, parent=None):
-        super(Dialog, self).__init__(parent)
-        self._document = None
-        self._path = None
         
-        mainLayout = QGridLayout()
-        self.setLayout(mainLayout)
-        
-        tabs = QTabWidget()
-        
-        import_tab = QWidget()
-        post_tab = QWidget()
-        
-        itabLayout = QGridLayout(import_tab)
-        ptabLayout = QGridLayout(post_tab)
-        
-        tabs.addTab(import_tab, "musicxml2ly")
-        tabs.addTab(post_tab, "after import")
+        self.imp_prgm = "musicxml2ly"
+        self.userg = "musicxml_import"
         
         self.noartCheck = QCheckBox()
         self.norestCheck = QCheckBox()
@@ -98,67 +72,7 @@ class Dialog(QDialog):
                           self.nobeamCheck,
                           self.useAbsCheck,
                           self.commMidiCheck]
-
-        self.formatCheck = QCheckBox()
-        self.trimDurCheck = QCheckBox()
-        self.removeScalesCheck = QCheckBox()
-        self.runEngraverCheck = QCheckBox()
-
-        self.postChecks = [self.formatCheck,
-                           self.trimDurCheck,
-                           self.removeScalesCheck,
-                           self.runEngraverCheck]
-
-        self.commandLineLabel = QLabel()
-        self.commandLine = QTextEdit(acceptRichText=False)
         
-        self.setChecksObjectNames()
-        
-        self.buttons = QDialogButtonBox(
-            QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        userguide.addButton(self.buttons, "musicxml_import")
-        
-        self.langCombo.addItem('')
-        self.langCombo.addItems(_langlist)
-
-        itabLayout.addWidget(self.noartCheck, 0, 0, 1, 2)
-        itabLayout.addWidget(self.norestCheck, 1, 0, 1, 2)
-        itabLayout.addWidget(self.nolayoutCheck, 2, 0, 1, 2)
-        itabLayout.addWidget(self.nobeamCheck, 3, 0, 1, 2)
-        itabLayout.addWidget(self.useAbsCheck, 4, 0, 1, 2)
-        itabLayout.addWidget(self.commMidiCheck, 5, 0, 1, 2)
-        itabLayout.addWidget(self.langLabel, 6, 0, 1, 2)
-        itabLayout.addWidget(self.langCombo, 7, 0, 1, 2)
-        itabLayout.addWidget(widgets.Separator(), 8, 0, 1, 2)
-        itabLayout.addWidget(self.commandLineLabel, 9, 0, 1, 2)
-        itabLayout.addWidget(self.commandLine, 10, 0, 1, 2)
-        
-        ptabLayout.addWidget(self.formatCheck, 0, 0, 1, 2)
-        ptabLayout.addWidget(self.trimDurCheck, 1, 0, 1, 2)       
-        ptabLayout.addWidget(self.removeScalesCheck, 2, 0, 1, 2)
-        ptabLayout.addWidget(self.runEngraverCheck, 3, 0, 1, 2)
-        ptabLayout.setRowStretch(4, 10)
-        
-        mainLayout.addWidget(tabs, 0, 0, 9, 2)
-        mainLayout.addWidget(self.buttons, 10, 0, 1, 2)
-        
-        app.translateUI(self)
-        qutil.saveDialogSize(self, "xml_import/dialog/size", QSize(480, 260))
-        self.buttons.accepted.connect(self.accept)
-        self.buttons.rejected.connect(self.reject)
-        
-        self.noartCheck.toggled.connect(self.makeCommandLine)
-        self.norestCheck.toggled.connect(self.makeCommandLine)
-        self.nolayoutCheck.toggled.connect(self.makeCommandLine)
-        self.nobeamCheck.toggled.connect(self.makeCommandLine)
-        self.useAbsCheck.toggled.connect(self.makeCommandLine)
-        self.commMidiCheck.toggled.connect(self.makeCommandLine)
-        self.langCombo.currentIndexChanged.connect(self.makeCommandLine)
-        self.makeCommandLine()
-        
-        self.loadSettings()
-        
-    def setChecksObjectNames(self):
         self.noartCheck.setObjectName("articulation-directions")
         self.norestCheck.setObjectName("rest-positions")
         self.nolayoutCheck.setObjectName("page-layout")
@@ -166,11 +80,21 @@ class Dialog(QDialog):
         self.useAbsCheck.setObjectName("absolute-mode")
         self.commMidiCheck.setObjectName("comment-out-midi")
         
-        self.formatCheck.setObjectName("reformat")
-        self.trimDurCheck.setObjectName("trim-durations")
-        self.removeScalesCheck.setObjectName("remove-scaling")
-        self.runEngraverCheck.setObjectName("engrave-directly")
-    
+        self.langCombo.addItem('')
+        self.langCombo.addItems(_langlist)
+        
+        self.impExtra = [self.langLabel, self.langCombo]
+        
+        super(Dialog, self).__init__(parent)
+        
+        self.langCombo.currentIndexChanged.connect(self.makeCommandLine)
+        app.translateUI(self)
+        qutil.saveDialogSize(self, "musicxml_import/dialog/size", QSize(480, 260))
+        
+        self.makeCommandLine()
+        
+        self.loadSettings()
+        
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Import Music XML")))
         self.noartCheck.setText(_("Import articulation directions"))
@@ -179,21 +103,13 @@ class Dialog(QDialog):
         self.nobeamCheck.setText(_("Import beaming"))
         self.useAbsCheck.setText(_("Pitches in absolute mode"))
         self.commMidiCheck.setText(_("Comment out midi block"))
-        self.commandLineLabel.setText(_("Command line:"))
         
         self.langLabel.setText(_("Language for pitch names"))
         self.langCombo.setItemText(0, _("Default"))
-        self.formatCheck.setText(_("Reformat source"))
-        self.trimDurCheck.setText(_("Trim durations (Make implicit per line)"))
-        self.removeScalesCheck.setText(_("Remove fraction duration scaling"))
-        self.runEngraverCheck.setText(_("Engrave directly"))
         
         self.buttons.button(QDialogButtonBox.Ok).setText(_("Run musicxml2ly"))
-
-    
-    def setDocument(self, path):
-        """Set the full path to the MusicXML document."""
-        self._document = path
+        
+        super(Dialog, self).translateUI()
     
     def makeCommandLine(self):
         """Reads the widgets and builds a command line."""
@@ -216,49 +132,14 @@ class Dialog(QDialog):
 
         cmd.append("$filename")
         self.commandLine.setText(' '.join(cmd))
-    
-    def getCmd(self):
-        """Returns the command line."""
-        cmd = []
-        for t in self.commandLine.toPlainText().split():
-            if t == '$musicxml2ly':
-                cmd.extend(lilypondinfo.preferred().toolcommand('musicxml2ly'))
-            elif t == '$filename':
-                cmd.append(self._document)
-            else:
-                cmd.append(t)
-        cmd.extend(['--output', '-'])
-        return cmd
-        
-    def run_command(self):
-        """ Run command line """
-        cmd = self.getCmd()
-        directory = os.path.dirname(self._document)
-        proc = subprocess.Popen(cmd, cwd=directory,
-            stdin = subprocess.PIPE,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE)
-        stdouterr = proc.communicate()
-        return stdouterr
-		
-    def getPostSettings(self):
-        """ returns settings in the post import tab """
-        post = []
-        for p in self.postChecks:
-            post.append(p.isChecked())
-        return post
         
     def loadSettings(self):
-        """ get users previous settings """
-        imp_default = [False, False, False, False, False, False]
-        post_default = [True, False, False, True]
-        s = QSettings()
-        s.beginGroup('xml_import')
-        for i, d in zip(self.impChecks, imp_default):
-            i.setChecked(s.value(i.objectName(), d, bool))
-        for p, f in zip(self.postChecks, post_default):
-            p.setChecked(s.value(p.objectName(), f, bool))
-        lang = s.value("language", "default", type(""))
+        """Get users previous settings."""
+        self.imp_default = [False, False, False, False, False, False]
+        self.settings = QSettings()
+        self.settings.beginGroup('musicxml_import')
+        super(Dialog, self).loadSettings()
+        lang = self.settings.value("language", "default", type(""))
         try:
             index = _langlist.index(lang)
         except ValueError:
@@ -266,13 +147,9 @@ class Dialog(QDialog):
         self.langCombo.setCurrentIndex(index + 1)
         
     def saveSettings(self):
-        """ save users last settings """
-        s = QSettings()
-        s.beginGroup('xml_import')
-        for i in self.impChecks:
-            s.setValue(i.objectName(), i.isChecked())
-        for p in self.postChecks:
-            s.setValue(p.objectName(), p.isChecked())
+        """Save users last settings."""
+        self.settings = QSettings()
+        self.settings.beginGroup('musicxml_import')
+        super(Dialog, self).saveSettings()
         index = self.langCombo.currentIndex()
-        s.setValue('language', 'default' if index == 0 else _langlist[index-1])
-
+        self.settings.setValue('language', 'default' if index == 0 else _langlist[index-1])

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -1,0 +1,161 @@
+# This file is part of the Frescobaldi project, http://www.frescobaldi.org/
+#
+# Copyright (c) 2008 - 2014 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+Generic import dialog. Presuppose a child instance for the specific import.
+"""
+
+from __future__ import unicode_literals
+
+import os
+import subprocess
+
+from PyQt4.QtGui import (QCheckBox, QDialog, QDialogButtonBox,
+    QGridLayout, QLabel, QTabWidget, QTextEdit, QWidget)
+
+import userguide
+import lilypondinfo
+import widgets
+
+
+class ToLyDialog(QDialog):
+	
+    def __init__(self, parent=None):
+        super(ToLyDialog, self).__init__(parent)
+        self._document = None
+        self._path = None
+        
+        mainLayout = QGridLayout()
+        self.setLayout(mainLayout)
+        
+        tabs = QTabWidget()
+        
+        import_tab = QWidget()
+        post_tab = QWidget()
+        
+        itabLayout = QGridLayout(import_tab)
+        ptabLayout = QGridLayout(post_tab)
+        
+        tabs.addTab(import_tab, self.imp_prgm)
+        tabs.addTab(post_tab, "after import")
+
+        self.formatCheck = QCheckBox()
+        self.trimDurCheck = QCheckBox()
+        self.removeScalesCheck = QCheckBox()
+        self.runEngraverCheck = QCheckBox()
+
+        self.postChecks = [self.formatCheck,
+                           self.trimDurCheck,
+                           self.removeScalesCheck,
+                           self.runEngraverCheck]
+
+        self.commandLineLabel = QLabel()
+        self.commandLine = QTextEdit(acceptRichText=False)
+        
+        self.formatCheck.setObjectName("reformat")
+        self.trimDurCheck.setObjectName("trim-durations")
+        self.removeScalesCheck.setObjectName("remove-scaling")
+        self.runEngraverCheck.setObjectName("engrave-directly")
+        
+        self.buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        userguide.addButton(self.buttons, self.userg)
+        
+        row = 0
+        for r, w in enumerate(self.impChecks):
+            row += r
+            itabLayout.addWidget(w, row, 0, 1, 2)
+            w.toggled.connect(self.makeCommandLine)
+        row += 1    
+        for r, w in enumerate(self.impExtra):
+            row += r 
+            itabLayout.addWidget(w, row, 0, 1, 2)
+        
+        itabLayout.addWidget(widgets.Separator(), row + 1, 0, 1, 2)
+        itabLayout.addWidget(self.commandLineLabel, row + 2, 0, 1, 2)
+        itabLayout.addWidget(self.commandLine, row + 2, 0, 1, 2)
+        
+        ptabLayout.addWidget(self.formatCheck, 0, 0, 1, 2)
+        ptabLayout.addWidget(self.trimDurCheck, 1, 0, 1, 2)       
+        ptabLayout.addWidget(self.removeScalesCheck, 2, 0, 1, 2)
+        ptabLayout.addWidget(self.runEngraverCheck, 3, 0, 1, 2)
+        ptabLayout.setRowStretch(4, 10)
+        
+        mainLayout.addWidget(tabs, 0, 0, 9, 2)
+        mainLayout.addWidget(self.buttons, 10, 0, 1, 2)
+        
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+    
+    def translateUI(self):
+        self.commandLineLabel.setText(_("Command line:"))
+        self.formatCheck.setText(_("Reformat source"))
+        self.trimDurCheck.setText(_("Trim durations (Make implicit per line)"))
+        self.removeScalesCheck.setText(_("Remove fraction duration scaling"))
+        self.runEngraverCheck.setText(_("Engrave directly"))
+    
+    def setDocument(self, path):
+        """Set the full path to the MusicXML document."""
+        self._document = path
+    
+    def getCmd(self):
+        """Returns the command line."""
+        cmd = []
+        for t in self.commandLine.toPlainText().split():
+            if t == '$musicxml2ly':
+                cmd.extend(lilypondinfo.preferred().toolcommand('musicxml2ly'))
+            elif t == '$filename':
+                cmd.append(self._document)
+            else:
+                cmd.append(t)
+        cmd.extend(['--output', '-'])
+        return cmd
+        
+    def run_command(self):
+        """Run command line."""
+        cmd = self.getCmd()
+        directory = os.path.dirname(self._document)
+        proc = subprocess.Popen(cmd, cwd=directory,
+            stdin = subprocess.PIPE,
+            stdout = subprocess.PIPE,
+            stderr = subprocess.PIPE)
+        stdouterr = proc.communicate()
+        return stdouterr
+		
+    def getPostSettings(self):
+        """Returns settings in the post import tab."""
+        post = []
+        for p in self.postChecks:
+            post.append(p.isChecked())
+        return post
+        
+    def loadSettings(self):
+        """Get users previous settings."""
+        post_default = [True, False, False, True]
+        for i, d in zip(self.impChecks, self.imp_default):
+            i.setChecked(self.settings.value(i.objectName(), d, bool))
+        for p, f in zip(self.postChecks, post_default):
+            p.setChecked(self.settings.value(p.objectName(), f, bool))
+        
+    def saveSettings(self):
+        """Save users last settings."""
+        for i in self.impChecks:
+            self.settings.setValue(i.objectName(), i.isChecked())
+        for p in self.postChecks:
+            self.settings.setValue(p.objectName(), p.isChecked())

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -120,6 +120,8 @@ class ToLyDialog(QDialog):
         for t in self.commandLine.toPlainText().split():
             if t == '$musicxml2ly':
                 cmd.extend(lilypondinfo.preferred().toolcommand('musicxml2ly'))
+            elif t == '$midi2ly':
+                cmd.extend(lilypondinfo.preferred().toolcommand('midi2ly'))
             elif t == '$abc2ly':
                 cmd.extend(lilypondinfo.preferred().toolcommand('abc2ly'))
             elif t == '$filename':

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -120,6 +120,8 @@ class ToLyDialog(QDialog):
         for t in self.commandLine.toPlainText().split():
             if t == '$musicxml2ly':
                 cmd.extend(lilypondinfo.preferred().toolcommand('musicxml2ly'))
+            elif t == '$abc2ly':
+                cmd.extend(lilypondinfo.preferred().toolcommand('abc2ly'))
             elif t == '$filename':
                 cmd.append(self._document)
             else:

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -132,6 +132,7 @@ def menu_file_import(mainwindow):
     ac = file_import.FileImport.instance(mainwindow).actionCollection
     
     m.addAction(ac.import_musicxml)
+    m.addAction(ac.import_midi)
     m.addAction(ac.import_abc)
     return m
 

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -132,6 +132,7 @@ def menu_file_import(mainwindow):
     ac = file_import.FileImport.instance(mainwindow).actionCollection
     
     m.addAction(ac.import_musicxml)
+    m.addAction(ac.import_abc)
     return m
 
 


### PR DESCRIPTION
The code is restructured with a generic import dialog, and abc2ly and midi2ly imports are added.

Some issues remaining:

1. abc2ly doesn't work in the same way as musicxml2ly and midi2ly.
2. The previous dialog has to be "forgotten" when switching between different imports.

I've indicated the problematic places in the code.