### PR TITLE
BUGFIX: MIDI Input setting was never used!

### DIFF
--- a/frescobaldi_app/midihub.py
+++ b/frescobaldi_app/midihub.py
@@ -125,7 +125,7 @@ def output_by_name(name):
             return portmidi.Output(n)
 
 def input_by_name(name):
-    """Returns a portmidi.Output instance for name."""
+    """Returns a portmidi.Input instance for name."""
     for n in range(get_count()):
         i = portmidi.get_device_info(n)
         input_name = _decode_name(i.name)

--- a/frescobaldi_app/midiinput/__init__.py
+++ b/frescobaldi_app/midiinput/__init__.py
@@ -137,7 +137,8 @@ class Listener(QThread):
             s = bytearray([77, data[0][0][0], data[0][0][1], data[0][0][2], data[0][0][3]])
             event = next(midifile.parser.parse_midi_events(s))[1]
             
-            self.NoteEventSignal.emit(event)
+            if isinstance(event,midifile.event.NoteEvent):
+                self.NoteEventSignal.emit(event)
     
     def stop(self):
         self._capturing = False

--- a/frescobaldi_app/midiinput/__init__.py
+++ b/frescobaldi_app/midiinput/__init__.py
@@ -42,7 +42,7 @@ class MidiIn(object):
     
     def open(self):
         s = QSettings()
-        self._portname = s.value("midi/input_port", midihub.default_input(), str)
+        self._portname = s.value("midi/midi/input_port", midihub.default_input(), str)
         self._pollingtime = s.value("midi/polling_time", 10, int)
         self._portmidiinput = midihub.input_by_name(self._portname)
         

--- a/frescobaldi_app/midiinput/elements.py
+++ b/frescobaldi_app/midiinput/elements.py
@@ -15,20 +15,20 @@ class Note:
         # get correct note 0...11 = c...b
         # and octave corresponding to octave modifiers ',' & '''
         self._midinote = midinote
-        self._octave, self._note = divmod(midinote, 12)
-        self._octave -= 4
-        self._pitch = ly.pitch.Pitch(notemapping[self._note][0], notemapping[self._note][1], self._octave)
+        octave, note = divmod(midinote, 12)
+        octave -= 4
+        self._pitch = ly.pitch.Pitch(notemapping[note][0] % 7, notemapping[note][1], octave + notemapping[note][0] // 7)
     
     def output(self, relativemode=False, language='nederlands'):
         if relativemode:
-            # makeRelative changes pitch, so we need temporary variables for note and octave
-            lastnote = self._pitch.note
-            lastoctave = self._pitch.octave
-            self._pitch.makeRelative(Note.LastPitch)
-            Note.LastPitch.note = lastnote
-            Note.LastPitch.octave = lastoctave
+            pitch = self._pitch.copy()
+            pitch.makeRelative(Note.LastPitch)
+            Note.LastPitch.note = self._pitch.note
+            Note.LastPitch.octave = self._pitch.octave
+        else:
+            pitch = self._pitch
         # also octavecheck if Shift is held
-        return self._pitch.output(language) +   (('='+ly.pitch.octaveToString(self._octave)) if QApplication.keyboardModifiers() & Qt.SHIFT else '')
+        return pitch.output(language) + (('='+ly.pitch.octaveToString(self._pitch.octave)) if QApplication.keyboardModifiers() & Qt.SHIFT else '')
     
     def midinote(self):
         return self._midinote
@@ -61,17 +61,18 @@ class NoteMappings:
     def to_sharp(self, note, alteration):
         if alteration==0.5:
             return (note, alteration)
-        return (note-1 if note > 0 else 6, 0.5)
+        return (note-1, 0.5)
 
     def to_flat(self, note, alteration):
         if alteration==-0.5:
             return (note, alteration)
-        return (note+1 if note <6 else 0, -0.5)
+        return (note+1, -0.5)
 
     def __init__(self):
         self.key_order_sharp = [6, 1, 8, 3, 10, 5, 0]
         self.key_order_flat = [10, 3, 8, 1, 6, 11, 4]
 
+        # Transform: midinote (0-11) -> (note, accidental)
         self.sharps = [(0, 0),    # c
                        (0, 0.5),  # cis
                        (1, 0),    # d
@@ -98,6 +99,7 @@ class NoteMappings:
                       (6, -0.5),  # bes
                       (6, 0)]     # b
         # Construct all possible mappings using some replacement logic
+        # 7 flats, ... 1 flats, 0, 1 sharp, ..., 7 sharps
 
         self.sharp_mappings = []
         self.flat_mappings = []


### PR DESCRIPTION
Could fix issues #797 and #853.

- midiinput/__init__.py used "midi/input_port" and preferences used "midi/midi/input_port".
- Bug has existed since first implementation of midi-input in commit 9473aa87 (2013-11-12).
