### PR TITLE
Source export options

### DIFF
--- a/frescobaldi_app/highlight2html.py
+++ b/frescobaldi_app/highlight2html.py
@@ -50,15 +50,15 @@ def html_document(document, scheme='editor', inline=False, number_lines=False, f
 def html(cursor, scheme='editor', inline=False, number_lines=False, full_html=True,
         wrap_tag="pre", wrap_attrib="id", wrap_attrib_name="document"):
     """Return a HTML document with the syntax-highlighted region.
-    
-    The tokens are marked with <span> tags. The cursor is a 
-    ly.document.Cursor instance. The specified text formats scheme is used 
-    (by default 'editor'). If inline is True, the span tags have inline 
-    style attributes. If inline is False, the span tags have class 
+
+    The tokens are marked with <span> tags. The cursor is a
+    ly.document.Cursor instance. The specified text formats scheme is used
+    (by default 'editor'). If inline is True, the span tags have inline
+    style attributes. If inline is False, the span tags have class
     attributes and a stylesheet is included.
-    
+
     Set number_lines to True to add line numbers.
-    
+
     """
     data = textformats.formatData(scheme)       # the current highlighting scheme
     w = ly.colorize.HtmlWriter()
@@ -72,5 +72,3 @@ def html(cursor, scheme='editor', inline=False, number_lines=False, full_html=Tr
     w.bgcolor = data.baseColors['background'].name()
     w.css_scheme = data.css_scheme()
     return w.html(cursor)
-
-

--- a/frescobaldi_app/highlight2html.py
+++ b/frescobaldi_app/highlight2html.py
@@ -29,22 +29,26 @@ import ly.document
 import ly.colorize
 
 
-def html_text(text, mode=None, scheme='editor', inline=True, number_lines=False, full_html=True):
+def html_text(text, mode=None, scheme='editor', inline=True, number_lines=False, full_html=True,
+    wrap_tag="pre", wrap_attrib="id", wrap_attrib_name="document"):
     """Converts the text to HTML using the specified or guessed mode."""
     c = ly.document.Cursor(ly.document.Document(text, mode))
-    return html(c, scheme, inline, number_lines, full_html)
+    return html(c, scheme, inline, number_lines, full_html, wrap_tag, wrap_attrib, wrap_attrib_name)
 
-def html_inline(cursor, scheme='editor', inline=True, number_lines=False, full_html=True):
+def html_inline(cursor, scheme='editor', inline=True, number_lines=False,
+        full_html=True, wrap_tag="pre", wrap_attrib="id", wrap_attrib_name="document"):
     """Return an (by default) inline-styled HTML document for the cursor's selection."""
     c = lydocument.cursor(cursor)
-    return html(c, scheme, inline, number_lines, full_html)
+    return html(c, scheme, inline, number_lines, full_html, wrap_tag, wrap_attrib, wrap_attrib_name)
 
-def html_document(document, scheme='editor', inline=False, number_lines=False, full_html=True):
+def html_document(document, scheme='editor', inline=False, number_lines=False, full_html=True,
+        wrap_tag="pre", wrap_attrib="id", wrap_attrib_name="document"):
     """Return a (by default) css-styled HTML document for the full document."""
     c = lydocument.Cursor(lydocument.Document(document))
-    return html(c, scheme, inline, number_lines, full_html)
+    return html(c, scheme, inline, number_lines, full_html, wrap_tag, wrap_attrib, wrap_attrib_name)
 
-def html(cursor, scheme='editor', inline=False, number_lines=False, full_html=True):
+def html(cursor, scheme='editor', inline=False, number_lines=False, full_html=True,
+        wrap_tag="pre", wrap_attrib="id", wrap_attrib_name="document"):
     """Return a HTML document with the syntax-highlighted region.
     
     The tokens are marked with <span> tags. The cursor is a 
@@ -58,6 +62,9 @@ def html(cursor, scheme='editor', inline=False, number_lines=False, full_html=Tr
     """
     data = textformats.formatData(scheme)       # the current highlighting scheme
     w = ly.colorize.HtmlWriter()
+    w.set_wrapper_tag(wrap_tag)
+    w.set_wrapper_attribute(wrap_attrib)
+    w.document_id = wrap_attrib_name
     w.inline_style = inline
     w.number_lines = number_lines
     w.full_html = full_html

--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -798,13 +798,16 @@ class MainWindow(QMainWindow):
         cursor = self.textCursor()
         if not cursor.hasSelection():
             return
-        number_lines = QSettings().value("source_export/number_lines", False, bool)
-        inline_style = QSettings().value("source_export/inline_copy", True, bool)
-        as_plain_text = QSettings().value("source_export/copy_html_as_plain_text", False, bool)
-        wrap_tag = QSettings().value("source_export/wrap_tag", "pre", str)
-        wrap_attrib = QSettings().value("source_export/wrap_attrib", "id", str)
-        wrap_attrib_name = QSettings().value("source_export/wrap_attrib_name", "document", str)
-        document_body_only = QSettings().value("source_export/copy_document_body_only", False, bool)
+
+        s = QSettings()
+        s.beginGroup("source_export")
+        number_lines = s.value("number_lines", False, bool)
+        inline_style = s.value("inline_copy", True, bool)
+        as_plain_text = s.value("copy_html_as_plain_text", False, bool)
+        wrap_tag = s.value("wrap_tag", "pre", str)
+        wrap_attrib = s.value("wrap_attrib", "id", str)
+        wrap_attrib_name = s.value("wrap_attrib_name", "document", str)
+        document_body_only = s.value("copy_document_body_only", False, bool)
         import highlight2html
         html = highlight2html.html_inline(cursor, inline=inline_style, number_lines=number_lines,
             full_html=not document_body_only, wrap_tag=wrap_tag, wrap_attrib=wrap_attrib,

--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -65,42 +65,42 @@ import file_import
 
 
 class MainWindow(QMainWindow):
-    
+
     # emitted when the MainWindow will close
     aboutToClose = pyqtSignal()
-    
+
     # only emitted when this is the last MainWindow to close
     aboutToCloseLast = pyqtSignal()
-    
+
     # both signals emit (current, previous)
     currentDocumentChanged = pyqtSignal(document.Document, document.Document)
     currentViewChanged = pyqtSignal(view.View, view.View)
-    
+
     # emitted when whether there is a selection changes
     selectionStateChanged = pyqtSignal(bool)
-    
+
     def __init__(self, other=None):
         """Creates a new MainWindow.
-        
+
         It adds itself to app.windows to keep a reference.
         It shares the documents list with all other MainWindows. It copies
         some info (like the currently active document) from the 'other' window,
         if given.
-        
+
         """
         QMainWindow.__init__(self)
         self.setAttribute(Qt.WA_DeleteOnClose)
-        
+
         # this could be made configurable
         self.setCorner(Qt.TopLeftCorner, Qt.LeftDockWidgetArea)
         self.setCorner(Qt.BottomLeftCorner, Qt.LeftDockWidgetArea)
         self.setCorner(Qt.TopRightCorner, Qt.RightDockWidgetArea)
         self.setCorner(Qt.BottomRightCorner, Qt.RightDockWidgetArea)
-        
+
         self._currentDocument = None
         self._currentView = lambda: None
         self._selectedState = None
-        
+
         # find an unused objectName
         names = set(win.objectName() for win in app.windows)
         for num in itertools.count(1):
@@ -108,9 +108,9 @@ class MainWindow(QMainWindow):
             if name not in names:
                 self.setObjectName(name)
                 break
-        
+
         app.windows.append(self)
-        
+
         mainwidget = QWidget()
         self.setCentralWidget(mainwidget)
         layout = QVBoxLayout()
@@ -125,76 +125,76 @@ class MainWindow(QMainWindow):
         self.createActions()
         self.createMenus()
         self.createToolBars()
-        
+
         app.translateUI(self)
         app.sessionChanged.connect(self.updateWindowTitle)
-        
+
         self.readSettings()
-        
+
         self.historyManager = historymanager.HistoryManager(self, other.historyManager if other else None)
         self.viewManager.viewChanged.connect(self.slotViewChanged)
         self.tabBar.currentDocumentChanged.connect(self.setCurrentDocument)
         self.setAcceptDrops(True)
-        
+
         # keep track of all ActionCollections for the keyboard settings dialog
         actioncollectionmanager.manager(self).addActionCollection(self.actionCollection)
         actioncollectionmanager.manager(self).addActionCollection(self.viewManager.actionCollection)
-        
+
         if other:
             self.setCurrentDocument(other.currentDocument())
         self.updateWindowTitle()
         app.mainwindowCreated(self)
-        
+
     def documents(self):
         """Returns the list of documents in the order of the TabBar."""
         return self.tabBar.documents()
-        
+
     def currentView(self):
         """Returns the current View or None."""
         return self._currentView()
-    
+
     def currentDocument(self):
         """Returns the current Document or None."""
         return self._currentDocument
-        
+
     def setCurrentDocument(self, doc, findOpenView=None):
         """Set the current document.
-        
+
         The findOpenView argument makes sense when the user has split the
         editor view in more than one.  If findOpenView == True and one of the
         views has the document, that view is focused. If findOpenView == False,
         the currently focused view is changed to the document. If findOpenView
         is None, the users setting is read.
-        
+
         """
         if findOpenView is None:
             findOpenView = QSettings().value("mainwindow/find_open_view", True, bool)
         self.viewManager.setCurrentDocument(doc, findOpenView)
-    
+
     def hasSelection(self):
         """Returns whether there is a selection."""
         return self.textCursor().hasSelection() if self.currentView() else False
-            
+
     def textCursor(self):
         """Returns the QTextCursor of the current View.
-        
+
         Raises an error if there is not yet a view.
-        
+
         """
         return self.currentView().textCursor()
-        
+
     def setTextCursor(self, cursor, findOpenView=None):
         """Switch to the cursor's document() and set that cursor on its View.
-        
+
         For the findOpenView argument, see setCurrentDocument().
         This method also respects the preferred number of surrounding lines
         that are at least to be shown (by using the gotoTextCursor() method of
         the View (see view.py)).
-        
+
         """
         self.setCurrentDocument(cursor.document(), findOpenView)
         self.currentView().gotoTextCursor(cursor)
-    
+
     def slotViewChanged(self, view):
         curv = self._currentView()
         if curv:
@@ -205,7 +205,7 @@ class MainWindow(QMainWindow):
         view.copyAvailable.connect(self.updateSelection)
         view.selectionChanged.connect(self.updateSelection)
         self._currentView = weakref.ref(view)
-        
+
         doc = view.document()
         curd, self._currentDocument = self._currentDocument, doc
         if curd is not doc:
@@ -227,7 +227,7 @@ class MainWindow(QMainWindow):
         self.currentViewChanged.emit(view, curv)
         if curd is not doc:
             self.currentDocumentChanged.emit(doc, curd)
-    
+
     def updateSelection(self):
         selection = self.textCursor().hasSelection()
         if selection != self._selectedState:
@@ -238,18 +238,18 @@ class MainWindow(QMainWindow):
             ac.edit_copy_colored_html.setEnabled(selection)
             ac.edit_cut.setEnabled(selection)
             ac.edit_select_none.setEnabled(selection)
-    
+
     def updateActions(self):
         view = self.currentView()
         action = self.actionCollection.view_wrap_lines
         action.setChecked(view.lineWrapMode() == QPlainTextEdit.WidgetWidth)
-        
+
     def updateDocActions(self):
         doc = self.currentDocument()
         ac = self.actionCollection
         ac.edit_undo.setEnabled(doc.isUndoAvailable())
         ac.edit_redo.setEnabled(doc.isRedoAvailable())
-        
+
     def updateWindowTitle(self):
         doc = self.currentDocument()
         name = []
@@ -265,14 +265,14 @@ class MainWindow(QMainWindow):
             if doc.isModified():
                 # L10N: state of document in window titlebar
                 name.append(_("[modified]"))
-        
+
         window_title = app.caption(" ".join(name))
-        
+
         if vcs.app_is_git_controlled():
             window_title += " " + vcs.app_active_branch_window_title()
-        
+
         self.setWindowTitle(window_title)
-    
+
     def dropEvent(self, ev):
         if not ev.source() and ev.mimeData().hasUrls():
             ev.accept()
@@ -289,11 +289,11 @@ class MainWindow(QMainWindow):
                 self.setCurrentDocument(docs[-1])
             for i in impurls:
                 imp.openDialog(i)
-    
+
     def dragEnterEvent(self, ev):
         if not ev.source() and ev.mimeData().hasUrls():
             ev.accept()
-        
+
     def closeEvent(self, ev):
         lastWindow = len(app.windows) == 1
         if not lastWindow or self.queryClose():
@@ -319,7 +319,7 @@ class MainWindow(QMainWindow):
 
     def queryCloseDocument(self, doc):
         """Returns whether a document can be closed.
-        
+
         If modified, asks the user. The document is not closed.
         """
         if not doc.isModified():
@@ -333,7 +333,7 @@ class MainWindow(QMainWindow):
             return self.saveDocument(doc)
         else:
             return res == QMessageBox.Discard
-        
+
     def createPopupMenu(self):
         """ Adds an entry to the popup menu to show/hide the tab bar. """
         menu = QMainWindow.createPopupMenu(self)
@@ -343,7 +343,7 @@ class MainWindow(QMainWindow):
         a.setChecked(self.tabBar.isVisible())
         a.toggled.connect(self.tabBar.setVisible)
         return menu
-        
+
     def readSettings(self):
         """ Read a few settings from the application global config. """
         settings = QSettings()
@@ -354,7 +354,7 @@ class MainWindow(QMainWindow):
         self.tabBar.setVisible(settings.value('tabbar', True, bool))
         if os.name != "posix" and settings.value('maximized', False, bool):
             self.showMaximized()
-        
+
     def writeSettings(self):
         """ Write a few settings to the application global config. """
         settings = QSettings()
@@ -364,27 +364,27 @@ class MainWindow(QMainWindow):
         settings.setValue('state', self.saveState())
         settings.setValue('tabbar', self.tabBar.isVisible())
         settings.setValue('maximized', self.isMaximized())
-    
+
     def readSessionSettings(self, settings):
         """Restore ourselves from session manager settings.
-        
+
         These methods store much more information than the readSettings and
         writeSettings methods. This method tries to restore window size and
         position. Also the objectName() is set, so that the window manager can
         preserve stacking order, etc.
-        
+
         """
         name = settings.value('name', '', type(""))
         if name:
             self.setObjectName(name)
         self.restoreGeometry(settings.value('geometry', QByteArray(), QByteArray))
         self.restoreState(settings.value('state', QByteArray(), QByteArray))
-        
+
     def writeSessionSettings(self, settings):
         """Write our state to the session manager settings.
-        
+
         See readSessionSettings().
-        
+
         """
         settings.setValue('name', self.objectName())
         settings.setValue('geometry', self.saveGeometry())
@@ -394,23 +394,23 @@ class MainWindow(QMainWindow):
         """Calls openUrls() with one url. See openUrls()."""
         for d in self.openUrls([url], encoding, ignore_errors):
             return d
-    
+
     def openUrls(self, urls, encoding=None, ignore_errors=False):
         """Open a list of urls, using encoding if specified.
-        
+
         Returns the list of documents that were successfully loaded.
-        
+
         If encoding is None, the encoding is read from the document, defaulting
         to UTF-8.
-        
+
         If ignore_errors is False (the default), an error message is given
         showing the url or urls that failed to load. If ignore_errors is True,
         load errors are silently ignored.
-        
+
         If an url fails to load, a document is not created. To create an
         empty document with an url, use the document.Document constructor.
         Successfully loaded urls are added to the recent files.
-        
+
         """
         docs = []
         failures = []
@@ -438,15 +438,15 @@ class MainWindow(QMainWindow):
                         errno = e.errno) for url, e in failures)
             QMessageBox.critical(self, app.caption(_("Error")), msg)
         return docs
-    
+
     def currentDirectory(self):
         """Returns the current directory of the current document.
-        
+
         If the document has no filename yet, returns the configured default
         directory, or the user's home directory.
         Is that is not set as well, returns the current directory
         of the application.
-        
+
         """
         import resultfiles
         curdir = (resultfiles.results(self.currentDocument()).currentDirectory()
@@ -457,19 +457,19 @@ class MainWindow(QMainWindow):
             return os.getcwdu()
         except AttributeError:
             return os.getcwd()
-    
+
     def cleanStart(self):
         """Called when the previous action left no document open.
-        
+
         Currently simply calls newDocument().
-        
+
         """
         self.newDocument()
-    
+
     ##
     # Implementations of menu actions
     ##
-    
+
     def newDocument(self):
         """ Creates a new, empty document. """
         d = document.Document()
@@ -488,7 +488,7 @@ class MainWindow(QMainWindow):
             import lilypondinfo
             d.setPlainText('\\version "{0}"\n\n'.format(lilypondinfo.preferred().versionString()))
             d.setModified(False)
-    
+
     def openDocument(self):
         """ Displays an open dialog to open one or more documents. """
         ext = os.path.splitext(self.currentDocument().url().path())[1]
@@ -500,13 +500,13 @@ class MainWindow(QMainWindow):
         docs = self.openUrls(urls)
         if docs:
             self.setCurrentDocument(docs[-1])
-        
+
     def saveDocument(self, doc, save_as=False):
         """ Saves the document, asking for a name if necessary.
-        
+
         If save_as is True, a name is always asked.
         Returns True if saving succeeded.
-        
+
         """
         if save_as or doc.url().isEmpty():
             filename = doc.url().toLocalFile()
@@ -525,7 +525,7 @@ class MainWindow(QMainWindow):
             url = QUrl.fromLocalFile(filename)
         else:
             url = doc.url()
-        
+
         if QSettings().value("strip_trailing_whitespace", False, bool):
             import reformat
             reformat.remove_trailing_whitespace(QTextCursor(doc))
@@ -547,20 +547,20 @@ class MainWindow(QMainWindow):
                 backup.removeBackup(filename)
             recentfiles.add(doc.url())
         return True
-            
+
     def saveDocumentAs(self, doc):
         """ Saves the document, always asking for a name.
-        
+
         Returns True if saving succeeded, False if it failed or was cancelled.
-        
+
         """
         return self.saveDocument(doc, True)
-        
+
     def closeDocument(self, doc):
         """ Closes the document, asking for saving if modified.
-        
+
         Returns True if closing succeeded.
-        
+
         """
         close = self.queryCloseDocument(doc)
         if close:
@@ -569,13 +569,13 @@ class MainWindow(QMainWindow):
             if not app.documents:
                 self.cleanStart()
         return close
-        
+
     def saveCurrentDocument(self):
         return self.saveDocument(self.currentDocument())
-    
+
     def saveCurrentDocumentAs(self):
         return self.saveDocumentAs(self.currentDocument())
-    
+
     def saveCopyAs(self):
         import ly.lex
         doc = self.currentDocument()
@@ -604,15 +604,15 @@ class MainWindow(QMainWindow):
                 strerror = e.strerror,
                 errno = e.errno)
             QMessageBox.critical(self, app.caption(_("Error")), msg)
-    
+
     def closeCurrentDocument(self):
         return self.closeDocument(self.currentDocument())
-    
+
     def reloadCurrentDocument(self):
         """Reload the current document again from disk.
-        
+
         This action can be undone.
-        
+
         """
         d = self.currentDocument()
         try:
@@ -624,7 +624,7 @@ class MainWindow(QMainWindow):
                 strerror = e.strerror,
                 errno = e.errno)
             QMessageBox.critical(self, app.caption(_("Error")), msg)
