### PR TITLE
[DO NOT MERGE] test TabBar settings

### DIFF
--- a/frescobaldi_app/tabbar.py
+++ b/frescobaldi_app/tabbar.py
@@ -47,6 +47,8 @@ class TabBar(QTabBar):
         self.setTabsClosable(True) # TODO: make configurable
         self.setMovable(True)      # TODO: make configurable
         self.setExpanding(False)
+        print(self.usesScrollButtons())
+        print(self.elideMode())
         
         mainwin = self.window()
         self.docs = []


### PR DESCRIPTION
This is **not** meant to be merged.
Can you please run Frescobaldi from this branch and report what is printed in the shell?
I suspect that the `usesScrollButtons` and `elideMode` settings are different between different systems, and the ones on Mac (or at least on Mac 10.6) are quite annoying, being `False` and `1` respectively.