### PR TITLE
Handle two calls to incoming.close(), one for disconect, one for "bye"

### DIFF
--- a/frescobaldi_app/remote/api.py
+++ b/frescobaldi_app/remote/api.py
@@ -81,8 +81,9 @@ class Incoming(object):
         socket.disconnected.connect(self.close)
     
     def close(self):
-        self.socket.deleteLater()
-        _incoming_handlers.remove(self)
+        if self in _incoming_handlers:
+            self.socket.deleteLater()
+            _incoming_handlers.remove(self)
     
     def read(self):
         """Read from the socket and let command() handle the commands."""


### PR DESCRIPTION
Fixes #650 

`_incoming_handlers` doesn't seem to be used for anything. Use it as a flag whether `socket.deleteLater()` has been called.