-    
+
     def reloadAllDocuments(self):
         """Reloads all documents."""
         failures = []
@@ -640,14 +640,14 @@ class MainWindow(QMainWindow):
                     strerror = e.strerror,
                     errno = e.errno) for d, e in failures)
             QMessageBox.critical(self, app.caption(_("Error")), msg)
-    
+
     def saveAllDocuments(self):
         """ Saves all documents.
-        
+
         Returns True if all documents were saved.
         If one document failed or was cancelled the whole operation is cancelled
         and this function returns False.
-        
+
         """
         cur = self.currentDocument()
         for doc in self.historyManager.documents():
@@ -661,12 +661,12 @@ class MainWindow(QMainWindow):
                     return False
         self.setCurrentDocument(cur, findOpenView=True)
         return True
-                    
+
     def closeOtherDocuments(self):
         """ Closes all documents that are not the current document.
-        
+
         Returns True if all documents were closed.
-        
+
         """
         cur = self.currentDocument()
         docs = self.historyManager.documents()[1:]
@@ -677,14 +677,14 @@ class MainWindow(QMainWindow):
         for doc in docs:
             doc.close()
         return True
-    
+
     def closeAllDocuments(self):
         """Closes all documents and keep one new, empty document."""
         sessions.manager.get(self).saveCurrentSessionIfDesired()
         if self.queryClose():
             sessions.setCurrentSession(None)
             self.cleanStart()
