### PR TITLE
ChangeLog: Remove stray Git conflict marker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -83,7 +83,6 @@ Changes in 2.18.2 -- December 26th, 2015
     #789)
   - fix TypeError: QPen(): argument 1 has unexpected type QBrush
   - fix some bugs in Quick Insert panel
->>>>>>> origin/master
 * Translations:
   - updated: Dutch, French, Italian, Ukrainian
 


### PR DESCRIPTION
Remove conflict marker added in commit 0b80a60 ("Merge remote-tracking
branch 'origin/master' into manuscript-viewer", 2016-03-11).