### PR TITLE
Fixes #848: crash at startup if SvgView active.

### DIFF
--- a/frescobaldi_app/svgview/__init__.py
+++ b/frescobaldi_app/svgview/__init__.py
@@ -27,7 +27,7 @@ This previews a SVG-file with initial editing abilities.
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QKeySequence
-from PyQt5.QtWidgets import QAction
+from PyQt5.QtWidgets import QAction, QLabel
 
 import app
 import actioncollection
@@ -54,7 +54,10 @@ class SvgViewPanel(panel.Panel):
         self.toggleViewAction().setText(_("SV&G View"))
         
     def createWidget(self):
-        from . import widget
+        try:
+            from . import widget
+        except ImportError as err:
+            return QLabel(str(err),self) # Display error as widget
         w = widget.SvgView(self)
         return w
     


### PR DESCRIPTION
Fixes #848 (crash at startup if SvgView active). Also happens in Mac OS X (and likely Linux) if required libraries are not present. Catch error and display error message in widget.