-    
+
     def quit(self):
         """Closes all MainWindows."""
         for window in app.windows[:]: # copy
@@ -693,13 +693,13 @@ class MainWindow(QMainWindow):
         self.close()
         if not app.windows:
             app.qApp.quit()
-    
+
     def restart(self):
         """Closes all MainWindows and restart Frescobaldi."""
         self.quit()
         if not app.windows:
             app.restart()
-    
+
     def insertFromFile(self):
         ext = os.path.splitext(self.currentDocument().url().path())[1]
         filetypes = app.filetypes(ext)
@@ -719,13 +719,13 @@ class MainWindow(QMainWindow):
             else:
                 text = util.universal_newlines(util.decode(data))
                 self.currentView().textCursor().insertText(text)
-        
+
     def openCurrentDirectory(self):
         helpers.openUrl(QUrl.fromLocalFile(self.currentDirectory()), "directory")
-    
+
     def openCommandPrompt(self):
         helpers.openUrl(QUrl.fromLocalFile(self.currentDirectory()), "shell")
-    
+
     def printSource(self):
         cursor = self.textCursor()
         try:
@@ -750,7 +750,7 @@ class MainWindow(QMainWindow):
             font.setPointSizeF(font.pointSizeF() * 0.8)
             doc.setDefaultFont(font)
             doc.print_(printer)
