### PR TITLE
Widget creation

### DIFF
--- a/frescobaldi_app/viewers/__init__.py
+++ b/frescobaldi_app/viewers/__init__.py
@@ -135,6 +135,18 @@ class AbstractViewPanel(panel.Panel):
         ac.viewer_show_toolbar.triggered.connect(self.slotShowToolbar)
         self.mainwindow().allDocumentsClosed.connect(self.closeAllViewdocs)
 
+    def widget(self):
+        """Ensures that our widget() is created and intitialized and returns it.
+        Overrides the default implementation of Panel because we need to call
+        the session handler *after* the widget is created."""
+        w = super(panel.Panel, self).widget()
+        if not w:
+            w = self.createWidget()
+            self.setWidget(w)
+            import sessions
+            self.slotSessionChanged(sessions.currentSession())
+        return w
+
     def _createConreteActions(self):
         """Create the actionCollection.
         Subclasses must override this method."""

--- a/frescobaldi_app/viewers/__init__.py
+++ b/frescobaldi_app/viewers/__init__.py
@@ -181,9 +181,10 @@ class AbstractViewPanel(panel.Panel):
         This is the lowercase classname, right-stripped
         of a trailing 'panel'.
         To be used for accessing the QSettings group."""
-        result = type(self).__name__.lower()
-        result = result if not result.endswith('panel') else result[:-5]
-        return result
+        if not hasattr(self, '_viewerName'):
+            name = type(self).__name__.lower()
+            self._viewerName = name if not name.endswith('panel') else name[:-5]
+        return self._viewerName
 
     def viewerPanelDisplayName(self):
         """Returns the 'display name' of the current viewer."""

--- a/frescobaldi_app/viewers/popplerwidget.py
+++ b/frescobaldi_app/viewers/popplerwidget.py
@@ -70,10 +70,6 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
         self.createView()
         self.createContextMenu()
         self.connectSlots()
-
-        # load current session when the widget is created
-        import sessions
-        panel.slotSessionChanged(sessions.currentSession())
         self.readSettings()
 
         userguide.openWhatsThis(self)
@@ -385,7 +381,6 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
             # perform highlighting after move has been started. This is to ensure that if kinetic scrolling is
             # is enabled its speed is already set so that we can adjust the highlight timer.
             self.highlight(links.destinations(), s)
-
 
     def highlight(self, destinations, slice, msec=None):
         """(Internal) Highlights the from the specified destinations the specified slice."""

--- a/frescobaldi_app/viewers/popplerwidget.py
+++ b/frescobaldi_app/viewers/popplerwidget.py
@@ -101,7 +101,7 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
         result = self.helpButton = QToolButton(
             icon = icons.get("help-contents"),
             autoRaise = True,
-            clicked = lambda: userguide.show(self.parent().viewerName()))
+            clicked = lambda: userguide.show(self.viewerName()))
 
     def _tbAddSeparator(self):
         """Add a separator to the toolbar."""
@@ -173,7 +173,7 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
         self._main_layout.addLayout(self._toolbar_layout)
 
         # create toolbar and add to layout
-        self._toolbar = toolbar = self.parent().mainwindow().addToolBar(self.parent().viewerName())
+        self._toolbar = toolbar = self.parent().mainwindow().addToolBar(self.viewerName())
         self._toolbar_layout.addWidget(toolbar)
         self._toolbar_layout.addStretch(1)
 
@@ -231,6 +231,12 @@ class AbstractPopplerWidget(abstractviewwidget.AbstractViewWidget):
         surface.linkHovered.connect(self.slotLinkHovered)
         surface.linkLeft.connect(self.slotLinkLeft)
         surface.linkHelpRequested.connect(self.slotLinkHelpRequested)
+
+    def viewerName(self):
+        """Return the viewerName() attribute of the panel."""
+        if not hasattr(self, '_viewerName'):
+            self._viewerName = self.parent().viewerName()
+        return self._viewerName
 
     def sizeHint(self):
         """Returns the initial size the PDF (Music) View prefers."""


### PR DESCRIPTION
This does *not* fix #735 at all, but hopefully makes the process of creating the widget and handling sessions more sane.

Now the session handlers are called *after* the widget has been created, avoiding the loop caused by the implicit calls of  `widget()`.