### PR TITLE
Viewer show submenu

### DIFF
--- a/frescobaldi_app/viewers/contextmenu.py
+++ b/frescobaldi_app/viewers/contextmenu.py
@@ -91,6 +91,11 @@ class ViewerContextMenu(QObject):
         sm.addAction(ac.music_zoom_out)
         sm.addAction(ac.music_zoom_original)
 
+    def addShowActions(self):
+        """Add actions to show alternative documents.
+        This is not implemented in the base class"""
+        pass
+
     def addCloseActions(self):
         """Add actions to close documents.
         This is not implemented in the base class"""
@@ -135,6 +140,7 @@ class ViewerContextMenu(QObject):
         self.addCopyImageAction()
         self.addCursorLinkActions(cursor, link, position)
         # Actions affecting the currently opened documents
+        self.addShowActions()
         self.addCloseActions()
         self.addReloadAction()
         # Actions affecting the viewer's state

--- a/frescobaldi_app/viewers/contextmenu.py
+++ b/frescobaldi_app/viewers/contextmenu.py
@@ -34,7 +34,7 @@ class ViewerContextMenu(QObject):
     def __init__(self, panel):
         self._panel = panel
         self._surface = None
-        self._menu = None
+        self._menu = QMenu(self._panel)
 
     def surface(self):
         """Return the (cached) surface"""
@@ -134,7 +134,6 @@ class ViewerContextMenu(QObject):
         """Build the panel's context menu dynamically.
         Implements the template method pattern to allow
         subclasses to override each step."""
-        self._menu = m = QMenu(self._panel)
 
         # Actions affecting the current link(selection)
         self.addCopyImageAction()
@@ -151,6 +150,6 @@ class ViewerContextMenu(QObject):
         self.addHelpAction()
 
         # show it!
-        if m.actions():
-            m.exec_(position)
-        m.deleteLater()
+        if self._menu.actions():
+            self._menu.exec_(position)
+        self._menu.deleteLater()

--- a/frescobaldi_app/viewers/manuscript/__init__.py
+++ b/frescobaldi_app/viewers/manuscript/__init__.py
@@ -200,3 +200,10 @@ class DocumentChooserAction(viewers.DocumentChooserAction):
         except ValueError:
             # no replacement possible because the original doc isn't found
             pass
+
+    def setActiveDocument(self, filename):
+        """Activate the given document if it's in the list of documents"""
+        filenames = [d.filename() for d in self._documents]
+        if filename in filenames:
+            self._currentIndex = filenames.index(filename)
+            self.updateDocument()

--- a/frescobaldi_app/viewers/manuscript/contextmenu.py
+++ b/frescobaldi_app/viewers/manuscript/contextmenu.py
@@ -23,7 +23,7 @@ The Manuscriot Viewer context menu additions.
 
 from __future__ import unicode_literals
 
-from PyQt4.QtGui import QMenu, QAction
+from PyQt4.QtGui import QMenu, QAction, QActionGroup
 
 from viewers import contextmenu
 
@@ -45,6 +45,8 @@ class ManuscriptViewerContextMenu(contextmenu.ViewerContextMenu):
         sm = QMenu(m)
         sm.setTitle(_("Show"))
         sm.setEnabled(multi_docs)
+        ag = QActionGroup(m)
+        ag.triggered.connect(self.slotShowDocument)
 
         for d in docs:
             action = QAction(sm)
@@ -52,21 +54,23 @@ class ManuscriptViewerContextMenu(contextmenu.ViewerContextMenu):
             action._document_filename = d.filename()
             # TODO: Tooltips aren't shown by Qt (it seems)
             action.setToolTip(d.filename())
-            action.setEnabled(d.filename() != current_doc_filename)
+            action.setCheckable(True)
+            action.setChecked(d.filename() == current_doc_filename)
 
             # variant a) doesn't work because the slot is never reached
             # action.triggered.connect(self.slotShowDocument)
 
             # variant b) doesn't work because it's always the *last*
             # entry that is triggered
-            document_actions[action] = d.filename()
-            @action.triggered.connect
-            def showDocument():
-                # TODO: Problem is: action.toolTip() is obviously always
-                # the one from the *last* entry.
-                print document_actions[action]
-                mds.setActiveDocument(document_actions[action])
+#            document_actions[action] = d.filename()
+            # @action.triggered.connect
+            # def showDocument():
+            #     # TODO: Problem is: action.toolTip() is obviously always
+            #     # the one from the *last* entry.
+            #     print document_actions[action]
+            #     mds.setActiveDocument(document_actions[action])
 
+            ag.addAction(action)
             sm.addAction(action)
 
         m.addSeparator()

--- a/frescobaldi_app/viewers/manuscript/contextmenu.py
+++ b/frescobaldi_app/viewers/manuscript/contextmenu.py
@@ -32,6 +32,18 @@ class ManuscriptViewerContextMenu(contextmenu.ViewerContextMenu):
     def __init__(self, panel):
         super(ManuscriptViewerContextMenu, self).__init__(panel)
 
+    def addShowActions(self):
+        """Adds a submenu giving access to the (other)
+        opened manuscripts"""
+        m = self._menu
+        sm = QMenu(m)
+        sm.setTitle(_("Show"))
+        docs = self._panel.actionCollection.music_document_select._documents
+        multi_docs = len(docs) > 1
+        sm.setEnabled(multi_docs)
+        m.addSeparator()
+        m.addMenu(sm)
+
     def addCloseActions(self):
         """Add actions to close documents.
         This is not implemented in the base class"""
@@ -41,7 +53,6 @@ class ManuscriptViewerContextMenu(contextmenu.ViewerContextMenu):
         if docs:
             sm = QMenu(m)
             sm.setTitle(_("Close"))
-            m.addSeparator()
             m.addMenu(sm)
             sm.addAction(ac.manuscript_close)
             multi_docs = len(docs) > 1

--- a/frescobaldi_app/viewers/popplerwidget.py
+++ b/frescobaldi_app/viewers/popplerwidget.py
@@ -109,13 +109,6 @@ class AbstractPopplerView(QWidget):
         if view:
             self.slotCurrentViewChanged(view)
 
-    def contextMenu(self):
-        if self._contextMenu:
-            return self._contextMenu
-        else:
-            from . import contextmenu
-            return self._ctxMenuClass(self.parent())
-
     def sizeHint(self):
         """Returns the initial size the PDF (Music) View prefers."""
         return self.parent().mainwindow().size() / 2
@@ -339,7 +332,8 @@ class AbstractPopplerView(QWidget):
             page, link = self.view.surface().pageLayout().linkAt(pos_in_surface)
             if link:
                 cursor = self._links.cursor(link, True)
-        self.contextMenu().show(pos, link, cursor)
+        self._contextMenu = self._ctxMenuClass(self.parent())
+        self._contextMenu.show(pos, link, cursor)
 
     def toolbar(self):
         """Returns the viewer's toolbar widget."""


### PR DESCRIPTION
I need some help now, after fiddling around for some (intermittent) time over a few days.

I try implementing a context-sub-menu giving access to the alternative open documents in the manuscript viewer. Building the menu seems to work, but I don't get the actions to trigger properly.

I have two different approaches (should be clear from the comments in `manuscript.contextmenu`) and both don't work. In one case the slot isn't executed at all - this is probably due to the fact that the object has already been deleted before the action is triggered. In the other case it's always the *last* item that defines the action - so you can only switch to the last document in the list.