-    
+
     def exportColoredHtml(self):
         doc = self.currentDocument()
         name, ext = os.path.splitext(os.path.basename(doc.url().path()))
@@ -778,22 +778,22 @@ class MainWindow(QMainWindow):
                 strerror = e.strerror,
                 errno = e.errno)
             QMessageBox.critical(self, app.caption(_("Error")), msg)
-        
+
     def undo(self):
         self.currentView().undo()
-        
+
     def redo(self):
         self.currentView().redo()
-    
+
     def cut(self):
         self.currentView().cut()
-        
+
     def copy(self):
         self.currentView().copy()
-        
+
     def paste(self):
         self.currentView().paste()
-        
+
     def copyColoredHtml(self):
         cursor = self.textCursor()
         if not cursor.hasSelection():
@@ -812,36 +812,36 @@ class MainWindow(QMainWindow):
         data = QMimeData()
         data.setText(html) if as_plain_text else data.setHtml(html)
         QApplication.clipboard().setMimeData(data)
-        
+
     def selectNone(self):
         cursor = self.currentView().textCursor()
         cursor.clearSelection()
         self.currentView().setTextCursor(cursor)
-    
+
     def selectAll(self):
         self.currentView().selectAll()
-        
+
     def selectBlock(self):
         import lydocument
         import ly.cursortools
         cursor = lydocument.cursor(self.textCursor())
         if ly.cursortools.select_block(cursor):
             self.currentView().setTextCursor(cursor.cursor())
-        
+
     def find(self):
         import search
         search.Search.instance(self).find()
-        
+
     def replace(self):
         import search
         search.Search.instance(self).replace()
-        
+
     def showPreferences(self):
         import preferences
         dlg = preferences.PreferencesDialog(self)
         dlg.exec_()
         dlg.deleteLater()
-    
+
     def toggleFullScreen(self, enabled):
         if enabled:
             self._maximized = self.isMaximized()
@@ -850,7 +850,7 @@ class MainWindow(QMainWindow):
             self.showNormal()
             if self._maximized:
                 self.showMaximized()
-    
+
     def newWindow(self):
         """Opens a new MainWindow."""
         self.writeSettings()
@@ -862,25 +862,25 @@ class MainWindow(QMainWindow):
         """Called when the user toggles View->Line Wrap"""
         wrap = QPlainTextEdit.WidgetWidth if enable else QPlainTextEdit.NoWrap
         self.currentView().setLineWrapMode(wrap)
-    
+
     def scrollUp(self):
         """Scroll up without moving the cursor"""
         sb = self.currentView().verticalScrollBar()
         sb.setValue(sb.value() - 1 if sb.value() else 0)
-        
+
     def scrollDown(self):
         """Scroll down without moving the cursor"""
         sb = self.currentView().verticalScrollBar()
         sb.setValue(sb.value() + 1)
-        
+
     def selectFullLinesUp(self):
         """Select lines upwards, selecting full lines."""
         self.selectFullLines(QTextCursor.Up)
-        
+
     def selectFullLinesDown(self):
         """Select lines downwards, selecting full lines."""
         self.selectFullLines(QTextCursor.Down)
-        
+
     def selectFullLines(self, direction):
         """Select full lines in the direction QTextCursor.Up or Down."""
         view = self.currentView()
@@ -892,33 +892,33 @@ class MainWindow(QMainWindow):
         cur.movePosition(direction, QTextCursor.KeepAnchor)
         cur.movePosition(QTextCursor.StartOfLine, QTextCursor.KeepAnchor)
         view.setTextCursor(cur)
-    
+
     def showManual(self):
         """Shows the user guide, called when user presses F1."""
         import userguide
         userguide.show()
-    
+
     def showAbout(self):
         """Shows about dialog."""
         import about
         about.AboutDialog(self).exec_()
-    
+
     def reportBug(self):
         """Opens e-mail composer to send a bug or feature report."""
         import bugreport
         bugreport.email('', _(
             "Please describe the issue or feature request.\n"
             "Provide as much information as possible.\n\n\n"))
-    
+
     def createActions(self):
         self.actionCollection = ac = ActionCollection()
-        
+
         # recent files
         self.menu_recent_files = m = QMenu()
         ac.file_open_recent.setMenu(m)
         m.aboutToShow.connect(self.populateRecentFilesMenu)
         m.triggered.connect(self.slotRecentFilesAction)
-        
+
         # connections
         ac.file_quit.triggered.connect(self.quit, Qt.QueuedConnection)
         ac.file_restart.triggered.connect(self.restart, Qt.QueuedConnection)
@@ -963,7 +963,7 @@ class MainWindow(QMainWindow):
         ac.help_manual.triggered.connect(self.showManual)
         ac.help_about.triggered.connect(self.showAbout)
         ac.help_bugreport.triggered.connect(self.reportBug)
-        
+
     def populateRecentFilesMenu(self):
         self.menu_recent_files.clear()
         for url in recentfiles.urls():
@@ -972,13 +972,13 @@ class MainWindow(QMainWindow):
             text = "{0}  ({1})".format(basename, util.homify(dirname))
             self.menu_recent_files.addAction(text).url = url
         qutil.addAccelerators(self.menu_recent_files.actions())
-    
+
     def slotRecentFilesAction(self, action):
         """Called when a recent files menu action is triggered."""
         d = self.openUrl(action.url)
         if d:
             self.setCurrentDocument(d)
-        
+
     def createMenus(self):
         menu.createMenus(self)
         # actions that are not in menus
@@ -987,7 +987,7 @@ class MainWindow(QMainWindow):
         self.addAction(ac.view_scroll_down)
         self.addAction(ac.edit_select_full_lines_up)
         self.addAction(ac.edit_select_full_lines_down)
-        
+
     def createToolBars(self):
         ac = self.actionCollection
         self.toolbar_main = t = self.addToolBar('')
@@ -1010,7 +1010,7 @@ class MainWindow(QMainWindow):
         w = t.widgetForAction(engrave.engraver(self).actionCollection.engrave_runner)
         w.addAction(engrave.engraver(self).actionCollection.engrave_publish)
         w.addAction(engrave.engraver(self).actionCollection.engrave_custom)
-        
+
         self.toolbar_music = t = self.addToolBar('')
         t.setObjectName('toolbar_music')
         ma = panelmanager.manager(self).musicview.actionCollection
@@ -1024,7 +1024,7 @@ class MainWindow(QMainWindow):
         t.addAction(ma.music_prev_page)
         t.addAction(ma.music_pager)
         t.addAction(ma.music_next_page)
-        
+
     def translateUI(self):
         self.toolbar_main.setWindowTitle(_("Main Toolbar"))
         self.toolbar_music.setWindowTitle(_("Music View Toolbar"))
@@ -1052,9 +1052,9 @@ class ActionCollection(actioncollection.ActionCollection):
         self.file_close_all = QAction(parent)
         self.file_quit = QAction(parent)
         self.file_restart = QAction(parent)
