### PR TITLE
Round tap tempo value to nearest common tempo

### DIFF
--- a/frescobaldi_app/scorewiz/scoreproperties.py
+++ b/frescobaldi_app/scorewiz/scoreproperties.py
@@ -222,10 +222,14 @@ class ScoreProperties(object):
     
     def setMetronomeValue(self, bpm):
         """ Tap the tempo tap button """
-        l = [abs(t - bpm) for t in metronomeValues]
-        m = min(l)
-        if m < 6:
-            self.metronomeValue.setCurrentIndex(l.index(m))
+        if  self.metronomeRound.isChecked():
+            l = [abs(t - bpm) for t in metronomeValues]
+            m = min(l)
+            if m < 6:
+                self.metronomeValue.setCurrentIndex(l.index(m))
+
+        else:
+            self.metronomeValue.setEditText(str(bpm))
 
     # Tempo indication
     def createTempoWidget(self):

--- a/frescobaldi_app/scorewiz/scoreproperties.py
+++ b/frescobaldi_app/scorewiz/scoreproperties.py
@@ -32,7 +32,7 @@ import fractions
 import re
 
 from PyQt4.QtCore import QSize, Qt
-from PyQt4.QtGui import QComboBox, QHBoxLayout, QIntValidator, QLabel
+from PyQt4.QtGui import QCheckBox, QComboBox, QGridLayout, QHBoxLayout, QIntValidator, QLabel
 
 import ly.dom
 import completionmodel
@@ -207,18 +207,29 @@ class ScoreProperties(object):
         self.metronomeTempo = widgets.tempobutton.TempoButton()
         self.metronomeTempo.tempo.connect(self.setMetronomeValue)
         self.metronomeLabel.setBuddy(self.metronomeNote)
+        self.metronomeRound = QCheckBox()
+
     
     def layoutMetronomeWidget(self, layout):
+        grid = QGridLayout()
+        grid.addWidget(self.metronomeLabel, 0, 0)
+
         box = QHBoxLayout(spacing=0)
-        box.addWidget(self.metronomeLabel)
         box.addWidget(self.metronomeNote)
         box.addWidget(self.metronomeEqualSign)
         box.addWidget(self.metronomeValue)
         box.addWidget(self.metronomeTempo)
-        layout.addLayout(box)
+        grid.addLayout(box, 0, 1)
+
+        grid.addWidget(self.metronomeRound, 1, 1)
+        layout.addLayout(grid)
         
     def tranlateMetronomeWidget(self):
         self.metronomeLabel.setText(_("Metronome mark:"))
+        self.metronomeRound.setText(_("Round tap tempo value"))
+        self.metronomeRound.setToolTip(_(
+            "Round the entered tap tempo to a common value."
+            ))
     
     def setMetronomeValue(self, bpm):
         """ Tap the tempo tap button """

--- a/frescobaldi_app/scorewiz/settings.py
+++ b/frescobaldi_app/scorewiz/settings.py
@@ -73,11 +73,23 @@ class ScoreProperties(QGroupBox, scoreproperties.ScoreProperties):
         scorewiz = self.window()
         scorewiz.pitchLanguageChanged.connect(self.setPitchLanguage)
         self.setPitchLanguage(scorewiz.pitchLanguage())
+
+        self.loadSettings()
+        self.window().finished.connect(self.saveSettings)
         
     def translateUI(self):
         self.translateWidgets()
         self.setTitle(_("Score properties"))
-    
+
+    def loadSettings(self):
+        s = QSettings()
+        s.beginGroup('scorewiz/scoreproperties')
+        self.metronomeRound.setChecked(s.value('round_metronome', True, bool))
+
+    def saveSettings(self):
+        s = QSettings()
+        s.beginGroup('scorewiz/scoreproperties')
+        s.setValue('round_metronome', self.metronomeRound.isChecked())
 
 
 class GeneralPreferences(QGroupBox):


### PR DESCRIPTION
This commit introduces a checkbox underneath the tap tempo widget in the score wizard. This checkbox is labelled "Round tap tempo value" and allows the user to enter a very precise tempo using the tap tempo button.

When the checkbox is set (default value for newer versions of Frescobaldi), behaviour is not changed, however when it is turned off, the tempo entry box will show the raw tempo from the button. For example, if the user tapped at exactly 117 BPM, the value shown will not be rounded to 116, i.e. one of the values in the tempo box.

This modification is a request from a friend, @pl-gauthier.