### PR TITLE
Keyboard shortcut for Midi input accidentals

### DIFF
--- a/frescobaldi_app/midiinput/tool.py
+++ b/frescobaldi_app/midiinput/tool.py
@@ -22,6 +22,7 @@ class MidiInputTool(panel.Panel):
         ac = self.actionCollection = Actions()
         ac.capture_start.triggered.connect(self.slotStartCapturing)
         ac.capture_stop.triggered.connect(self.slotStopCapturing)
+        ac.accidental_switch.triggered.connect(self.slotAccidentalSwitch)
         actioncollectionmanager.manager(mainwindow).addActionCollection(ac)
         mainwindow.addDockWidget(Qt.BottomDockWidgetArea, self)
     
@@ -34,7 +35,10 @@ class MidiInputTool(panel.Panel):
     
     def slotStopCapturing(self):
         self.widget().stopcapturing()
-    
+
+    def slotAccidentalSwitch(self):
+        self.widget().switchaccidental()
+
     def createWidget(self):
         from . import widget
         return widget.Widget(self)
@@ -44,12 +48,17 @@ class Actions(actioncollection.ActionCollection):
     def createActions(self, parent=None):
         self.capture_start = QAction(parent)
         self.capture_stop = QAction(parent)
+        self.accidental_switch = QAction(parent)
         
         self.capture_start.setIcon(icons.get('media-record'))
         self.capture_stop.setIcon(icons.get('process-stop'))
+
+        self.accidental_switch.setShortcut(QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_3))
         
     def translateUI(self):
         self.capture_start.setText(_("midi input", "Start capturing"))
         self.capture_start.setToolTip(_("midi input", "Start MIDI capturing"))
         self.capture_stop.setText(_("midi input", "Stop capturing"))
         self.capture_stop.setToolTip(_("midi input", "Stop MIDI capturing"))
+        self.accidental_switch.setText(_("midi input", "Switch accidental style"))    
+        self.accidental_switch.setToolTip(_("midi input", "Change accidental style (flats or sharps)"))

--- a/frescobaldi_app/midiinput/widget.py
+++ b/frescobaldi_app/midiinput/widget.py
@@ -64,7 +64,8 @@ class Widget(QWidget):
         self._capture = QToolButton()
         self._capture.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self._capture.setDefaultAction(ac.capture_start)
-        
+        self.addAction(ac.accidental_switch)
+
         self._notemode = QLabel()
         
         layout = QVBoxLayout()
@@ -133,6 +134,12 @@ class Widget(QWidget):
             self._capture.removeAction(self._capture.actions()[0])
         self._capture.setDefaultAction(ac.capture_start)
     
+    def switchaccidental(self):
+        if self.accidentals() == 'flats':
+            self._accidentalssharps.setChecked(True)
+        else:
+            self._accidentalsflats.setChecked(True)
+
     def savesettings(self):
         s = QSettings()
         s.beginGroup("midiinputdock")

--- a/frescobaldi_app/midiinput/widget.py
+++ b/frescobaldi_app/midiinput/widget.py
@@ -33,6 +33,7 @@ class Widget(QWidget):
         signals.append(self._keysignature.currentIndexChanged)
         
         self._labelaccidentals = QLabel()
+        self._labelaccidentals.setFixedHeight(20)
         self._accidentalssharps = QRadioButton()
         signals.append(self._accidentalssharps.clicked)
         self._accidentalsflats = QRadioButton()
@@ -72,7 +73,9 @@ class Widget(QWidget):
         self.setLayout(layout)
         grid = QGridLayout(spacing=0)
         layout.addLayout(grid)
-               
+        
+        self.empty = QWidget();   #Empty widget expands and fills bottom
+
         grid.addWidget(self._labelmidichannel, 0, 0)
         grid.addWidget(self._midichannel, 0, 1)
         grid.addWidget(self._labelkeysignature, 1, 0)
@@ -87,7 +90,8 @@ class Widget(QWidget):
         grid.addWidget(self._sostenuto, 5, 1)
         grid.addWidget(self._labelsoft, 6, 0)
         grid.addWidget(self._soft, 6, 1)
-        
+        grid.addWidget(self.empty, 7, 0)
+
         hbox = QHBoxLayout()
         layout.addLayout(hbox)
         hbox.addWidget(self._capture)


### PR DESCRIPTION
Added a keyboard shortcut for switching between accidental styles (flats or sharps), requested in Issue #890. I've kept the default shortcut to be Ctrl+Shift+3 and icon transpose-tools.svg. 