-        
+
         self.export_colored_html = QAction(parent)
-        
+
         self.edit_undo = QAction(parent)
         self.edit_redo = QAction(parent)
         self.edit_cut = QAction(parent)
@@ -1071,22 +1071,22 @@ class ActionCollection(actioncollection.ActionCollection):
         self.edit_find_previous = QAction(parent)
         self.edit_replace = QAction(parent)
         self.edit_preferences = QAction(parent)
-        
+
         self.view_next_document = QAction(parent)
         self.view_previous_document = QAction(parent)
         self.view_wrap_lines = QAction(parent, checkable=True)
         self.view_scroll_up = QAction(parent)
         self.view_scroll_down = QAction(parent)
-        
+
         self.window_new = QAction(parent)
         self.window_fullscreen = QAction(parent)
         self.window_fullscreen.setCheckable(True)
-        
+
         self.help_manual = QAction(parent)
         self.help_whatsthis = QWhatsThis.createAction(parent)
         self.help_about = QAction(parent)
         self.help_bugreport = QAction(parent)
-        
+
         # icons
         self.file_new.setIcon(icons.get('document-new'))
         self.file_open.setIcon(icons.get('document-open'))
@@ -1102,7 +1102,7 @@ class ActionCollection(actioncollection.ActionCollection):
         self.file_print_source.setIcon(icons.get('document-print'))
         self.file_close.setIcon(icons.get('document-close'))
         self.file_quit.setIcon(icons.get('application-exit'))
-        
+
         self.edit_undo.setIcon(icons.get('edit-undo'))
         self.edit_redo.setIcon(icons.get('edit-redo'))
         self.edit_cut.setIcon(icons.get('edit-cut'))
@@ -1115,18 +1115,18 @@ class ActionCollection(actioncollection.ActionCollection):
         self.edit_find_previous.setIcon(icons.get('go-up-search'))
         self.edit_replace.setIcon(icons.get('edit-find-replace'))
         self.edit_preferences.setIcon(icons.get('preferences-system'))
-        
+
         self.view_next_document.setIcon(icons.get('go-next'))
         self.view_previous_document.setIcon(icons.get('go-previous'))
-        
+
         self.window_new.setIcon(icons.get('window-new'))
         self.window_fullscreen.setIcon(icons.get('view-fullscreen'))
-        
+
         self.help_manual.setIcon(icons.get('help-contents'))
         self.help_whatsthis.setIcon(icons.get('help-contextual'))
         self.help_bugreport.setIcon(icons.get('tools-report-bug'))
         self.help_about.setIcon(icons.get('help-about'))
-        
+
         # shortcuts
         self.file_new.setShortcuts(QKeySequence.New)
         self.file_open.setShortcuts(QKeySequence.Open)
@@ -1134,7 +1134,7 @@ class ActionCollection(actioncollection.ActionCollection):
         self.file_save_as.setShortcuts(QKeySequence.SaveAs)
         self.file_close.setShortcuts(QKeySequence.Close)
         self.file_quit.setShortcuts(QKeySequence.Quit)
-        
+
         self.edit_undo.setShortcuts(QKeySequence.Undo)
         self.edit_redo.setShortcuts(QKeySequence.Redo)
         self.edit_cut.setShortcuts(QKeySequence.Cut)
@@ -1150,16 +1150,16 @@ class ActionCollection(actioncollection.ActionCollection):
         self.edit_find_previous.setShortcuts(QKeySequence.FindPrevious)
         self.edit_replace.setShortcuts(QKeySequence.Replace)
         self.edit_preferences.setShortcuts(QKeySequence.Preferences)
-        
+
         self.view_next_document.setShortcuts(QKeySequence.Forward)
         self.view_previous_document.setShortcuts(QKeySequence.Back)
         self.view_scroll_up.setShortcut(Qt.CTRL + Qt.Key_Up)
         self.view_scroll_down.setShortcut(Qt.CTRL + Qt.Key_Down)
-        
+
         self.window_fullscreen.setShortcuts([QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_F), QKeySequence(Qt.Key_F11)])
-        
+
         self.help_manual.setShortcuts(QKeySequence.HelpContents)
-        
+
         # Mac OS X-specific roles?
         if sys.platform.startswith('darwin'):
             import macosx
@@ -1171,7 +1171,7 @@ class ActionCollection(actioncollection.ActionCollection):
                 self.file_quit.setMenuRole(QAction.NoRole)
                 self.edit_preferences.setMenuRole(QAction.NoRole)
                 self.help_about.setMenuRole(QAction.NoRole)
-        
+
     def translateUI(self):
         self.file_new.setText(_("action: new document", "&New"))
         self.file_open.setText(_("&Open..."))
@@ -1196,9 +1196,9 @@ class ActionCollection(actioncollection.ActionCollection):
         self.file_close_all.setToolTip(_("Closes all documents and leaves the current session."))
         self.file_quit.setText(_("&Quit"))
         self.file_restart.setText(_("Restart {appname}").format(appname=appinfo.appname))
-        
+
         self.export_colored_html.setText(_("Export Source as Colored &HTML..."))
-        
+
         self.edit_undo.setText(_("&Undo"))
         self.edit_redo.setText(_("Re&do"))
         self.edit_cut.setText(_("Cu&t"))
@@ -1215,19 +1215,17 @@ class ActionCollection(actioncollection.ActionCollection):
         self.edit_find_previous.setText(_("Find Pre&vious"))
         self.edit_replace.setText(_("&Replace..."))
         self.edit_preferences.setText(_("Pr&eferences..."))
-        
+
         self.view_next_document.setText(_("&Next Document"))
         self.view_previous_document.setText(_("&Previous Document"))
         self.view_wrap_lines.setText(_("Wrap &Lines"))
         self.view_scroll_up.setText(_("Scroll Up"))
         self.view_scroll_down.setText(_("Scroll Down"))
-        
+
         self.window_new.setText(_("New &Window"))
         self.window_fullscreen.setText(_("&Fullscreen"))
-        
+
         self.help_manual.setText(_("&User Guide"))
         self.help_whatsthis.setText(_("&What's This?"))
         self.help_bugreport.setText(_("Report a &Bug..."))
         self.help_about.setText(_("&About {appname}...").format(appname=appinfo.appname))
-        
-

--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -765,10 +765,17 @@ class MainWindow(QMainWindow):
             name, "{0} (*.html)".format("HTML Files"))
         if not filename:
             return #cancelled
-        number_lines = QSettings().value("source_export/number_lines", False, bool)
-        inline_style = QSettings().value("source_export/inline_export", False, bool)
+
+        s = QSettings()
+        s.beginGroup("source_export")
+        number_lines = s.value("number_lines", False, bool)
+        inline_style = s.value("inline_export", False, bool)
+        wrap_tag = s.value("wrap_tag", "pre", str)
+        wrap_attrib = s.value("wrap_attrib", "id", str)
+        wrap_attrib_name = s.value("wrap_attrib_name", "document", str)
         import highlight2html
-        html = highlight2html.html_document(doc, inline=inline_style, number_lines=number_lines)
+        html = highlight2html.html_document(doc, inline=inline_style, number_lines=number_lines,
+            wrap_tag=wrap_tag, wrap_attrib=wrap_attrib, wrap_attrib_name=wrap_attrib_name)
         try:
             with open(filename, "wb") as f:
                 f.write(html.encode('utf-8'))

