### PR TITLE
add kind of Mac installation to debuginfo (fixes #785)

### DIFF
--- a/frescobaldi_app/debuginfo.py
+++ b/frescobaldi_app/debuginfo.py
@@ -24,6 +24,8 @@ Provides version information of important supporting modules.
 from __future__ import unicode_literals
 
 import functools
+import sys
+import os
 
 import appinfo
 
@@ -84,6 +86,18 @@ def python_poppler_version():
     import popplerqt4
     return '.'.join(format(n) for n in popplerqt4.version())
 
+if sys.platform.startswith('darwin'):
+    @_catch_unknown
+    def mac_installation_kind():
+        import macosx
+        if macosx.inside_app_bundle():
+            if os.path.islink(os.getcwd() + '/../MacOS/python'):
+                return 'lightweight app bundle'
+            else:
+                return 'standalone app bundle'
+        else:
+            return 'command line'
+
 
 def version_info_named():
     """Yield all the relevant names and their version string."""
@@ -96,6 +110,8 @@ def version_info_named():
     yield "poppler", poppler_version()
     yield "python-poppler-qt", python_poppler_version()
     yield "OS", operating_system()
+    if sys.platform.startswith('darwin'):
+        yield "installation kind", mac_installation_kind()
 
 
 def version_info_string(separator='\n'):


### PR DESCRIPTION
The pull request is based on v2.x because I currently cannot run Qt5, but the changes are independent of Qt, so they can be easily cherry-picked in master branch.

@wbsoft Can you apply the changes to both branches or would you prefer me to apply them also to master, even if I cannot test it?