### PR TITLE
Make manuscript viewer open single file (pdf) only

### DIFF
--- a/frescobaldi_app/manuscript/widget.py
+++ b/frescobaldi_app/manuscript/widget.py
@@ -108,14 +108,13 @@ class ManuscriptView(QWidget):
         self.view.clear()
 
     def openManuscripts(self):
-        """ Displays an open dialog to open one or more documents. """
+        """ Displays an open dialog to open a manuscript PDF. """
         caption = app.caption(_("dialog title", "Open Manuscript(s)"))
         directory = app.basedir()
-        files = QFileDialog.getOpenFileNames(self, caption, directory, '*')
-        for f in files:
-            self.view.clear()
-            doc = popplerqt4.Poppler.Document.load(f)
-            self.view.load(doc)
+        filename = QFileDialog().getOpenFileName(self, caption, directory, '*.pdf',)
+        self.view.clear()
+        doc = popplerqt4.Poppler.Document.load(filename)
+        self.view.load(doc)
 
     def dockwidget(self):
         return self._dockwidget()


### PR DESCRIPTION
For now the manuscript viewer can only handle a single PDF
(and I think it's a good idea to leave it at that for now).
Therefore the the file open dialog should only allow opening one file,
and as we can only open PDFs for now this should also be restricted.

Once we open up the tool it'll be easy to re-add the functionality.