--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -801,10 +801,14 @@ class MainWindow(QMainWindow):
         number_lines = QSettings().value("source_export/number_lines", False, bool)
         inline_style = QSettings().value("source_export/inline_copy", True, bool)
         as_plain_text = QSettings().value("source_export/copy_html_as_plain_text", False, bool)
+        wrap_tag = QSettings().value("source_export/wrap_tag", "pre", str)
+        wrap_attrib = QSettings().value("source_export/wrap_attrib", "id", str)
+        wrap_attrib_name = QSettings().value("source_export/wrap_attrib_name", "document", str)
         document_body_only = QSettings().value("source_export/copy_document_body_only", False, bool)
         import highlight2html
         html = highlight2html.html_inline(cursor, inline=inline_style, number_lines=number_lines,
-            full_html=not document_body_only)
+            full_html=not document_body_only, wrap_tag=wrap_tag, wrap_attrib=wrap_attrib,
+            wrap_attrib_name=wrap_attrib_name)
         data = QMimeData()
         data.setText(html) if as_plain_text else data.setHtml(html)
         QApplication.clipboard().setMimeData(data)

--- a/frescobaldi_app/preferences/editor.py
+++ b/frescobaldi_app/preferences/editor.py
@@ -282,9 +282,9 @@ class SourceExport(preferences.Group):
             "If enabled, HTML is copied to the clipboard as plain text. "
             "Use this when you want to type HTML formatted code in a "
             "plain text editing environment."))
