### PR TITLE
Allow MusicXML export to follow \include's

### DIFF
--- a/frescobaldi_app/file_export/__init__.py
+++ b/frescobaldi_app/file_export/__init__.py
@@ -62,7 +62,7 @@ class FileExport(plugin.MainWindowPlugin):
             return False # cancelled
         import ly.musicxml
         writer = ly.musicxml.writer()
-        writer.parse_text(doc.toPlainText())
+        writer.parse_text(doc.toPlainText(), orgname)
         xml = writer.musicxml()
         # put the Frescobaldi version in the xml file
         software = xml.root.find('.//encoding/software')


### PR DESCRIPTION
This is functionality that has already been available with python-ly
but simply not "activated" in Frescobaldi.

Closes #873

I hope this is sufficient as it simply passes the filename of the
currently open tab. If anything like respecting master documents
should be respected some more work would be involved (but actually
I don't think that should prevent this from being merged).

**NOTE:** I have tested this on the `2.19` branch but I don't think there should be any issue applying it to current master as well.