### PR TITLE
userguide: explain how to add URLs pointing to lilypond.org documentation

### DIFF
--- a/frescobaldi_app/userguide/prefs_lilydoc.md
+++ b/frescobaldi_app/userguide/prefs_lilydoc.md
@@ -1,11 +1,29 @@
 === LilyPond Documentation ===
-    
-Here you can add local paths or URLs pointing to LilyPond documentation. A 
-local path should point to the directory where either the `Documentation` 
+
+Here you can add local paths or URLs pointing to LilyPond documentation.
+
+== Local path ==
+
+A local path should point to the directory where either the `Documentation`
 directory lives, or the whole `share/doc/lilypond/html/offline-root` path.
 
-If those can't be found, documentation is looked for in all subdirectories 
-of the given path, one level deep. This makes it possible to put multiple 
-versions of LilyPond documentation in different subdirectories and have 
+If those can't be found, documentation is looked for in all subdirectories
+of the given path, one level deep. This makes it possible to put multiple
+versions of LilyPond documentation in different subdirectories and have
 Frescobaldi automatically find them.
 
+== Remote URL ==
+
+If you don't want to manage the LilyPond documentation locally on your
+computer, you can add an URL to the LilyPond website.  The URL should
+have the following format:
+
+    http://www.lilypond.org/doc/VERSION/
+
+where *VERSION* can be either a specific release number or the latest stable
+or development release, as in the following examples:
+
+    http://www.lilypond.org/doc/v2.18/
+    http://www.lilypond.org/doc/v2.19/
+    http://www.lilypond.org/doc/stable/
+    http://www.lilypond.org/doc/development/


### PR DESCRIPTION
Some people think that they can add whatever URL taken from the LilyPond website, but it seems that a specific format should be used instead:

- [on lilypond-user](https://lists.gnu.org/archive/html/lilypond-user/2015-11/msg00252.html)
- issue #534 

lilypond.org is down since a few days, but you can check the redirects [here](http://git.savannah.gnu.org/gitweb/?p=lilypond.git;a=blob;f=Documentation/web/server/lilypond.org.htaccess;h=c6da26a1bb1ac2d54cd91f32baacc1a6459e1927;hb=HEAD#l52).