-        self.copyDocumentBodyOnly.setText(_("Copy <pre> element only"))
+        self.copyDocumentBodyOnly.setText(_("Copy document body only"))
         self.copyDocumentBodyOnly.setToolTip('<qt>' + _(
-            "If enabled, only the HTML contents, wrapped in a PRE tag, will be "
+            "If enabled, only the HTML contents, wrapped in a single tag, will be "
             "copied to the clipboard instead of a full HTML document with a "
             "header section. "
             "May be used in conjunction with the plain text option, with the "

--- a/frescobaldi_app/preferences/editor.py
+++ b/frescobaldi_app/preferences/editor.py
@@ -25,7 +25,7 @@ from __future__ import unicode_literals
 
 from PyQt4.QtCore import QSettings
 from PyQt4.QtGui import (
-    QCheckBox, QComboBox, QFileDialog, QGridLayout, QLabel, QLineEdit, QSpinBox, 
+    QCheckBox, QComboBox, QFileDialog, QGridLayout, QLabel, QLineEdit, QSpinBox,
     QVBoxLayout, QWidget)
 
 import app
@@ -42,10 +42,10 @@ import widgets.urlrequester
 class Editor(preferences.ScrolledGroupsPage):
     def __init__(self, dialog):
         super(Editor, self).__init__(dialog)
-        
+
         layout = QVBoxLayout()
         self.scrolledWidget.setLayout(layout)
-        
+
         layout.addWidget(ViewSettings(self))
         layout.addWidget(Highlighting(self))
         layout.addWidget(Indenting(self))
@@ -57,20 +57,20 @@ class Editor(preferences.ScrolledGroupsPage):
 class ViewSettings(preferences.Group):
     def __init__(self, page):
         super(ViewSettings, self).__init__(page)
-        
+
         layout = QGridLayout(spacing=1)
         self.setLayout(layout)
-        
+
         self.wrapLines = QCheckBox(toggled=self.changed)
         self.numContextLines = QSpinBox(minimum=0, maximum=20, valueChanged=self.changed)
         self.numContextLinesLabel = l = QLabel()
         l.setBuddy(self.numContextLines)
-        
+
         layout.addWidget(self.wrapLines, 0, 0, 1, 1)
         layout.addWidget(self.numContextLinesLabel, 1, 0)
         layout.addWidget(self.numContextLines, 1, 1)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_("View Preferences"))
         self.wrapLines.setText(_("Wrap long lines by default"))
@@ -92,7 +92,7 @@ class ViewSettings(preferences.Group):
         s.beginGroup("view_preferences")
         self.wrapLines.setChecked(s.value("wrap_lines", False, bool))
         self.numContextLines.setValue(s.value("context_lines", 3, int))
-    
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup("view_preferences")
@@ -103,10 +103,10 @@ class ViewSettings(preferences.Group):
 class Highlighting(preferences.Group):
     def __init__(self, page):
         super(Highlighting, self).__init__(page)
-        
+
         layout = QGridLayout(spacing=1)
         self.setLayout(layout)
-        
+
         self.messageLabel = QLabel(wordWrap=True)
         layout.addWidget(self.messageLabel, 0, 0, 1, 2)
         self.labels = {}
@@ -118,16 +118,16 @@ class Highlighting(preferences.Group):
             e.valueChanged.connect(page.changed)
             layout.addWidget(l, row, 0)
             layout.addWidget(e, row, 1)
-            
+
         app.translateUI(self)
-    
+
     def items(self):
         """
         Yields (name, title, default) tuples for every setting in this group.
         Default is understood in seconds.
         """
         yield "match", _("Matching Item:"), 1
-        
+
     def translateUI(self):
         self.setTitle(_("Highlighting Options"))
         self.messageLabel.setText(_(
@@ -141,13 +141,13 @@ class Highlighting(preferences.Group):
             self.entries[name].setPrefix(prefix)
             self.entries[name].setSuffix(suffix)
             self.labels[name].setText(title)
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("editor_highlighting")
         for name, title, default in self.items():
             self.entries[name].setValue(s.value(name, default, int))
-    
+
     def saveSettings(self):
         s= QSettings()
         s.beginGroup("editor_highlighting")
@@ -158,34 +158,34 @@ class Highlighting(preferences.Group):
 class Indenting(preferences.Group):
     def __init__(self, page):
         super(Indenting, self).__init__(page)
-        
+
         layout = QGridLayout(spacing=1)
         self.setLayout(layout)
-        
+
         self.tabwidthBox = QSpinBox(minimum=1, maximum=99)
         self.tabwidthLabel = l = QLabel()
         l.setBuddy(self.tabwidthBox)
-        
+
         self.nspacesBox = QSpinBox(minimum=0, maximum=99)
         self.nspacesLabel = l = QLabel()
         l.setBuddy(self.nspacesBox)
-        
+
         self.dspacesBox = QSpinBox(minimum=0, maximum=99)
         self.dspacesLabel = l = QLabel()
         l.setBuddy(self.dspacesBox)
-        
+
         layout.addWidget(self.tabwidthLabel, 0, 0)
         layout.addWidget(self.tabwidthBox, 0, 1)
         layout.addWidget(self.nspacesLabel, 1, 0)
         layout.addWidget(self.nspacesBox, 1, 1)
         layout.addWidget(self.dspacesLabel, 2, 0)
         layout.addWidget(self.dspacesBox, 2, 1)
-        
+
         self.tabwidthBox.valueChanged.connect(page.changed)
         self.nspacesBox.valueChanged.connect(page.changed)
         self.dspacesBox.valueChanged.connect(page.changed)
         self.translateUI()
-        
+
     def translateUI(self):
         self.setTitle(_("Indenting Preferences"))
         self.tabwidthLabel.setText(_("Visible Tab Width:"))
@@ -216,7 +216,7 @@ class Indenting(preferences.Group):
         self.tabwidthBox.setValue(s.value("tab_width", 8, int))
         self.nspacesBox.setValue(s.value("indent_spaces", 2, int))
         self.dspacesBox.setValue(s.value("document_spaces", 8, int))
-    
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup("indent")
@@ -228,10 +228,10 @@ class Indenting(preferences.Group):
 class SourceExport(preferences.Group):
     def __init__(self, page):
         super(SourceExport, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.numberLines = QCheckBox(toggled=self.changed)
         self.inlineStyleCopy = QCheckBox(toggled=self.changed)
         self.copyHtmlAsPlainText = QCheckBox(toggled=self.changed)
@@ -245,7 +245,7 @@ class SourceExport(preferences.Group):
         layout.addWidget(self.copyDocumentBodyOnly)
 
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_("Source Export Preferences"))
         self.numberLines.setText(_("Show line numbers"))
@@ -257,7 +257,7 @@ class SourceExport(preferences.Group):
             "If enabled, inline style attributes are used when copying "
             "colored HTML to the clipboard. "
             "Otherwise, a CSS stylesheet is embedded."))
-        
+
         self.inlineStyleExport.setText(_("Use inline style when exporting colored HTML"))
         self.inlineStyleExport.setToolTip('<qt>' + _(
             "If enabled, inline style attributes are used when exporting "
@@ -299,24 +299,24 @@ class SourceExport(preferences.Group):
 class TypographicalQuotes(preferences.Group):
     def __init__(self, page):
         super(TypographicalQuotes, self).__init__(page)
-        
+
         layout = QGridLayout(spacing=1)
         self.setLayout(layout)
         l = self.languageLabel = QLabel()
         c = self.languageCombo = QComboBox(currentIndexChanged=self.languageChanged)
         l.setBuddy(c)
-        
+
         self.primaryLabel = QLabel()
         self.secondaryLabel = QLabel()
         self.primaryLeft = QLineEdit(textEdited=self.changed)
         self.primaryRight = QLineEdit(textEdited=self.changed)
         self.secondaryLeft = QLineEdit(textEdited=self.changed)
         self.secondaryRight = QLineEdit(textEdited=self.changed)
-        
+
         self._langs = ["current", "custom"]
         self._langs.extend(lang for lang in lasptyqu.available() if lang != "C")
         c.addItems(['' for i in self._langs])
-        
+
         layout.addWidget(self.languageLabel, 0, 0)
         layout.addWidget(self.primaryLabel, 1, 0)
         layout.addWidget(self.secondaryLabel, 2, 0)
@@ -325,9 +325,9 @@ class TypographicalQuotes(preferences.Group):
         layout.addWidget(self.primaryRight, 1, 2)
         layout.addWidget(self.secondaryLeft, 2, 1)
         layout.addWidget(self.secondaryRight, 2, 2)
-        
+
         app.translateUI(self)
-    
+
     def languageChanged(self):
         """Called when the user changes the combobox."""
         enabled = self.languageCombo.currentIndex() == 1
@@ -338,7 +338,7 @@ class TypographicalQuotes(preferences.Group):
         self.secondaryLeft.setEnabled(enabled)
         self.secondaryRight.setEnabled(enabled)
         self.changed.emit()
-        
+
     def translateUI(self):
         self.setTitle(_("Typographical Quotes"))
         self.languageLabel.setText(_("Quotes to use:"))
@@ -376,5 +376,3 @@ class TypographicalQuotes(preferences.Group):
         s.setValue("primary_right", self.primaryRight.text())
         s.setValue("secondary_left", self.secondaryLeft.text())
         s.setValue("secondary_right", self.secondaryRight.text())
-
-

--- a/frescobaldi_app/preferences/editor.py
+++ b/frescobaldi_app/preferences/editor.py
@@ -239,10 +239,13 @@ class SourceExport(preferences.Group):
         self.copyDocumentBodyOnly = QCheckBox(toggled=self.changed)
         self.wrapperTag = QLabel()
         self.wrapTagSelector = QComboBox()
+        self.wrapTagSelector.currentIndexChanged.connect(page.changed)
         self.wrapperAttribute = QLabel()
         self.wrapAttribSelector = QComboBox()
+        self.wrapAttribSelector.currentIndexChanged.connect(page.changed)
         self.wrapAttribNameLabel = QLabel()
         self.wrapAttribName = QLineEdit()
+        self.wrapAttribName.textEdited.connect(page.changed)
 
         # left column
         layout.addWidget(self.numberLines, 0, 0)
@@ -315,6 +318,11 @@ class SourceExport(preferences.Group):
         self.inlineStyleExport.setChecked(s.value("inline_export", False, bool))
         self.copyHtmlAsPlainText.setChecked(s.value("copy_html_as_plain_text", False, bool))
         self.copyDocumentBodyOnly.setChecked(s.value("copy_document_body_only", False, bool))
+        self.wrapTagSelector.setCurrentIndex(
+            self.wrapTagSelector.findText(s.value("wrap_tag", "pre", str)))
+        self.wrapAttribSelector.setCurrentIndex(
+            self.wrapAttribSelector.findText(s.value("wrap_attrib", "id", str)))
+        self.wrapAttribName.setText(s.value("wrap_attrib_name", "document", str))
 
     def saveSettings(self):
         s = QSettings()
@@ -324,6 +332,9 @@ class SourceExport(preferences.Group):
         s.setValue("inline_export", self.inlineStyleExport.isChecked())
         s.setValue("copy_html_as_plain_text", self.copyHtmlAsPlainText.isChecked())
         s.setValue("copy_document_body_only", self.copyDocumentBodyOnly.isChecked())
+        s.setValue("wrap_tag", self.wrapTagSelector.currentText())
+        s.setValue("wrap_attrib", self.wrapAttribSelector.currentText())
+        s.setValue("wrap_attrib_name", self.wrapAttribName.text())
 
 
 class TypographicalQuotes(preferences.Group):

--- a/frescobaldi_app/preferences/editor.py
+++ b/frescobaldi_app/preferences/editor.py
@@ -229,7 +229,7 @@ class SourceExport(preferences.Group):
     def __init__(self, page):
         super(SourceExport, self).__init__(page)
 
-        layout = QVBoxLayout()
+        layout = QGridLayout(spacing=1)
         self.setLayout(layout)
 
         self.numberLines = QCheckBox(toggled=self.changed)
@@ -237,12 +237,26 @@ class SourceExport(preferences.Group):
         self.copyHtmlAsPlainText = QCheckBox(toggled=self.changed)
         self.inlineStyleExport = QCheckBox(toggled=self.changed)
         self.copyDocumentBodyOnly = QCheckBox(toggled=self.changed)
+        self.wrapperTag = QLabel()
+        self.wrapTagSelector = QComboBox()
+        self.wrapperAttribute = QLabel()
+        self.wrapAttribSelector = QComboBox()
+        self.wrapAttribNameLabel = QLabel()
+        self.wrapAttribName = QLineEdit()
 
-        layout.addWidget(self.numberLines)
-        layout.addWidget(self.inlineStyleCopy)
-        layout.addWidget(self.inlineStyleExport)
-        layout.addWidget(self.copyHtmlAsPlainText)
-        layout.addWidget(self.copyDocumentBodyOnly)
+        # left column
+        layout.addWidget(self.numberLines, 0, 0)
+        layout.addWidget(self.inlineStyleCopy, 1, 0)
+        layout.addWidget(self.inlineStyleExport, 2, 0)
+        layout.addWidget(self.copyHtmlAsPlainText, 3, 0)
+        #right column
+        layout.addWidget(self.copyDocumentBodyOnly, 0, 1, 1, 2)
+        layout.addWidget(self.wrapperTag, 1, 1)
+        layout.addWidget(self.wrapTagSelector, 1, 2)
+        layout.addWidget(self.wrapperAttribute, 2, 1)
+        layout.addWidget(self.wrapAttribSelector, 2, 2)
+        layout.addWidget(self.wrapAttribNameLabel, 3, 1)
+        layout.addWidget(self.wrapAttribName, 3, 2)
 
         app.translateUI(self)
 
@@ -276,6 +290,22 @@ class SourceExport(preferences.Group):
             "May be used in conjunction with the plain text option, with the "
             "inline style option turned off, to copy highlighted code in a "
             "text editor when an external style sheet is already available."))
+        self.wrapperTag.setText(_("Tag to wrap around source:" + "  "))
+        self.wrapperTag.setToolTip('<qt>' + _(
+            "Choose what tag the colored HTML will be wrapped into."))
+        self.wrapTagSelector.addItem(_("pre"))
+        self.wrapTagSelector.addItem(_("code"))
+        self.wrapTagSelector.addItem(_("div"))
+        self.wrapperAttribute.setText(_("Attribute type of wrapper:" + "  "))
+        self.wrapperAttribute.setToolTip('<qt>' + _(
+            "Choose whether the wrapper tag should be of type 'id' or 'class'"))
+        self.wrapAttribSelector.addItem(_("id"))
+        self.wrapAttribSelector.addItem(_("class"))
+        self.wrapAttribNameLabel.setText(_("Name of attribute:" + "  "))
+        self.wrapAttribNameLabel.setToolTip('<qt>' + _(
+            "Arbitrary name for the type attribute. " +
+            "This must match the CSS stylesheet if using external CSS."))
+
 
     def loadSettings(self):
         s = QSettings()

--- a/frescobaldi_app/preferences/editor.py
+++ b/frescobaldi_app/preferences/editor.py
@@ -248,12 +248,12 @@ class SourceExport(preferences.Group):
         self.wrapAttribName.textEdited.connect(page.changed)
 
         # left column
-        layout.addWidget(self.numberLines, 0, 0)
-        layout.addWidget(self.inlineStyleCopy, 1, 0)
-        layout.addWidget(self.inlineStyleExport, 2, 0)
-        layout.addWidget(self.copyHtmlAsPlainText, 3, 0)
+        layout.addWidget(self.copyHtmlAsPlainText, 0, 0)
+        layout.addWidget(self.copyDocumentBodyOnly, 1, 0)
+        layout.addWidget(self.inlineStyleCopy, 2, 0)
+        layout.addWidget(self.inlineStyleExport, 3, 0)
         #right column
-        layout.addWidget(self.copyDocumentBodyOnly, 0, 1, 1, 2)
+        layout.addWidget(self.numberLines, 0, 1, 1, 2)
         layout.addWidget(self.wrapperTag, 1, 1)
         layout.addWidget(self.wrapTagSelector, 1, 2)
         layout.addWidget(self.wrapperAttribute, 2, 1)

--- a/frescobaldi_app/userguide/prefs_editor.md
+++ b/frescobaldi_app/userguide/prefs_editor.md
@@ -30,6 +30,37 @@ a real Tab by moving the number to zero.
 You can also set indentation preferences per-document, see
 {document_variables}.
 
+= Source Export Preferences=
+
+Configures how colored source code is produced when exporting to a file or
+copying to clipboard. Available options are:
+
+* `Copy HTML as plain text` |
+  Generates the colored source code as HTML markup so it can be pasted in HTML
+  pages.  When unchecked rich text is produced that can be pasted to rich text
+  editors like word processors.
+* `Copy document body only` |
+  Wraps the source in a single HTML tag. When unchecked a full HTML document is
+  produced.
+  *Note:* This option doesn't take effect when *exporting* source code.
+* `Use inline style when copying colored HTML` |
+  Inserts CSS styles *in* the generated HTML tags.
+  When unchecked CSS classes are used.
+  *Note:* When this option is *unchecked* and `Copy document body only` is
+  *checked* no actual CSS styles will be generated. To use this option there has
+  to be an external CSS available in the target document.
+  *Note:* This option doesn't take effect when *exporting* source code.
+* `Use inline style when exporting colored HTML` |
+  Same as above but applies for exporting instead of copying.
+* `Show line numbers` |
+  (should be self-explanatory)
+* `Wrappers` |
+  By default colored code is wrapped in a `<pre id="document"></pre>` tag, but
+  this can be configured to use a selection of wrapper tags and attribute types
+  and an arbitrary attribute name.
+  So it is for example to generate an `<div class="lilypond">` element if that
+  is more suitable for the existing CSS.
+
 
 #VARS
 menu_autoindent menu tools -> &Automatic Indent

--- a/frescobaldi_app/viewhighlighter.py
+++ b/frescobaldi_app/viewhighlighter.py
@@ -57,21 +57,21 @@ class ViewHighlighter(widgets.arbitraryhighlighter.ArbitraryHighlighter, plugin.
         """Called when something changes in the bookmarks."""
         for type, marks in bookmarks.bookmarks(self.parent().document()).marks().items():
             self.highlight(type, marks, -1)
-    
+
     def eventFilter(self, view, ev):
         if ev.type() in (QEvent.FocusIn, QEvent.FocusOut):
             self.updateCursor(view)
         return False
-    
+
     def updateCursor(self, view=None):
         """Called when the textCursor has moved. Highlights the current line.
-        
+
         If view is None (the default), our parent() is assumed to be the
         view. The eventFilter() method calls us with the view, this is
         done because the event filter is sometimes called very late in
         the destructor phase, when our parent is possibly not valid
         anymore.
-        
+
         """
         if view is None:
             view = self.parent()
@@ -86,7 +86,7 @@ class ViewHighlighter(widgets.arbitraryhighlighter.ArbitraryHighlighter, plugin.
         color.setAlpha(200 if view.hasFocus() else 100)
         self._cursorFormat.setBackground(color)
         self.highlight(self._cursorFormat, [cursor], 0)
-        
+
     def readSettings(self):
         data = textformats.formatData('editor')
         self._baseColors = data.baseColors
@@ -95,14 +95,12 @@ class ViewHighlighter(widgets.arbitraryhighlighter.ArbitraryHighlighter, plugin.
 
     def textFormat(self, name):
         """(Internal) Returns a QTextCharFormat setup according to the preferences.
-        
+
         For bookmarks and the current line, FullWidthSelection is automatically enabled.
-        
+
         """
         f = QTextCharFormat()
         f.setBackground(self._baseColors[name])
         if name in ('current', 'mark', 'error'):
             f.setProperty(QTextFormat.FullWidthSelection, True)
         return f
-
-


### PR DESCRIPTION
I hope this really works and there are no other "side-effects" that I didn't see/realize.

This adds some more options to the source export that I have always missed (actually I had to manually replace output for each export).

This PR relies on https://github.com/wbsoft/python-ly/pull/42 against `python-ly`. That means it can only be tested when the other PR has been merged or with the `config-colorize` branch of `python-ly` checked out.