### PR TITLE
Remove (trailing) whitespace

### DIFF
--- a/frescobaldi_app/about.py
+++ b/frescobaldi_app/about.py
@@ -38,40 +38,40 @@ import userguide.page
 
 class AboutDialog(QDialog):
     """A simple 'About Frescobaldi' dialog.
-    
+
     Most of the information is taken from the info module.
-    
+
     """
     def __init__(self, mainwindow):
         """Creates the about dialog. You can simply exec_() it."""
         super(AboutDialog, self).__init__(mainwindow)
-        
+
         self.setWindowTitle(_("About {appname}").format(appname = appinfo.appname))
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         tabw = QTabWidget()
         layout.addWidget(tabw)
-        
+
         tabw.addTab(About(self), _("About"))
         tabw.addTab(Credits(self), _("Credits"))
         tabw.addTab(Version(self), _("Version"))
-        
+
         button = QDialogButtonBox(QDialogButtonBox.Ok)
         button.setCenterButtons(True)
         button.accepted.connect(self.accept)
         layout.addWidget(button)
         layout.setSizeConstraint(QLayout.SetFixedSize)
-        
+
 
 class About(QWidget):
     """About widget."""
     def __init__(self, parent=None):
         super(About, self).__init__(parent)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         size = QSize(100, 100)
         pic = QLabel()
         pic.setPixmap(icons.get("frescobaldi").pixmap(size))
@@ -82,7 +82,7 @@ class About(QWidget):
         text.setText(html())
         text.linkActivated.connect(self.openLink)
         layout.addWidget(text)
-    
+
     def openLink(self, url):
         helpers.openUrl(QUrl(url))
 
@@ -123,7 +123,7 @@ def html():
     license = _("Licensed under the {gpl}.").format(
         gpl = """<a href="http://www.gnu.org/licenses/gpl.html">GNU GPL</a>""")
     homepage = appinfo.url
-    
+
     return html_template.format(**locals())
 
 

--- a/frescobaldi_app/actioncollection.py
+++ b/frescobaldi_app/actioncollection.py
@@ -57,60 +57,60 @@ class ActionCollectionBase(object):
 
     You must subclass this class and provide a name for the actioncollection
     in the 'name' class attribute.
-    
+
     """
     def __init__(self, widget=None):
         self._widget = weakref.ref(widget) if widget else lambda: None
         self._actions = {}  # maps name to action
         self._defaults = {} # maps name to default list of shortcuts
         app.settingsChanged.connect(self.load)
-    
+
     def widget(self):
         """Returns the widget given on construction or None."""
         return self._widget()
-        
+
     def setDefaultShortcuts(self, name, shortcuts):
         """Set a default list of QKeySequence objects for the named action."""
         self._defaults[name] = shortcuts
-        
+
     def defaultShortcuts(self, name):
         """Returns the default shortcuts (list of QKeySequences) for the action.
-        
+
         If not defined, returns None.
-        
+
         """
         return self._defaults.get(name)
-        
+
     def actions(self):
         """Returns the dictionary with actions."""
         return self._actions
-        
+
     def defaults(self):
         """Returns the dictionary with actions that have a default shortcut."""
         return self._defaults
-        
+
     def shortcuts(self, name):
         """Returns the list of shortcuts for the named action, or None."""
         try:
             return self._actions[name].shortcuts()
         except KeyError:
             pass
-    
+
     def setShortcuts(self, name, shortcuts):
         """Implement to set the shortcuts list for our action."""
         pass
-    
+
     def settingsGroup(self):
         """Returns settings group to load/save shortcuts from or to."""
         s = QSettings()
         scheme = s.value("shortcut_scheme", "default", str)
         s.beginGroup("shortcuts/{0}/{1}".format(scheme, self.name))
         return s
-        
+
     def load(self):
         """Implement to load shortcuts from our settingsGroup()."""
         pass
-    
+
     def title(self):
         """If this returns a meaningful title, actions can be grouped in the shortcut settings dialog."""
         pass
@@ -118,22 +118,22 @@ class ActionCollectionBase(object):
 
 class ActionCollection(ActionCollectionBase):
     """Keeps a fixed list of QActions as instance attributes.
-    
+
     Subclass this and add the actions as instance attributes in
     the createActions() method.
-    
+
     You can set the default shortcuts directly in the actions in the
     createActions() method, it is not needed to use the setDefaultShortcuts()
     method for that.
-    
+
     Set the titles for the actions in the translateUI() method.
-    
+
     """
     def __init__(self, parent=None):
         """Creates the ActionCollection.
-        
+
         parent is an optional widget that is also the parent for the created actions.
-        
+
         """
         super(ActionCollection, self).__init__(parent)
         self.createActions(parent)
@@ -141,20 +141,20 @@ class ActionCollection(ActionCollectionBase):
         self.storeDefaults()
         self.load(False) # load the shortcuts without resettings defaults
         app.translateUI(self)
-        
+
     def createActions(self, parent=None):
         """Should add actions as instance attributes.
-        
+
         The QActions should get icons and shortcuts. Texts should be set
         in translateUI(). The actions are created with the parent given on instantiation.
-        
+
         """
         pass
 
     def translateUI(self):
         """Should (re)translate all the titles of the actions."""
         pass
-    
+
     def storeDefaults(self):
         """Saves the preset default QKeySequence lists for the actions."""
         for name, action in self._actions.items():
@@ -166,7 +166,7 @@ class ActionCollection(ActionCollectionBase):
         action = self.actions().get(name)
         if not action:
             return
-        
+
         default = self.defaultShortcuts(name)
         setting = self.settingsGroup()
         action.setShortcuts(shortcuts)
@@ -181,13 +181,13 @@ class ActionCollection(ActionCollectionBase):
                 setting.setValue(name, shortcuts)
             else:
                 setting.remove(name)
-    
+
     def load(self, restoreDefaults=True):
         """Reads keyboard shortcuts from the settings.
-        
+
         If restoreDefaults == True, resets the other shortcuts to their default
         values. If restoreDefaults == False, does not touch the other shortcuts.
-        
+
         """
         settings = self.settingsGroup()
         keys = settings.allKeys()
@@ -209,45 +209,45 @@ class ActionCollection(ActionCollectionBase):
 
 class ShortcutCollection(ActionCollectionBase):
     """An ActionCollection type that only saves actions that have a keyboard shortcut.
-    
+
     Should always be instantiated with a visible widget (preferably MainWindow)
     as parent.
-    
+
     Use the setShortcuts() method to set a list (possibly empty) of QKeySequence
     objects.  Every change causes other instances of the same-named collection
     to reload.
-    
+
     This serves two purposes:
     1. save keyboard shortcuts for actions created by the user or from a very large list
     2. make the keyboard shortcuts working even if the component the actions are
        contained in is not even loaded yet.
-       
+
        To make this work, implement the realAction() method to instantiate the widget the
        action is meant for and then return the real action.
-       
+
     """
     # save weak references to other instances with the same name and sync then.
     others = {}
-    
+
     # shortcut context to use by default
     shortcutContext = Qt.WindowShortcut
-    
+
     def __init__(self, widget):
         """Creates the ShortcutCollection.
-        
+
         The widget is required as actions are added to it, so their keyboard
         shortcuts get triggered.
-        
+
         """
         super(ShortcutCollection, self).__init__(widget)
         self.createDefaultShortcuts()
         self.load()
         self.others.setdefault(self.name, []).append(weakref.ref(self))
-    
+
     def createDefaultShortcuts(self):
         """Should set some default shortcut lists using setDefaultShortcuts()."""
         pass
-        
+
     def load(self):
         """Reads keyboard shortcuts from the settings.  Instantiates QActions as needed."""
         # clears all actions
@@ -271,7 +271,7 @@ class ShortcutCollection(ActionCollectionBase):
                     settings.remove(name)
             else:
                 self.action(name).setShortcuts(shortcuts)
-    
+
     def setShortcuts(self, name, shortcuts):
         """Sets the shortcuts list for our action. Use an empty list to remove the shortcuts."""
         if shortcuts:
@@ -285,7 +285,7 @@ class ShortcutCollection(ActionCollectionBase):
             else:
                 self.settingsGroup().remove(name)
         self.reloadOthers()
-    
+
     def restoreDefaultShortcuts(self, name):
         """Resets the shortcuts for the specified action to their default value."""
         shortcuts = self.defaultShortcuts(name)
@@ -295,7 +295,7 @@ class ShortcutCollection(ActionCollectionBase):
             self.removeAction(name)
         self.settingsGroup().remove(name)
         self.reloadOthers()
-        
+
     def removeAction(self, name):
         """(Internal) Removes the named action, returning True it it did exist."""
         try:
@@ -305,7 +305,7 @@ class ShortcutCollection(ActionCollectionBase):
         a.setParent(None)
         del self._actions[name]
         return True
-        
+
     def action(self, name):
         """Returns a QAction for the name, instantiating it if necessary."""
         try:
@@ -316,25 +316,25 @@ class ShortcutCollection(ActionCollectionBase):
             a.triggered.connect(lambda: self.triggerAction(name))
             self.widget().addAction(a)
         return a
-    
+
     def triggerAction(self, name):
         """Called when the user presses a saved keyboard shortcut."""
         a = self.realAction(name)
         if a:
             a.trigger()
-            
+
     def realAction(self, name):
         """Implement this to return the real action the name refers to,
-        
+
         This is called when the text and icon are needed (e.g. when the shortcut
         dialog is opened) or when our "shadow" action keyboard shortcut is triggered.
-        
+
         The function may return None, e.g. when the action our name refers to does
         not exist anymore.  In that case our action is also removed.
-        
+
         """
         pass
-    
+
     def actions(self):
         """Returns our real actions instead of the shadow ones."""
         d = {}
@@ -349,7 +349,7 @@ class ShortcutCollection(ActionCollectionBase):
         if changed:
             self.reloadOthers()
         return d
-    
+
     def reloadOthers(self):
         """Reload others managing the same shortcuts (e.g. in case of multiple mainwindows)."""
         for ref in self.others[self.name][:]:

--- a/frescobaldi_app/actioncollectionmanager.py
+++ b/frescobaldi_app/actioncollectionmanager.py
@@ -39,9 +39,9 @@ def manager(mainwindow):
 
 def action(collection_name, action_name):
     """Return a QAction from the application.
-    
+
     May return None, if the named collection or action does not exist.
-    
+
     """
     for mgr in ActionCollectionManager.instances():
         return mgr.action(collection_name, action_name)
@@ -52,17 +52,17 @@ class ActionCollectionManager(plugin.MainWindowPlugin):
     def __init__(self, mainwindow):
         """Creates the ActionCollectionManager for the given mainwindow."""
         self._actioncollections = weakref.WeakValueDictionary()
-    
+
     def addActionCollection(self, collection):
         """Add an actioncollection to our list (used for changing keyboard shortcuts).
-        
+
         Does not keep a reference to it.  If the ActionCollection gets garbage collected,
         it is removed automatically from our list.
-        
+
         """
         if collection.name not in self._actioncollections:
             self._actioncollections[collection.name] = collection
-        
+
     def removeActionCollection(self, collection):
         """Removes the given ActionCollection from our list."""
         if collection.name in self._actioncollections:
@@ -71,7 +71,7 @@ class ActionCollectionManager(plugin.MainWindowPlugin):
     def actionCollections(self):
         """Iterate over the ActionCollections in our list."""
         return self._actioncollections.values()
-        
+
     def action(self, collection_name, action_name):
         """Returns the named action from the named collection."""
         collection = self._actioncollections.get(collection_name)
@@ -79,7 +79,7 @@ class ActionCollectionManager(plugin.MainWindowPlugin):
             if isinstance(collection, actioncollection.ShortcutCollection):
                 return collection.realAction(action_name)
             return getattr(collection, action_name, None)
-    
+
     def iterShortcuts(self, skip=None):
         """Iter all shortcuts of all collections."""
         for collection in self.actionCollections():
@@ -87,13 +87,13 @@ class ActionCollectionManager(plugin.MainWindowPlugin):
                 if (collection, name) != skip:
                     for shortcut in collection.shortcuts(name):
                         yield shortcut, collection, name, a
-    
+
     def findShortcutConflict(self, shortcut, skip):
         """Find the possible shortcut conflict and return the conflict name.
-        
+
         skip must be a tuple (collection, name).
         it's the action to skip (the action that is about to be changed).
-        
+
         """
         if shortcut:
             for data in self.iterShortcuts(skip):
@@ -101,7 +101,7 @@ class ActionCollectionManager(plugin.MainWindowPlugin):
                 if s1.matches(shortcut) or shortcut.matches(s1):
                     return qutil.removeAccelerator(data[-1].text())
         return None
-    
+
     def removeShortcuts(self, shortcuts):
         """Find and remove shorcuts of the given list."""
         for data in self.iterShortcuts():
@@ -111,4 +111,4 @@ class ActionCollectionManager(plugin.MainWindowPlugin):
                     collShortcuts = collection.shortcuts(name)
                     collShortcuts.remove(s1)
                     collection.setShortcuts(name, collShortcuts)
-    
+

--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -62,9 +62,9 @@ jobFinished = Signal()          # (Document, Job, bool success)
 
 def activeWindow():
     """Return the currently active MainWindow.
-    
+
     Only returns None if there are no windows at all.
-    
+
     """
     if windows:
         w = QApplication.activeWindow()
@@ -74,9 +74,9 @@ def activeWindow():
 
 def openUrl(url, encoding=None):
     """Returns a Document instance for the given QUrl.
-    
+
     If there is already a document with that url, it is returned.
-    
+
     """
     d = findDocument(url)
     if not d:
@@ -98,9 +98,9 @@ def openUrl(url, encoding=None):
 
 def findDocument(url):
     """Returns a Document instance for the given QUrl if already loaded.
-    
+
     Returns None if no document with given url exists or if the url is empty.
-    
+
     """
     if not url.isEmpty():
         for d in documents:
@@ -123,13 +123,13 @@ def instantiate():
 
 def oninit(func):
     """Call specified function on QApplication instantiation.
-    
+
     If the QApplication already has been instantiated, the function is called
     directly.
-    
+
     As this function returns the specified function, you can use this as a
     decorator.
-    
+
     """
     if qApp:
         func()
@@ -152,14 +152,14 @@ def restart():
         args = [python_executable] + args
     import subprocess
     subprocess.Popen(args)
-    
+
 def translateUI(obj, priority=0):
     """Translates texts in the object.
-    
+
     Texts are translated again if the language is changed.
     The object must have a translateUI() method.  It is
     also called by this function.
-    
+
     """
     languageChanged.connect(obj.translateUI, priority)
     obj.translateUI()
@@ -170,9 +170,9 @@ def caption(title):
 
 def filetypes(extension=None):
     """Returns a list of supported filetypes.
-    
+
     If a type matches extension, it is placed first.
-    
+
     """
     have, havenot = [], []
     for patterns, name in (

--- a/frescobaldi_app/autocomplete/__init__.py
+++ b/frescobaldi_app/autocomplete/__init__.py
@@ -43,7 +43,7 @@ class CompleterManager(plugin.MainWindowPlugin):
             self.setView(mainwindow.currentView())
         complete = QSettings().value("autocomplete", True, bool)
         ac.autocomplete.setChecked(complete)
-    
+
     def setView(self, view):
         self.completer().setWidget(view)
 
@@ -55,11 +55,11 @@ class CompleterManager(plugin.MainWindowPlugin):
             self._completer = c = completer.Completer()
             c.autoComplete = self.actionCollection.autocomplete.isChecked()
             return self._completer
-    
+
     def setAutoComplete(self, enabled):
         QSettings().setValue("autocomplete", enabled)
         self.completer().autoComplete = enabled
-    
+
     def showCompletions(self):
         if self.mainwindow().currentView().hasFocus():
             self.completer().showCompletionPopup()
@@ -74,7 +74,7 @@ class Actions(actioncollection.ActionCollection):
         self.autocomplete = QAction(parent, checkable=True)
         self.popup_completions = QAction(parent)
         self.popup_completions.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_Space))
-    
+
     def translateUI(self):
         self.autocomplete.setText(_("Automatic &Completion"))
         self.popup_completions.setText(_("Show C&ompletions Popup"))

--- a/frescobaldi_app/autocomplete/completer.py
+++ b/frescobaldi_app/autocomplete/completer.py
@@ -38,11 +38,11 @@ class Completer(widgets.completer.Completer):
         self.popup().setMinimumWidth(100)
         app.settingsChanged.connect(self.readSettings)
         self.readSettings()
-    
+
     def readSettings(self):
         self.popup().setFont(textformats.formatData('editor').font)
         self.popup().setPalette(textformats.formatData('editor').palette())
-    
+
     def completionCursor(self):
         cursor = self.textCursor()
         # trick: if we are still visible we don't have to analyze the text again

--- a/frescobaldi_app/autocomplete/completiondata.py
+++ b/frescobaldi_app/autocomplete/completiondata.py
@@ -150,7 +150,7 @@ bookpart = sorted(
     everywhere + inputmodes + markup + start_music + modes[2:] + blocks
 )
 
-    
+
 # stuff inside \book {}
 book = sorted(
     everywhere + inputmodes + markup + start_music
@@ -219,11 +219,11 @@ lilypond_toplevel = listmodel.ListModel(sorted(itertools.chain(util.make_cmds(
 lilypond_book = listmodel.ListModel(book, display = util.command)
 
 lilypond_bookpart = listmodel.ListModel(bookpart, display = util.command)
-    
+
 lilypond_score = listmodel.ListModel(score, display = util.command)
 
 lilypond_engravers = listmodel.ListModel(ly.data.engravers())
-    
+
 def lilypond_grob_properties(grob, hash_quote=True):
     display = (lambda item: "#'" + item) if hash_quote else (lambda item: item)
     return listmodel.ListModel(ly.data.grob_properties(grob),

--- a/frescobaldi_app/autocomplete/documentdata.py
+++ b/frescobaldi_app/autocomplete/documentdata.py
@@ -75,7 +75,7 @@ class DocumentDataSource(plugin.DocumentPlugin):
             completiondata.score,
             harvest.include_identifiers(cursor),
             harvest.names(cursor)))), display = util.command)
-    
+
     @util.keep
     def bookpartcommands(self, cursor):
         """Stuff inside \\bookpart { }. """
@@ -83,7 +83,7 @@ class DocumentDataSource(plugin.DocumentPlugin):
             completiondata.bookpart,
             harvest.include_identifiers(cursor),
             harvest.names(cursor)))), display = util.command)
-    
+
     @util.keep
     def bookcommands(self, cursor):
         """Stuff inside \\book { }. """
@@ -91,8 +91,8 @@ class DocumentDataSource(plugin.DocumentPlugin):
             completiondata.book,
             harvest.include_identifiers(cursor),
             harvest.names(cursor)))), display = util.command)
-    
-    
+
+
     @util.keep
     def musiccommands(self, cursor):
         return listmodel.ListModel(sorted(set(itertools.chain(
@@ -115,13 +115,13 @@ class DocumentDataSource(plugin.DocumentPlugin):
 
     def includenames(self, cursor, directory=None):
         """Finds files relative to the directory of the cursor's document.
-        
+
         If the document has a local filename, looks in that directory,
         also in a subdirectory of it, if the directory argument is given.
-        
-        Then looks recursively in the user-set include paths, 
+
+        Then looks recursively in the user-set include paths,
         and finally in LilyPond's own ly/ folder.
-        
+
         """
         names = []
         # names in current dir
@@ -134,17 +134,17 @@ class DocumentDataSource(plugin.DocumentPlugin):
                     for f in get_filenames(basedir, True)))
             else:
                 names.extend(sorted(get_filenames(basedir, True)))
-        
+
         # names in specified include paths
         import documentinfo
         for basedir in documentinfo.info(self.document()).includepath():
-            
+
             # store dir relative to specified include path root
             reldir = directory if directory else ""
             # look for files in the current relative directory
             for f in sorted(get_filenames(os.path.join(basedir, reldir), True)):
                 names.append(os.path.join(reldir, f))
-        
+
         # names from LilyPond itself
         import engrave.command
         datadir = engrave.command.info(self.document()).datadir()
@@ -154,11 +154,11 @@ class DocumentDataSource(plugin.DocumentPlugin):
             names.extend(sorted(f for f in get_filenames(basedir)
                 if not f.endswith('init.ly')
                 and f.islower()))
-        
+
         # forward slashes on Windows (issue #804)
         if os.name == "nt":
             names = [name.replace('\\', '/') for name in names]
-        
+
         return listmodel.ListModel(names)
 
 

--- a/frescobaldi_app/autocomplete/harvest.py
+++ b/frescobaldi_app/autocomplete/harvest.py
@@ -47,7 +47,7 @@ def markup_commands(cursor):
     """Harvest markup command definitions until the cursor."""
     return get_docinfo(cursor).markup_definitions()
 
-    
+
 def schemewords(document):
     """Harvests all schemewords from the document."""
     for t in tokeniter.all_tokens(document):
@@ -69,7 +69,7 @@ def include_markup_commands(cursor):
     files = fileinfo.includefiles(get_docinfo(cursor), dinfo.includepath())
     return itertools.chain.from_iterable(fileinfo.docinfo(f).markup_definitions()
                                          for f in files)
-    
+
 
 _words = re.compile(r'\w{5,}|\w{2,}(?:[:-]\w+)+').finditer
 _word_types = (

--- a/frescobaldi_app/backup.py
+++ b/frescobaldi_app/backup.py
@@ -30,9 +30,9 @@ from PyQt5.QtCore import QSettings
 
 def backup(filename):
     """Makes a backup of 'filename'.
-    
+
     Returns True if the backup succeeded.
-    
+
     """
     if filename:
         try:
@@ -54,9 +54,9 @@ def removeBackup(filename):
 
 def scheme():
     """Returns a string that must contain "FILE".
-    
+
     Replacing that part yields the backup name.
-    
+
     """
     s = QSettings().value("backup_scheme", "FILE~")
     assert 'FILE' in s and s != 'FILE'

--- a/frescobaldi_app/bookmarkmanager.py
+++ b/frescobaldi_app/bookmarkmanager.py
@@ -46,7 +46,7 @@ class BookmarkManager(plugin.MainWindowPlugin):
         if mainwindow.currentView():
             self.slotViewChanged(mainwindow.currentView())
             self.slotDocumentChanged(mainwindow.currentDocument())
-    
+
     def slotViewChanged(self, view, prev=None):
         if prev:
             prev.cursorPositionChanged.disconnect(self.updateMarkStatus)
@@ -66,22 +66,22 @@ class BookmarkManager(plugin.MainWindowPlugin):
         view = self.mainwindow().currentView()
         lineNumber = view.textCursor().blockNumber()
         bookmarks.bookmarks(view.document()).toggleMark(lineNumber, 'mark')
-    
+
     def clearErrorMarks(self):
         doc = self.mainwindow().currentDocument()
         bookmarks.bookmarks(doc).clear('error')
-        
+
     def clearAllMarks(self):
         doc = self.mainwindow().currentDocument()
         bookmarks.bookmarks(doc).clear()
-    
+
     def nextMark(self):
         view = self.mainwindow().currentView()
         cursor = view.textCursor()
         cursor = bookmarks.bookmarks(view.document()).nextMark(cursor)
         if cursor:
             view.gotoTextCursor(cursor)
-            
+
     def previousMark(self):
         view = self.mainwindow().currentView()
         cursor = view.textCursor()

--- a/frescobaldi_app/bookmarks.py
+++ b/frescobaldi_app/bookmarks.py
@@ -54,31 +54,31 @@ def bookmarks(document):
 
 class Bookmarks(plugin.DocumentPlugin):
     """Manages bookmarks (marked lines) for a Document.
-    
+
     The marks are stored in the metainfo for the Document.
-    
+
     """
     marksChanged = signals.Signal()
-    
+
     def __init__(self, document):
         """Creates the Bookmarks instance."""
         document.loaded.connect(self.load)
         document.saved.connect(self.save)
         document.closed.connect(self.save)
         self.load() # initializes self._marks
-        
+
     def marks(self, type=None):
         """Returns marks (QTextCursor instances).
-        
+
         If type is specified (one of the names in the module-global types variable),
         the list of marks of that type is returned.
         If type is None, a dictionary listing all types mapped to lists of marks
         is returned.
-        
+
         """
-        
+
         return self._marks[type] if type else self._marks
-    
+
     def setMark(self, linenum, type):
         """Marks the given line number with a mark of the given type."""
         nums = [mark.blockNumber() for mark in self._marks[type]]
@@ -93,7 +93,7 @@ class Bookmarks(plugin.DocumentPlugin):
             pass
         self._marks[type].insert(index, mark)
         self.marksChanged()
-        
+
     def unsetMark(self, linenum, type):
         """Removes a mark of the given type on the given line."""
         nums = [mark.blockNumber() for mark in self._marks[type]]
@@ -106,7 +106,7 @@ class Bookmarks(plugin.DocumentPlugin):
                 if linenum not in nums:
                     break
             self.marksChanged()
-        
+
     def toggleMark(self, linenum, type):
         """Toggles the mark of the given type on the given line."""
         nums = [mark.blockNumber() for mark in self._marks[type]]
@@ -136,7 +136,7 @@ class Bookmarks(plugin.DocumentPlugin):
                 if mark.blockNumber() == linenum:
                     return True
         return False
-        
+
     def clear(self, type=None):
         """Removes all marks, or only all marks of the given type. if specified."""
         if type is None:
@@ -160,7 +160,7 @@ class Bookmarks(plugin.DocumentPlugin):
         index = bisect.bisect_right(nums, cursor.blockNumber())
         if index < len(nums):
             return QTextCursor(marks[index].block())
-        
+
     def previousMark(self, cursor, type=None):
         """Finds the first mark before the cursor (of the type if specified)."""
         if type is None:
@@ -187,7 +187,7 @@ class Bookmarks(plugin.DocumentPlugin):
         for type in types:
             self._marks[type] = [QTextCursor(self.document().findBlockByNumber(num)) for num in d.get(type, [])]
         self.marksChanged()
-        
+
     def save(self):
         """Saves the marks to the metainfo."""
         d = {}

--- a/frescobaldi_app/browseriface.py
+++ b/frescobaldi_app/browseriface.py
@@ -57,7 +57,7 @@ class BrowserIface(plugin.MainWindowPlugin):
         self._history = [Position()]
         self._index = 0    # the index points to the current position
         self.updateActions()
-    
+
     def goBack(self):
         """Called when the user activates the go_back action."""
         if self._index > 0:
@@ -66,7 +66,7 @@ class BrowserIface(plugin.MainWindowPlugin):
             p = self._history[self._index]
             self.mainwindow().setTextCursor(p.cursor, p.find_open_view)
             self.updateActions()
-            
+
     def goForward(self):
         """Called when the user activates the go_forward action."""
         if self._index < len(self._history) - 1:
@@ -80,17 +80,17 @@ class BrowserIface(plugin.MainWindowPlugin):
         """Move to the new cursor position and remember the current one."""
         self._remember(findOpenView)
         self.mainwindow().setTextCursor(cursor, findOpenView)
-    
+
     def setCurrentDocument(self, doc, findOpenView=None):
         """Switch to a different document and remember the current cursor position."""
         self._remember(findOpenView)
         self.mainwindow().setCurrentDocument(doc, findOpenView)
-    
+
     def updateActions(self):
         """Update the actions depending on current position in history."""
         self.actionCollection.go_back.setEnabled(self._index > 0)
         self.actionCollection.go_forward.setEnabled(self._index < len(self._history) - 1)
-    
+
     def _remember(self, findOpenView):
         """(Internal) Remember the current cursor position and whether a new view was requested."""
         pos = self._history[self._index]
@@ -100,12 +100,12 @@ class BrowserIface(plugin.MainWindowPlugin):
         del self._history[self._index:]
         self._history.append(Position())
         self.updateActions()
-    
+
     def _documentClosed(self, doc):
         """(Internal) Called when a document is closed.
-        
+
         Removes the positions in the history of that document.
-        
+
         """
         for i, pos in reversed(list(enumerate(self._history))):   # copy
             if pos.cursor and doc is pos.cursor.document():
@@ -124,13 +124,13 @@ class Actions(actioncollection.ActionCollection):
     def createActions(self, parent):
         self.go_back = QAction(parent)
         self.go_forward = QAction(parent)
-        
+
         self.go_back.setIcon(icons.get('go-previous'))
         self.go_forward.setIcon(icons.get('go-next'))
-        
+
         self.go_back.setShortcut(QKeySequence(Qt.ALT + Qt.Key_Backspace))
         self.go_forward.setShortcut(QKeySequence(Qt.ALT + Qt.Key_End))
-    
+
     def translateUI(self):
         self.go_back.setText(_("Go to previous position"))
         self.go_back.setIconText(_("Back"))

--- a/frescobaldi_app/charmap/__init__.py
+++ b/frescobaldi_app/charmap/__init__.py
@@ -38,13 +38,13 @@ class CharMap(panel.Panel):
     def translateUI(self):
         self.setWindowTitle(_("Special Characters"))
         self.toggleViewAction().setText(_("Special Charac&ters"))
-        
+
     def createWidget(self):
         from . import widget
         w = widget.Widget(self)
         w.charmap.charmap.characterClicked.connect(self.insertCharacter)
         return w
-    
+
     def insertCharacter(self, character):
         character = character.rstrip('\0')  # PyQt bug workaround
         self.mainwindow().textCursor().insertText(character)

--- a/frescobaldi_app/charmap/widget.py
+++ b/frescobaldi_app/charmap/widget.py
@@ -44,11 +44,11 @@ _blocks = tuple(itertools.takewhile(
 class Widget(QWidget):
     def __init__(self, tool):
         super(Widget, self).__init__(tool)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
         layout.setContentsMargins(0, 0, 0, 0)
-        
+
         self.blockCombo = QComboBox()
         self.charmap = CharMapWidget()
 
@@ -59,16 +59,16 @@ class Widget(QWidget):
         p = self.blockCombo.sizePolicy()
         p.setHorizontalPolicy(QSizePolicy.Ignored)
         self.blockCombo.setSizePolicy(p)
-        
+
         # size policy of combo popup
         p = self.blockCombo.view().sizePolicy()
         p.setHorizontalPolicy(QSizePolicy.MinimumExpanding)
         self.blockCombo.view().setSizePolicy(p)
-        
+
         model = listmodel.ListModel(_blocks,
             display = lambda b: b.name)
         self.blockCombo.setModel(model)
-        
+
         # load block setting
         name = QSettings().value("charmaptool/last_block", "", str)
         if name:
@@ -76,13 +76,13 @@ class Widget(QWidget):
                 if b.name == name:
                     self.blockCombo.setCurrentIndex(i)
                     break
-        
+
         self.blockCombo.activated[int].connect(self.updateBlock)
         self.updateBlock()
-        
+
         self.loadSettings()
         app.settingsChanged.connect(self.loadSettings)
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("charmaptool")
@@ -93,7 +93,7 @@ class Widget(QWidget):
         self.charmap.charmap.setDisplayFont(font)
         size = s.value("fontsize", font.pointSizeF(), float)
         self.charmap.charmap.setDisplayFontSizeF(size)
-    
+
     def updateBlock(self):
         i = self.blockCombo.currentIndex()
         if 0 <= i < len(_blocks):
@@ -113,7 +113,7 @@ class CharMapWidget(QScrollArea):
         # TEMP
         self.charmap.setRange(32, 1023)
         self.charmap.setColumnCount(8)
-    
+
     def resizeEvent(self, ev):
         self.charmap.setColumnCount(
             self.charmap.columnCountForWidth(ev.size().width()))

--- a/frescobaldi_app/completionmodel.py
+++ b/frescobaldi_app/completionmodel.py
@@ -35,11 +35,11 @@ _models = {}
 
 def model(key):
     """Returns the model for the given settings key.
-    
+
     A Model is instantiated if necessary.
     The model remains alive until the application exits, at which
     moment the data is saved.
-    
+
     """
     try:
         return _models[key]
@@ -51,25 +51,25 @@ def model(key):
 
 def complete(lineedit, key):
     """A convenience function that installs a completer on the QLineEdit.
-    
+
     The key is the QSettings key used to store the completions persistently.
-    By default, the function tries to add the text in the line edit to 
+    By default, the function tries to add the text in the line edit to
     the stored completions when the window() of the lineedit is a Dialog
     and its accepted signal is fired.
-    
+
     Returned is a callable a signal can be connected to, that stores the text
     in the line edit in the completions. (You don't have to use that if your
     widget is in a QDialog that has an accepted() signal.)
-    
+
     """
     m = model(key)
     c = QCompleter(m, lineedit)
     lineedit.setCompleter(c)
     def store(completer = weakref.ref(c)):
         """Stores the contents of the line edit in the completer's model.
-        
+
         Does not keep a reference to any object.
-        
+
         """
         c = completer()
         if c:
@@ -81,9 +81,9 @@ def complete(lineedit, key):
                     model.addString(text)
     def connect():
         """Try to connect the store() function to the accepted() signal of the parent QDialog.
-        
+
         Return True if that succeeds, else False.
-        
+
         """
         dlg = lineedit.window()
         try:
@@ -97,22 +97,22 @@ def complete(lineedit, key):
 
 class Model(QStringListModel):
     """A simple model providing a list of strings for a QCompleter.
-    
+
     Instantiate the model with a QSettings key, e.g. 'somegroup/names'.
     Use the addString() method to add a string.
-    
+
     """
     def __init__(self, key):
         super(Model, self).__init__()
         self.key = key
         self._changed = False
         self.load()
-        
+
     def load(self):
         strings = qsettings.get_string_list(QSettings(), self.key)
         self.setStringList(sorted(strings))
         self._changed = False
-    
+
     def save(self):
         if self._changed:
             QSettings().setValue(self.key, self.stringList())

--- a/frescobaldi_app/contextmenu.py
+++ b/frescobaldi_app/contextmenu.py
@@ -40,12 +40,12 @@ def contextmenu(view):
 
     # create the actions in the actions list
     actions = []
-    
+
     actions.extend(open_files(cursor, menu, mainwindow))
-    
+
     actions.extend(jump_to_definition(cursor, menu, mainwindow))
-    
-    
+
+
     if cursor.hasSelection():
         import panelmanager
         actions.append(mainwindow.actionCollection.edit_copy_colored_html)
@@ -54,7 +54,7 @@ def contextmenu(view):
         ac = documentactions.get(mainwindow).actionCollection
         actions.append(ac.edit_cut_assign)
         actions.append(ac.edit_move_to_include_file)
-    
+
     # now add the actions to the standard menu
     if actions:
         first_action = menu.actions()[0] if menu.actions() else None

--- a/frescobaldi_app/convert_ly.py
+++ b/frescobaldi_app/convert_ly.py
@@ -68,13 +68,13 @@ def convert(mainwindow):
 class Dialog(QDialog):
     def __init__(self, parent=None):
         super(Dialog, self).__init__(parent)
-        
+
         self._info = None
         self._text = ''
         self._convertedtext = ''
         self._encoding = None
         self.mainwindow = parent
-        
+
         self.fromVersionLabel = QLabel()
         self.fromVersion = QLineEdit()
         self.reason = QLabel()
@@ -87,11 +87,11 @@ class Dialog(QDialog):
         self.copyCheck = QCheckBox(checked=
             QSettings().value('convert_ly/copy_messages', True, bool))
         self.tabw = QTabWidget()
-        
+
         self.tabw.addTab(self.messages, '')
         self.tabw.addTab(self.diff, '')
         self.tabw.addTab(self.uni_diff, '')
-        
+
         self.buttons = QDialogButtonBox(
             QDialogButtonBox.Reset | QDialogButtonBox.Save |
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -99,10 +99,10 @@ class Dialog(QDialog):
         self.buttons.rejected.connect(self.reject)
         self.buttons.button(QDialogButtonBox.Reset).clicked.connect(self.run)
         self.buttons.button(QDialogButtonBox.Save).clicked.connect(self.saveFile)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         grid = QGridLayout()
         grid.addWidget(self.fromVersionLabel, 0, 0)
         grid.addWidget(self.fromVersion, 0, 1)
@@ -110,13 +110,13 @@ class Dialog(QDialog):
         grid.addWidget(self.toVersionLabel, 1, 0)
         grid.addWidget(self.toVersion, 1, 1)
         grid.addWidget(self.lilyChooser, 1, 3, 1, 2)
-        
+
         layout.addLayout(grid)
         layout.addWidget(self.tabw)
         layout.addWidget(self.copyCheck)
         layout.addWidget(widgets.Separator())
         layout.addWidget(self.buttons)
-        
+
         app.translateUI(self)
         qutil.saveDialogSize(self, 'convert_ly/dialog/size', QSize(600, 300))
         app.settingsChanged.connect(self.readSettings)
@@ -124,7 +124,7 @@ class Dialog(QDialog):
         self.finished.connect(self.saveCopyCheckSetting)
         self.lilyChooser.currentIndexChanged.connect(self.slotLilyPondVersionChanged)
         self.slotLilyPondVersionChanged()
-        
+
     def translateUI(self):
         self.fromVersionLabel.setText(_("From version:"))
         self.toVersionLabel.setText(_("To version:"))
@@ -138,20 +138,20 @@ class Dialog(QDialog):
         self.buttons.button(QDialogButtonBox.Reset).setText(_("Run Again"))
         self.buttons.button(QDialogButtonBox.Save).setText(_("Save as file"))
         self.setCaption()
-    
+
     def saveCopyCheckSetting(self):
         QSettings().setValue('convert_ly/copy_messages', self.copyCheck.isChecked())
-    
+
     def readSettings(self):
         font = textformats.formatData('editor').font
         self.diff.setFont(font)
         diffFont = QFont("Monospace")
         diffFont.setStyleHint(QFont.TypeWriter)
         self.uni_diff.setFont(diffFont)
-    
+
     def slotLilyPondVersionChanged(self):
         self.setLilyPondInfo(self.lilyChooser.lilyPondInfo())
-    
+
     def setCaption(self):
         version = self._info and self._info.versionString() or _("<unknown>")
         title = _("Convert-ly from LilyPond {version}").format(version=version)
@@ -164,7 +164,7 @@ class Dialog(QDialog):
         self.setConvertedText()
         self.setDiffText()
         self.messages.clear()
-    
+
     def setConvertedText(self, text=''):
         self._convertedtext = text
         self.buttons.button(QDialogButtonBox.Ok).setEnabled(bool(text))
@@ -175,23 +175,23 @@ class Dialog(QDialog):
                 wrapcolumn=100))
         else:
             self.diff.clear()
-            
+
     def setDiffText(self, text=''):
         if text:
             from_filename = "current"   # TODO: maybe use real filename here
             to_filename = "converted"   # but difflib can choke on non-ascii characters,
                                         # see https://github.com/wbsoft/frescobaldi/issues/674
             difflist = list(difflib.unified_diff(
-                    self._text.split('\n'), text.split('\n'), 
+                    self._text.split('\n'), text.split('\n'),
                     from_filename, to_filename))
             diffHLstr = self.diffHighl(difflist)
             self.uni_diff.setHtml(diffHLstr)
         else:
             self.uni_diff.clear()
-    
+
     def convertedText(self):
         return self._convertedtext or ''
-    
+
     def setDocument(self, doc):
         v = documentinfo.docinfo(doc).version_string()
         if v:
@@ -203,7 +203,7 @@ class Dialog(QDialog):
         self._encoding = doc.encoding() or 'UTF-8'
         self.setConvertedText()
         self.setDiffText()
-        
+
     def run(self):
         """Runs convert-ly (again)."""
         fromVersion = self.fromVersion.text()
@@ -215,7 +215,7 @@ class Dialog(QDialog):
         info = self._info
         command = info.toolcommand(info.ly_tool('convert-ly'))
         command += ['-f', fromVersion, '-t', toVersion, '-']
-        
+
         # if the user wants english messages, do it also here: LANGUAGE=C
         env = None
         if os.name == "nt":
@@ -238,7 +238,7 @@ class Dialog(QDialog):
                 env[b'LANGUAGE'] = b'C'
             else:
                 env['LANGUAGE'] = 'C'
-        
+
         with qutil.busyCursor():
             try:
                 proc = subprocess.Popen(command,
@@ -282,7 +282,7 @@ class Dialog(QDialog):
             return FileInfo('html-diff', 'html', self.diff.toHtml())
         elif index == 2:
             return FileInfo('uni-diff', 'diff', self.uni_diff.toPlainText())
-            
+
     def diffHighl(self, difflist):
         """Return highlighted version of input."""
         result = []
@@ -304,5 +304,5 @@ class FileInfo():
         self.filename = filename
         self.ext = ext
         self.text = text
-		
-		 
+
+

--- a/frescobaldi_app/copy2image.py
+++ b/frescobaldi_app/copy2image.py
@@ -49,9 +49,9 @@ except ImportError:
 
 def copy_image(parent_widget, page, rect=None, filename=None):
     """Shows the dialog to copy a PDF page to a raster image.
-    
+
     If rect is given, only that part of the page is copied.
-    
+
     """
     dlg = Dialog(parent_widget)
     dlg.show()
@@ -71,7 +71,7 @@ class Dialog(QDialog):
         self.dpiCombo.lineEdit().setCompleter(None)
         self.dpiCombo.setValidator(QDoubleValidator(10.0, 1200.0, 4, self.dpiCombo))
         self.dpiCombo.addItems([format(i) for i in (72, 100, 200, 300, 600, 1200)])
-        
+
         self.colorButton = widgets.colorbutton.ColorButton()
         self.colorButton.setColor(QColor(Qt.white))
         self.crop = QCheckBox()
@@ -84,12 +84,12 @@ class Dialog(QDialog):
         self.copyButton.setIcon(icons.get('edit-copy'))
         self.saveButton = self.buttons.addButton('', QDialogButtonBox.ApplyRole)
         self.saveButton.setIcon(icons.get('document-save'))
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         layout.addWidget(self.imageViewer)
-        
+
         controls = QHBoxLayout()
         layout.addLayout(controls)
         controls.addWidget(self.dpiLabel)
@@ -115,7 +115,7 @@ class Dialog(QDialog):
         self.copyButton.clicked.connect(self.copyToClipboard)
         self.saveButton.clicked.connect(self.saveAs)
         qutil.saveDialogSize(self, "copy_image/dialog/size", QSize(480, 320))
-    
+
     def translateUI(self):
         self.setCaption()
         self.dpiLabel.setText(_("DPI:"))
@@ -141,7 +141,7 @@ class Dialog(QDialog):
             "You can also drag the small picture icon in the bottom right, "
             "which drags the actual file on disk, e.g. to an e-mail message.\n"
             "</p>").format(command="\u2318"))
-        
+
     def readSettings(self):
         s = QSettings()
         s.beginGroup('copy_image')
@@ -150,7 +150,7 @@ class Dialog(QDialog):
         self.crop.setChecked(s.value("autocrop", False, bool))
         self.antialias.setChecked(s.value("antialias", True, bool))
         self.scaleup.setChecked(s.value("scaleup", False, bool))
-    
+
     def writeSettings(self):
         s = QSettings()
         s.beginGroup('copy_image')
@@ -159,7 +159,7 @@ class Dialog(QDialog):
         s.setValue("autocrop", self.crop.isChecked())
         s.setValue("antialias", self.antialias.isChecked())
         s.setValue("scaleup", self.scaleup.isChecked())
-    
+
     def setCaption(self):
         if self._filename:
             filename = os.path.basename(self._filename)
@@ -167,7 +167,7 @@ class Dialog(QDialog):
             filename = _("<unknown>")
         title = _("Image from {filename}").format(filename = filename)
         self.setWindowTitle(app.caption(title))
-        
+
     def setPage(self, page, rect, filename):
         self._page = page
         self._rect = rect
@@ -195,14 +195,14 @@ class Dialog(QDialog):
             i = i.scaled(i.size() / 2, transformMode=Qt.SmoothTransformation)
         self._image = i
         self.cropImage()
-    
+
     def cropImage(self):
         image = self._image
         if self.crop.isChecked():
             image = image.copy(autoCropRect(image))
         self.imageViewer.setImage(image)
         self.fileDragger.setImage(image)
-    
+
     def copyToClipboard(self):
         QApplication.clipboard().setImage(self.imageViewer.image())
 
@@ -226,11 +226,11 @@ class FileDragger(gadgets.drag.FileDragger):
     image = None
     basename = None
     currentFile = None
-    
+
     def setImage(self, image):
         self.image = image
         self.currentFile = None
-        
+
     def filename(self):
         if self.currentFile:
             return self.currentFile
@@ -248,9 +248,9 @@ class FileDragger(gadgets.drag.FileDragger):
 
 def autoCropRect(image):
     """Returns a QRect specifying the contents of the QImage.
-    
+
     Edges of the image are trimmed if they have the same color.
-    
+
     """
     # pick the color at most of the corners
     colors = collections.defaultdict(int)

--- a/frescobaldi_app/cursordiff.py
+++ b/frescobaldi_app/cursordiff.py
@@ -33,29 +33,29 @@ import cursortools
 
 def insert_text(cursor, text):
     """Replaces selected text of a QTextCursor.
-    
+
     This is done without erasing all the other QTextCursor instances that could
     exist in the selected range. It works by making a diff between the
     existing selection and the replacement text, and applying that diff.
-    
+
     """
     if not cursor.hasSelection() or text == "":
         cursor.insertText(text)
         return
-    
+
     start = cursor.selectionStart()
     new_pos = start + len(text)
-    
+
     old = cursor.selection().toPlainText()
     diff = difflib.SequenceMatcher(None, old, text).get_opcodes()
-    
+
     # make a list of edits
     edits = sorted(
         ((start + i1, start + i2, text[j1:j2])
          for tag, i1, i2, j1, j2 in diff
          if tag != 'equal'),
         reverse = True)
-    
+
     # perform the edits
     with cursortools.compress_undo(cursor):
         for pos, end, text in edits:

--- a/frescobaldi_app/cursortools.py
+++ b/frescobaldi_app/cursortools.py
@@ -30,16 +30,16 @@ from PyQt5.QtGui import QTextBlock, QTextBlockUserData, QTextCursor
 
 def block(cursor):
     """Returns the cursor's block.
-    
+
     If the cursor has a selection, returns the block the selection starts in
     (regardless of the cursor's position()).
-    
+
     """
     if cursor.hasSelection():
         return cursor.document().findBlock(cursor.selectionStart())
     return cursor.block()
 
-    
+
 def blocks(cursor):
     """Yields the block(s) containing the cursor or selection."""
     d = cursor.document()
@@ -50,7 +50,7 @@ def blocks(cursor):
         if block == end:
             break
         block = block.next()
-     
+
 
 def contains(c1, c2):
     """Returns True if cursor2's selection falls inside cursor1's."""
@@ -60,9 +60,9 @@ def contains(c1, c2):
 
 def forwards(block, until=QTextBlock()):
     """Yields the block and all following blocks.
-    
+
     If until is a valid block, yields the blocks until the specified block.
-    
+
     """
     if until.isValid():
         while block.isValid() and block <= until:
@@ -76,9 +76,9 @@ def forwards(block, until=QTextBlock()):
 
 def backwards(block, until=QTextBlock()):
     """Yields the block and all preceding blocks.
-    
+
     If until is a valid block, yields the blocks until the specified block.
-    
+
     """
     if until.isValid():
         while block.isValid() and block >= until:
@@ -89,7 +89,7 @@ def backwards(block, until=QTextBlock()):
             yield block
             block = block.previous()
 
-    
+
 def all_blocks(document):
     """Yields all blocks of the document."""
     return forwards(document.firstBlock())
@@ -97,13 +97,13 @@ def all_blocks(document):
 
 def partition(cursor):
     """Returns a three-tuple of strings (before, selection, after).
-    
+
     'before' is the text before the cursor's position or selection start,
     'after' is the text after the cursor's position or selection end,
     'selection' is the selected text.
-    
+
     before and after never contain a newline.
-    
+
     """
     start = cursor.document().findBlock(cursor.selectionStart())
     end = cursor.document().findBlock(cursor.selectionEnd())
@@ -126,14 +126,14 @@ def compress_undo(cursor, join_previous = False):
 @contextlib.contextmanager
 def keep_selection(cursor, edit=None):
     """Performs operations inside the selection and restore the selection afterwards.
-    
+
     If edit is given, call setTextCursor(cursor) on the Q(Plain)TextEdit afterwards.
-    
+
     """
     start, end, pos = cursor.selectionStart(), cursor.selectionEnd(), cursor.position()
     cur2 = QTextCursor(cursor)
     cur2.setPosition(end)
-    
+
     try:
         yield
     finally:
@@ -149,10 +149,10 @@ def keep_selection(cursor, edit=None):
 
 def strip_selection(cursor, chars=None):
     """Adjusts the selection of the cursor just like Python's strip().
-    
+
     If there is no selection or the selection would vanish completely,
     nothing is done.
-    
+
     """
     if not cursor.hasSelection():
         return
@@ -232,7 +232,7 @@ def previous_blank(block):
 
 
 def data(block):
-    """Get the block's QTextBlockUserData, creating it if necessary.""" 
+    """Get the block's QTextBlockUserData, creating it if necessary."""
     data = block.userData()
     if not data:
         data = QTextBlockUserData()

--- a/frescobaldi_app/cut_assign.py
+++ b/frescobaldi_app/cut_assign.py
@@ -47,15 +47,15 @@ def cut_assign(cursor):
         "text to:"), regexp="[A-Za-z]+")
     if not name:
         return
-    
+
     cursortools.strip_selection(cursor)
-    
+
     # determine state at cursor
     block = cursortools.block(cursor)
     state = tokeniter.state(block)
     for t in tokeniter.partition(cursor).left:
         state.follow(t)
-    
+
     mode = ""
     for p in state.parsers():
         if isinstance(p, ly.lex.lilypond.ParseInputMode):
@@ -102,13 +102,13 @@ def cut_assign(cursor):
 
 def move_to_include_file(cursor, parent_widget=None):
     """Opens a dialog to save the cursor's selection to a file.
-    
+
     The cursor's selection is then replaced with an \\include statement.
     This function does its best to supply a good default filename and
     use it correctly in a relative \\include statement.
-    
+
     Of course it only works well if the document already has a filename.
-    
+
     """
     doc = cursor.document()
     text = cursor.selection().toPlainText()

--- a/frescobaldi_app/debug.py
+++ b/frescobaldi_app/debug.py
@@ -22,9 +22,9 @@ def doc_repr(self):
     index = app.documents.index(self)
     return '<Document #{0} "{1}">'.format(index, self.url().toString())
 document.Document.__repr__ = doc_repr
-    
+
 @app.documentCreated.connect
-def f(doc): 
+def f(doc):
     print("created:", doc)
 
 @app.documentLoaded.connect
@@ -47,8 +47,8 @@ def f(doc, job, success):
 
 
 # more to add...
-    
-    
+
+
 # delete unneeded stuff
 del f, doc_repr
 

--- a/frescobaldi_app/definition.py
+++ b/frescobaldi_app/definition.py
@@ -54,9 +54,9 @@ def target(node):
 
 def goto_definition(mainwindow, cursor=None):
     """Go to the definition of the item the mainwindow's cursor is at.
-    
+
     Return True if there was a definition.
-    
+
     """
     if cursor is None:
         cursor = mainwindow.textCursor()

--- a/frescobaldi_app/docbrowser/__init__.py
+++ b/frescobaldi_app/docbrowser/__init__.py
@@ -45,11 +45,11 @@ class HelpBrowser(panel.Panel):
     def translateUI(self):
         self.setWindowTitle(_("Documentation Browser"))
         self.toggleViewAction().setText(_("&Documentation Browser"))
-        
+
     def createWidget(self):
         from . import browser
         return browser.Browser(self)
-        
+
     def activate(self):
         super(HelpBrowser, self).activate()
         self.widget().webview.setFocus()
@@ -57,10 +57,10 @@ class HelpBrowser(panel.Panel):
 
 class Actions(actioncollection.ActionCollection):
     name = "docbrowser"
-    
+
     def title(self):
         return _("Documentation Browser")
-    
+
     def createActions(self, parent=None):
         self.help_back = QAction(parent)
         self.help_forward = QAction(parent)
@@ -68,16 +68,16 @@ class Actions(actioncollection.ActionCollection):
         self.help_print = QAction(parent)
         self.help_lilypond_doc= QAction(parent)
         self.help_lilypond_context = QAction(parent)
-        
+
         self.help_back.setIcon(icons.get("go-previous"))
         self.help_forward.setIcon(icons.get("go-next"))
         self.help_home.setIcon(icons.get("go-home"))
         self.help_lilypond_doc.setIcon(icons.get("lilypond-run"))
         self.help_print.setIcon(icons.get("document-print"))
-        
+
         self.help_lilypond_doc.setShortcut(QKeySequence("F9"))
         self.help_lilypond_context.setShortcut(QKeySequence("Shift+F9"))
-        
+
     def translateUI(self):
         self.help_back.setText(_("Back"))
         self.help_forward.setText(_("Forward"))

--- a/frescobaldi_app/docbrowser/sourceviewer.py
+++ b/frescobaldi_app/docbrowser/sourceviewer.py
@@ -39,29 +39,29 @@ class SourceViewer(QDialog):
         layout = QVBoxLayout()
         layout.setContentsMargins(4, 4, 4, 4)
         self.setLayout(layout)
-        
+
         self.urlLabel = QLabel(wordWrap=True)
         layout.addWidget(self.urlLabel)
         self.textbrowser = QTextBrowser()
         layout.addWidget(self.textbrowser)
-        
+
         self.urlLabel.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         self.textbrowser.setLineWrapMode(QTextBrowser.NoWrap)
-        
+
         app.settingsChanged.connect(self.readSettings)
         self.readSettings()
         app.translateUI(self)
         qutil.saveDialogSize(self, "helpbrowser/sourceviewer/size", QSize(400, 300))
-        
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("LilyPond Source")))
-        
+
     def readSettings(self):
         data = textformats.formatData('editor')
         self.textbrowser.setPalette(data.palette())
         self.textbrowser.setFont(data.font)
         highlighter.highlight(self.textbrowser.document())
-        
+
     def showReply(self, reply):
         reply.setParent(self)
         self.urlLabel.setText(reply.url().toString())
@@ -69,7 +69,7 @@ class SourceViewer(QDialog):
         reply.finished.connect(self.loadingFinished)
         self.textbrowser.clear()
         self.show()
-        
+
     def loadingFinished(self):
         data = self._reply.readAll()
         self._reply.close()

--- a/frescobaldi_app/doclist/__init__.py
+++ b/frescobaldi_app/doclist/__init__.py
@@ -37,7 +37,7 @@ class DocumentList(panel.Panel):
     def translateUI(self):
         self.setWindowTitle(_("Documents"))
         self.toggleViewAction().setText(_("Docum&ents"))
-        
+
     def createWidget(self):
         from . import widget
         w = widget.Widget(self)

--- a/frescobaldi_app/doclist/widget.py
+++ b/frescobaldi_app/doclist/widget.py
@@ -37,9 +37,9 @@ import engrave
 
 def path(url):
     """Returns the path, as a string, of the url to group documents.
-    
+
     Returns None if the document is nameless.
-    
+
     """
     if url.isEmpty():
         return None
@@ -67,7 +67,7 @@ class Widget(QTreeWidget):
         self.itemSelectionChanged.connect(self.slotItemSelectionChanged)
         app.settingsChanged.connect(self.populate)
         self.populate()
-    
+
     def populate(self):
         self._group = QSettings().value("document_list/group_by_folder", False, bool)
         self.clear()
@@ -80,11 +80,11 @@ class Widget(QTreeWidget):
             doc = self.parentWidget().mainwindow().currentDocument()
             if doc:
                 self.selectDocument(doc)
-        
+
     def addDocument(self, doc):
         self._items[doc] = QTreeWidgetItem(self)
         self.setDocumentStatus(doc)
-    
+
     def removeDocument(self, doc):
         i = self._items.pop(doc)
         if not self._group:
@@ -95,7 +95,7 @@ class Widget(QTreeWidget):
         if parent.childCount() == 0:
             self.takeTopLevelItem(self.indexOfTopLevelItem(parent))
             del self._paths[parent._path]
-    
+
     def selectDocument(self, doc):
         self.setCurrentItem(self._items[doc], 0, QItemSelectionModel.ClearAndSelect)
 
@@ -116,7 +116,7 @@ class Widget(QTreeWidget):
             self.groupDocument(doc)
         else:
             self.sortItems(0, Qt.AscendingOrder)
-    
+
     def groupDocument(self, doc):
         """Called, if grouping is enabled, to group the document."""
         i = self._items[doc]
@@ -142,29 +142,29 @@ class Widget(QTreeWidget):
             self.takeTopLevelItem(self.indexOfTopLevelItem(i))
         new_parent.addChild(i)
         new_parent.sortChildren(0, Qt.AscendingOrder)
-    
+
     def document(self, item):
         """Returns the document for item."""
         for d, i in self._items.items():
             if i == item:
                 return d
-        
+
     def slotItemSelectionChanged(self):
         if len(self.selectedItems()) == 1:
             doc = self.document(self.selectedItems()[0])
             if doc:
                 self.parentWidget().mainwindow().setCurrentDocument(doc)
-    
+
     def contextMenuEvent(self, ev):
         item = self.itemAt(ev.pos())
         if not item:
             return
-        
+
         mainwindow = self.parentWidget().mainwindow()
-        
+
         selection = self.selectedItems()
         doc = self.document(item)
-        
+
         if len(selection) <= 1 and doc:
             # a single document is right-clicked
             import documentcontextmenu
@@ -172,12 +172,12 @@ class Widget(QTreeWidget):
             menu.exec_(doc, ev.globalPos())
             menu.deleteLater()
             return
-        
+
         menu = QMenu(mainwindow)
         save = menu.addAction(icons.get('document-save'), '')
         menu.addSeparator()
         close = menu.addAction(icons.get('document-close'), '')
-        
+
         if len(selection) > 1:
             # multiple documents are selected
             save.setText(_("Save selected documents"))
@@ -193,7 +193,7 @@ class Widget(QTreeWidget):
                 # the "Untitled" group is right-clicked
                 save.setText(_("Save all untitled documents"))
                 close.setText(_("Close all untitled documents"))
-        
+
         @save.triggered.connect
         def savedocuments():
             for d in documents:
@@ -201,13 +201,13 @@ class Widget(QTreeWidget):
                     mainwindow.setCurrentDocument(d)
                 if not mainwindow.saveDocument(d):
                     break
-        
+
         @close.triggered.connect
         def close_documents():
             for d in documents:
                 if not mainwindow.closeDocument(d):
                     break
-        
+
         menu.exec_(ev.globalPos())
         menu.deleteLater()
 

--- a/frescobaldi_app/document.py
+++ b/frescobaldi_app/document.py
@@ -20,7 +20,7 @@
 """
 A Frescobaldi document.
 
-This contains the text the user can edit in Frescobaldi. In most cases it will 
+This contains the text the user can edit in Frescobaldi. In most cases it will
 be a LilyPond source file, but other file types can be used as well.
 
 """
@@ -39,28 +39,28 @@ import signals
 
 
 class Document(QTextDocument):
-    
+
     urlChanged = signals.Signal() # new url, old url
     closed = signals.Signal()
     loaded = signals.Signal()
     saving = signals.SignalContext()
     saved = signals.Signal()
-    
+
     @classmethod
     def load_data(cls, url, encoding=None):
         """Class method to load document contents from an url.
-        
+
         This is intended to open a document without instantiating one
         if loading the contents fails.
-        
+
         This method returns the text contents of the url as decoded text,
         thus a unicode string.
-        
+
         The line separator is always '\\n'.
-        
+
         """
         filename = url.toLocalFile()
-        
+
         # currently, we do not support non-local files
         if not filename:
             raise IOError("not a local file")
@@ -68,14 +68,14 @@ class Document(QTextDocument):
             data = f.read()
         text = util.decode(data, encoding)
         return util.universal_newlines(text)
-    
+
     @classmethod
     def new_from_url(cls, url, encoding=None):
         """Create and return a new document, loaded from url.
-        
+
         This is intended to open a new Document without instantiating one
         if loading the contents fails.
-        
+
         """
         if not url.isEmpty():
             text = cls.load_data(url, encoding)
@@ -86,14 +86,14 @@ class Document(QTextDocument):
             d.loaded()
             app.documentLoaded(d)
         return d
-        
+
     def __init__(self, url=None, encoding=None):
         """Create a new Document with url and encoding.
-        
+
         Does not load the contents, you should use load() for that, or
         use the new_from_url() constructor to instantiate a new Document
         with the contents loaded.
-        
+
         """
         if url is None:
             url = QUrl()
@@ -105,7 +105,7 @@ class Document(QTextDocument):
         self.modificationChanged.connect(self.slotModificationChanged)
         app.documents.append(self)
         app.documentCreated(self)
-        
+
     def slotModificationChanged(self):
         app.documentModificationChanged(self)
 
@@ -116,15 +116,15 @@ class Document(QTextDocument):
 
     def load(self, url=None, encoding=None, keepUndo=False):
         """Load the specified or current url (if None was specified).
-        
+
         Currently only local files are supported. An IOError is raised
         when trying to load a nonlocal URL.
-        
+
         If loading succeeds and an url was specified, the url is make the
         current url (by calling setUrl() internally).
-        
+
         If keepUndo is True, the loading can be undone (with Ctrl-Z).
-        
+
         """
         if url is None:
             url = QUrl()
@@ -141,16 +141,16 @@ class Document(QTextDocument):
             self.setUrl(url)
         self.loaded()
         app.documentLoaded(self)
-            
+
     def save(self, url=None, encoding=None):
         """Saves the document to the specified or current url.
-        
+
         Currently only local files are supported. An IOError is raised
         when trying to save a nonlocal URL.
-        
+
         If saving succeeds and an url was specified, the url is made the
         current url (by calling setUrl() internally).
-        
+
         """
         if url is None:
             url = QUrl()
@@ -176,7 +176,7 @@ class Document(QTextDocument):
 
     def url(self):
         return self._url
-        
+
     def setUrl(self, url):
         """ Change the url for this document. """
         if url is None:
@@ -193,31 +193,31 @@ class Document(QTextDocument):
         if changed:
             self.urlChanged(url, old)
             app.documentUrlChanged(self, url, old)
-    
+
     def encoding(self):
         return variables.get(self, "coding") or self._encoding
-        
+
     def setEncoding(self, encoding):
         self._encoding = encoding
-    
+
     def encodedText(self):
         """Return the text of the document as a bytes string encoded in the
         correct encoding.
-        
+
         The line separator is '\\n' on Unix/Linux/Mac OS X, '\\r\\n' on Windows.
-        
+
         Useful to save to a file.
-        
+
         """
         text = util.platform_newlines(self.toPlainText())
         return util.encode(text, self.encoding())
-        
+
     def documentName(self):
         """Return a suitable name for this document.
-        
+
         This is only to be used for display. If the url of the document is
         empty, something like "Untitled" or "Untitled (3)" is returned.
-        
+
         """
         if self._url.isEmpty():
             if self._num == 1:

--- a/frescobaldi_app/documentactions.py
+++ b/frescobaldi_app/documentactions.py
@@ -62,10 +62,10 @@ class DocumentActions(plugin.MainWindowPlugin):
         ac.tools_quick_remove_dynamics.triggered.connect(self.quickRemoveDynamics)
         ac.tools_quick_remove_fingerings.triggered.connect(self.quickRemoveFingerings)
         ac.tools_quick_remove_markup.triggered.connect(self.quickRemoveMarkup)
-        
+
         mainwindow.currentDocumentChanged.connect(self.updateDocActions)
         mainwindow.selectionStateChanged.connect(self.updateSelectionActions)
-        
+
     def updateDocActions(self, doc):
         minfo = metainfo.info(doc)
         if minfo.highlighting:
@@ -73,7 +73,7 @@ class DocumentActions(plugin.MainWindowPlugin):
         ac = self.actionCollection
         ac.view_highlighting.setChecked(minfo.highlighting)
         ac.tools_indent_auto.setChecked(minfo.auto_indent)
-    
+
     def updateSelectionActions(self, selection):
         self.actionCollection.edit_cut_assign.setEnabled(selection)
         self.actionCollection.edit_move_to_include_file.setEnabled(selection)
@@ -87,99 +87,99 @@ class DocumentActions(plugin.MainWindowPlugin):
         self.actionCollection.tools_quick_remove_dynamics.setEnabled(selection)
         self.actionCollection.tools_quick_remove_fingerings.setEnabled(selection)
         self.actionCollection.tools_quick_remove_markup.setEnabled(selection)
-    
+
     def currentView(self):
         return self.mainwindow().currentView()
-    
+
     def currentDocument(self):
         return self.mainwindow().currentDocument()
-        
+
     def updateOtherDocActions(self):
         """Calls updateDocActions() in other instances that show same document."""
         doc = self.currentDocument()
         for i in self.instances():
             if i is not self and i.currentDocument() == doc:
                 i.updateDocActions(doc)
-    
+
     def gotoFileOrDefinition(self):
         import open_file_at_cursor
         result = open_file_at_cursor.open_file_at_cursor(self.mainwindow())
         if not result:
             import definition
             definition.goto_definition(self.mainwindow())
-    
+
     def cutAssign(self):
         import cut_assign
         cut_assign.cut_assign(self.currentView().textCursor())
-        
+
     def moveToIncludeFile(self):
         import cut_assign
         cut_assign.move_to_include_file(self.currentView().textCursor(), self.mainwindow())
-    
+
     def toggleAuto_indent(self):
         minfo = metainfo.info(self.currentDocument())
         minfo.auto_indent = not minfo.auto_indent
         self.updateOtherDocActions()
-    
+
     def re_indent(self):
         import indent
         indent.re_indent(self.currentView().textCursor())
-    
+
     def reFormat(self):
         import reformat
         reformat.reformat(self.currentView().textCursor())
-    
+
     def removeTrailingWhitespace(self):
         import reformat
         reformat.remove_trailing_whitespace(self.currentView().textCursor())
-    
+
     def toggleHighlighting(self):
         doc = self.currentDocument()
         minfo = metainfo.info(doc)
         minfo.highlighting = not minfo.highlighting
         highlighter.highlighter(doc).setHighlighting(minfo.highlighting)
         self.updateOtherDocActions()
-    
+
     def convertLy(self):
         import convert_ly
         convert_ly.convert(self.mainwindow())
-    
+
     def quickRemoveComments(self):
         import quickremove
         quickremove.comments(self.mainwindow().textCursor())
-    
+
     def quickRemoveArticulations(self):
         import quickremove
         quickremove.articulations(self.mainwindow().textCursor())
-    
+
     def quickRemoveOrnaments(self):
         import quickremove
         quickremove.ornaments(self.mainwindow().textCursor())
-    
+
     def quickRemoveInstrumentScripts(self):
         import quickremove
         quickremove.instrument_scripts(self.mainwindow().textCursor())
-    
+
     def quickRemoveSlurs(self):
         import quickremove
         quickremove.slurs(self.mainwindow().textCursor())
-    
+
     def quickRemoveBeams(self):
         import quickremove
         quickremove.beams(self.mainwindow().textCursor())
-    
+
     def quickRemoveLigatures(self):
         import quickremove
         quickremove.ligatures(self.mainwindow().textCursor())
-    
+
     def quickRemoveDynamics(self):
         import quickremove
         quickremove.dynamics(self.mainwindow().textCursor())
-    
+
     def quickRemoveFingerings(self):
         import quickremove
         quickremove.fingerings(self.mainwindow().textCursor())
-    
+
     def quickRemoveMarkup(self):
         import quickremove
         quickremove.markup(self.mainwindow().textCursor())
@@ -209,13 +209,13 @@ class Actions(actioncollection.ActionCollection):
         self.tools_quick_remove_dynamics = QAction(parent)
         self.tools_quick_remove_fingerings = QAction(parent)
         self.tools_quick_remove_markup = QAction(parent)
-        
+
         self.edit_cut_assign.setIcon(icons.get('edit-cut'))
         self.edit_move_to_include_file.setIcon(icons.get('edit-cut'))
 
         self.view_goto_file_or_definition.setShortcut(QKeySequence(Qt.ALT + Qt.Key_Return))
         self.edit_cut_assign.setShortcut(QKeySequence(Qt.SHIFT + Qt.CTRL + Qt.Key_X))
-    
+
     def translateUI(self):
         self.edit_cut_assign.setText(_("Cut and Assign..."))
         self.edit_move_to_include_file.setText(_("Move to Include File..."))
@@ -225,7 +225,7 @@ class Actions(actioncollection.ActionCollection):
         self.tools_indent_indent.setText(_("Re-&Indent"))
         self.tools_reformat.setText(_("&Format"))
         self.tools_remove_trailing_whitespace.setText(_("Remove Trailing &Whitespace"))
-        self.tools_convert_ly.setText(_("&Update with convert-ly...")) 
+        self.tools_convert_ly.setText(_("&Update with convert-ly..."))
         self.tools_quick_remove_comments.setText(_("Remove &Comments"))
         self.tools_quick_remove_articulations.setText(_("Remove &Articulations"))
         self.tools_quick_remove_ornaments.setText(_("Remove &Ornaments"))

--- a/frescobaldi_app/documentcontextmenu.py
+++ b/frescobaldi_app/documentcontextmenu.py
@@ -35,11 +35,11 @@ class DocumentContextMenu(QMenu):
     def __init__(self, mainwindow):
         super(DocumentContextMenu, self).__init__(mainwindow)
         self._doc = lambda: None
-        
+
         self.createActions()
         app.translateUI(self)
         self.aboutToShow.connect(self.updateActions)
-    
+
     def createActions(self):
         self.doc_save = self.addAction(icons.get('document-save'), '')
         self.doc_save_as = self.addAction(icons.get('document-save-as'), '')
@@ -49,13 +49,13 @@ class DocumentContextMenu(QMenu):
         self.addSeparator()
         self.doc_toggle_sticky = self.addAction(icons.get('pushpin'), '')
         self.doc_toggle_sticky.setCheckable(True)
-        
+
         self.doc_save.triggered.connect(self.docSave)
         self.doc_save_as.triggered.connect(self.docSaveAs)
         self.doc_close.triggered.connect(self.docClose)
         self.doc_close_others.triggered.connect(self.docCloseOther)
         self.doc_toggle_sticky.triggered.connect(self.docToggleSticky)
-    
+
     def updateActions(self):
         """Called just before show."""
         doc = self._doc()
@@ -63,31 +63,31 @@ class DocumentContextMenu(QMenu):
             import engrave
             engraver = engrave.Engraver.instance(self.mainwindow())
             self.doc_toggle_sticky.setChecked(doc is engraver.stickyDocument())
-    
+
     def translateUI(self):
         self.doc_save.setText(_("&Save"))
         self.doc_save_as.setText(_("Save &As..."))
         self.doc_close.setText(_("&Close"))
         self.doc_close_others.setText(_("Close Other Documents"))
         self.doc_toggle_sticky.setText(_("Always &Engrave This Document"))
-    
+
     def mainwindow(self):
         return self.parentWidget()
-        
+
     def exec_(self, document, pos):
         self._doc = weakref.ref(document)
         super(DocumentContextMenu, self).exec_(pos)
-    
+
     def docSave(self):
         doc = self._doc()
         if doc:
             self.mainwindow().saveDocument(doc)
-    
+
     def docSaveAs(self):
         doc = self._doc()
         if doc:
             self.mainwindow().saveDocumentAs(doc)
-    
+
     def docClose(self):
         doc = self._doc()
         if doc:

--- a/frescobaldi_app/documenticon.py
+++ b/frescobaldi_app/documenticon.py
@@ -32,10 +32,10 @@ import icons
 
 def icon(doc, mainwindow=None):
     """Provides a QIcon for a Document.
-    
+
     If a MainWindow is provided, the sticky icon can be returned, if the
     Document is sticky for that main window.
-    
+
     """
     return DocumentIconProvider.instance(doc).icon(mainwindow)
 
@@ -43,16 +43,16 @@ def icon(doc, mainwindow=None):
 class DocumentIconProvider(plugin.DocumentPlugin):
     """Provides an icon for a Document."""
     iconChanged = signals.Signal()
-    
+
     def __init__(self, doc):
         doc.modificationChanged.connect(self._send_icon)
         mgr = jobmanager.manager(doc)
         mgr.started.connect(self._send_icon)
         mgr.finished.connect(self._send_icon)
-    
+
     def _send_icon(self):
         self.iconChanged()
-    
+
     def icon(self, mainwindow=None):
         doc = self.document()
         job = jobmanager.job(doc)

--- a/frescobaldi_app/documentinfo.py
+++ b/frescobaldi_app/documentinfo.py
@@ -67,14 +67,14 @@ def mode(document, guess=True):
 
 def defaultfilename(document):
     """Return a default filename that could be used for the document.
-    
+
     The name is based on the score's title, composer etc.
-    
+
     """
     i = info(document)
     m = i.music()
     import ly.music.items as mus
-    
+
     # which fields (in order) to harvest:
     s = QSettings()
     custom = s.value("custom_default_filename", False, bool)
@@ -84,7 +84,7 @@ def defaultfilename(document):
         fields = [m.group(1) for m in re.finditer(r'\{(.*?)\}', template)]
     else:
         fields = ('composer', 'title')
-    
+
     d = {}
     for h in m.find(mus.Header):
         for a in h.find(mus.Assignment):
@@ -109,20 +109,20 @@ def defaultfilename(document):
         filename = document.documentName()
     ext = ly.lex.extensions[i.mode()]
     return filename + ext
-    
-    
+
+
 class DocumentInfo(plugin.DocumentPlugin):
     """Computes and caches various information about a Document."""
     def __init__(self, document):
         document.contentsChanged.connect(self._reset)
         document.closed.connect(self._reset)
         self._reset()
-        
+
     def _reset(self):
         """Called when the document is changed."""
         self._lydocinfo = None
         self._music = None
-    
+
     def lydocinfo(self):
         """Return the lydocinfo instance for our document."""
         if self._lydocinfo is None:
@@ -130,7 +130,7 @@ class DocumentInfo(plugin.DocumentPlugin):
             v = variables.manager(self.document()).variables()
             self._lydocinfo = lydocinfo.DocInfo(doc, v)
         return self._lydocinfo
-    
+
     def music(self):
         """Return the music.Document instance for our document."""
         if self._music is None:
@@ -139,40 +139,40 @@ class DocumentInfo(plugin.DocumentPlugin):
             self._music = music.Document(doc)
         self._music.include_path = self.includepath()
         return self._music
-    
+
     def mode(self, guess=True):
         """Returns the type of document ('lilypond, 'html', etc.).
-        
+
         The mode can be set using the "mode" document variable.
         If guess is True (default), the mode is auto-recognized based on the contents
         if not set explicitly using the "mode" variable. In this case, this function
         always returns an existing mode.
-        
+
         If guess is False, auto-recognizing is not done and the function returns None
         if the mode wasn't set explicitly.
-        
+
         """
         mode = variables.get(self.document(), "mode")
         if mode in ly.lex.modes:
             return mode
         if guess:
             return self.lydocinfo().mode()
-    
+
     def includepath(self):
         """Return the configured include path.
-        
+
         A path is a list of directories.
-        
+
         If there is a session specific include path, it is used.
         Otherwise the path is taken from the LilyPond preferences.
-        
+
         Currently the document does not matter.
-        
+
         """
         # get the global include path
         include_path = qsettings.get_string_list(
             QSettings(), "lilypond_settings/include_path")
-        
+
         # get the session specific include path
         import sessions
         session_settings = sessions.currentSessionGroup()
@@ -182,27 +182,27 @@ class DocumentInfo(plugin.DocumentPlugin):
                 include_path = sess_path
             else:
                 include_path = sess_path + include_path
-        
+
         return include_path
-        
+
     def jobinfo(self, create=False):
         """Returns a two-tuple(filename, includepath).
-        
-        The filename is the file LilyPond shall be run on. This can be the 
-        original filename of the document (if it has a filename and is not 
-        modified), but also the filename of a temporarily saved copy of the 
+
+        The filename is the file LilyPond shall be run on. This can be the
+        original filename of the document (if it has a filename and is not
+        modified), but also the filename of a temporarily saved copy of the
         document.
-        
-        The includepath is the same as self.includepath(), but with the 
-        directory of the original file prepended, only if a temporary 
-        'scratchdir'-area is used and the document does include other files 
-        (and therefore the original folder should be given in the include 
+
+        The includepath is the same as self.includepath(), but with the
+        directory of the original file prepended, only if a temporary
+        'scratchdir'-area is used and the document does include other files
+        (and therefore the original folder should be given in the include
         path to LilyPond).
-        
+
         """
         includepath = self.includepath()
         filename = self.document().url().toLocalFile()
-        
+
         # Determine the filename to run the engraving job on
         if not filename or self.document().isModified():
             # We need to use a scratchdir to save our contents to
@@ -215,41 +215,41 @@ class DocumentInfo(plugin.DocumentPlugin):
             if create or (scratch.path() and os.path.exists(scratch.path())):
                 filename = scratch.path()
         return filename, includepath
-    
+
     def includefiles(self):
         """Returns a set of filenames that are included by this document.
-        
+
         The document's own filename is not added to the set.
         The configured include path is used to find files.
         Included files are checked recursively, relative to our file,
         relative to the including file, and if that still yields no file, relative
         to the directories in the includepath().
-        
+
         This method uses caching for both the document contents and the other files.
-        
+
         """
         return fileinfo.includefiles(self.lydocinfo(), self.includepath())
 
     def child_urls(self):
         """Return a tuple of urls included by the Document.
-        
+
         This only returns urls that are referenced directly, not searching
         via an include path. If the Document has no url set, an empty tuple
-        is returned. 
-        
+        is returned.
+
         """
         url = self.document().url()
         if url.isEmpty():
             return ()
         return tuple(url.resolved(QUrl(arg)) for arg in self.lydocinfo().include_args())
-        
+
     def basenames(self):
         """Returns a list of basenames that our document is expected to create.
-        
+
         The list is created based on include files and the define output-suffix and
         \bookOutputName and \bookOutputSuffix commands.
         You should add '.ext' and/or '-[0-9]+.ext' to find created files.
-        
+
         """
         # if the file defines an 'output' variable, it is used instead
         output = variables.get(self.document(), 'output')
@@ -258,24 +258,24 @@ class DocumentInfo(plugin.DocumentPlugin):
             dirname = os.path.dirname(filename)
             return [os.path.join(dirname, name.strip())
                     for name in output.split(',')]
-        
+
         mode = self.mode()
-        
+
         if mode == "lilypond":
             return fileinfo.basenames(self.lydocinfo(), self.includefiles(), filename)
-        
+
         elif mode == "html":
             pass
-        
+
         elif mode == "texinfo":
             pass
-        
+
         elif mode == "latex":
             pass
-        
+
         elif mode == "docbook":
             pass
-        
+
         return []
 
 

--- a/frescobaldi_app/documentmenu.py
+++ b/frescobaldi_app/documentmenu.py
@@ -37,24 +37,24 @@ class DocumentMenu(QMenu):
         super(DocumentMenu, self).__init__(mainwindow)
         self.aboutToShow.connect(self.populate)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_('menu title', '&Documents'))
-    
+
     def populate(self):
         self.clear()
         mainwindow = self.parentWidget()
         for a in DocumentActionGroup.instance(mainwindow).actions():
             self.addAction(a)
-            
+
 
 class DocumentActionGroup(plugin.MainWindowPlugin, QActionGroup):
     """Maintains a list of actions to set the current document.
-    
+
     The actions are added to the View->Documents menu in the order
     of the tabbar. The actions also get accelerators that are kept
     during the lifetime of a document.
-    
+
     """
     def __init__(self, mainwindow):
         QActionGroup.__init__(self, mainwindow)
@@ -72,7 +72,7 @@ class DocumentActionGroup(plugin.MainWindowPlugin, QActionGroup):
         mainwindow.currentDocumentChanged.connect(self.setCurrentDocument)
         engrave.engraver(mainwindow).stickyChanged.connect(self.setDocumentStatus)
         self.triggered.connect(self.slotTriggered)
-    
+
     def actions(self):
         return [self._acts[doc] for doc in self.mainwindow().documents()]
 
@@ -83,12 +83,12 @@ class DocumentActionGroup(plugin.MainWindowPlugin, QActionGroup):
             a.setChecked(True)
         self._acts[doc] = a
         self.setDocumentStatus(doc)
-        
+
     def removeDocument(self, doc):
         self._acts[doc].deleteLater()
         del self._acts[doc]
         del self._accels[doc]
-        
+
     def setCurrentDocument(self, doc):
         self._acts[doc].setChecked(True)
 
@@ -112,7 +112,7 @@ class DocumentActionGroup(plugin.MainWindowPlugin, QActionGroup):
         if icon.name() == "text-plain":
             icon = QIcon()
         self._acts[doc].setIcon(icon)
-    
+
     def slotTriggered(self, action):
         for doc, act in self._acts.items():
             if act == action:

--- a/frescobaldi_app/documentstructure.py
+++ b/frescobaldi_app/documentstructure.py
@@ -94,13 +94,13 @@ def create_outline_re():
 class DocumentStructure(plugin.DocumentPlugin):
     def __init__(self, document):
         self._outline = None
-    
+
     def invalidate(self):
         """Called when the document changes or the settings are changed."""
         self._outline = None
         app.settingsChanged.disconnect(self.invalidate)
         self.document().contentsChanged.disconnect(self.invalidate)
-    
+
     def outline(self):
         """Return the document outline as a series of match objects."""
         if self._outline is None:

--- a/frescobaldi_app/documenttooltip.py
+++ b/frescobaldi_app/documenttooltip.py
@@ -41,12 +41,12 @@ import ly.lex.lilypond
 
 def pixmap(cursor, num_lines=6, scale=0.8):
     """Return a QPixmap displaying the selected lines of the document.
-    
+
     If the cursor has no selection, num_lines are drawn.
-    
+
     By default the text is drawn 0.8 * the normal font size. You can change
     that by supplying the scale parameter.
-    
+
     """
     block = cursor.document().findBlock(cursor.selectionStart())
     c2 = QTextCursor(block)
@@ -55,7 +55,7 @@ def pixmap(cursor, num_lines=6, scale=0.8):
         c2.movePosition(QTextCursor.EndOfBlock, QTextCursor.KeepAnchor)
     else:
         c2.movePosition(QTextCursor.NextBlock, QTextCursor.KeepAnchor, num_lines)
-    
+
     data = textformats.formatData('editor')
     doc = QTextDocument()
     font = QFont(data.font)
@@ -73,12 +73,12 @@ def pixmap(cursor, num_lines=6, scale=0.8):
 
 def show(cursor, pos=None, num_lines=6):
     """Displays a tooltip showing part of the cursor's Document.
-    
+
     If the cursor has a selection, those blocks are displayed.
     Otherwise, num_lines lines are displayed.
-    
+
     If pos is not given, the global mouse position is used.
-    
+
     """
     pix = pixmap(cursor, num_lines)
     label = QLabel()
@@ -90,11 +90,11 @@ def show(cursor, pos=None, num_lines=6):
 
 def text(cursor):
     """Return basic tooltip text displaying filename, line and column information.
-    
+
     If the position is inside a music expression, the name of the variable the
     expression is assigned to is also appended on a new line. If the time
     position can be determined it is appended on a third line.
-    
+
     """
     filename = cursor.document().documentName()
     line = cursor.blockNumber() + 1
@@ -111,10 +111,10 @@ def text(cursor):
 
 def get_definition(cursor):
     """Return the variable name the cursor's music expression is assigned to.
-    
+
     If the music is in a \\score instead, "\\score" is returned.
     Returns None if no variable name can be found.
-    
+
     """
     block = cursor.block()
     while block.isValid():
@@ -130,9 +130,9 @@ def get_definition(cursor):
 
 def time_position(cursor):
     """Returns the time position of the music the cursor points at.
-    
+
     Format the value as "5/1" etc.
-    
+
     """
     import documentinfo
     pos = documentinfo.music(cursor.document()).time_position(cursor.position())

--- a/frescobaldi_app/documenttree.py
+++ b/frescobaldi_app/documenttree.py
@@ -44,19 +44,19 @@ class DocumentNode(ly.node.Node):
 
 def tree(urls=False):
     """Return the open documents as a tree structure.
-    
+
     Returned is a ly.node.Node instance having the toplevel documents (documents
     that are not included by other open documents) as children. The children of
     the nodes are the documents that are included by the toplevel document.
-    
+
     Every node has the Document in its document attribute.
-    
+
     If urls == True, nodes will also be generated for urls that refer to
     documents that are not yet open. They will have the QUrl in their url
     attribute.
-    
+
     It is not checked whether the referred to urls or files actually exist.
-    
+
     """
     root = ly.node.Node()
     nodes = {}

--- a/frescobaldi_app/documentwatcher.py
+++ b/frescobaldi_app/documentwatcher.py
@@ -54,11 +54,11 @@ class DocumentWatcher(plugin.DocumentPlugin):
     """Maintains if a change was detected for a document."""
     def __init__(self, d):
         self.changed = False
-    
+
     def isdeleted(self):
         """Return True if some change has occurred, the document has a local
         filename, but the file is not existing on disk.
-        
+
         """
         if self.changed:
             filename = self.document().url().toLocalFile()
@@ -80,7 +80,7 @@ def removeUrl(url):
     if filename:
         watcher.removePath(filename)
 
-    
+
 def unchange(document):
     """Mark document as not changed (anymore)."""
     DocumentWatcher.instance(document).changed = False
@@ -95,7 +95,7 @@ def documentUrlChanged(document, url, old):
         removeUrl(old)
     addUrl(url)
 
-            
+
 def documentClosed(document):
     """Called whenever a document closes."""
     for d in app.documents:
@@ -118,7 +118,7 @@ def whileSaving(document):
     finally:
         addUrl(document.url())
 
-    
+
 def fileChanged(filename):
     """Called whenever the global filesystem watcher detects a change."""
     url = QUrl.fromLocalFile(filename)

--- a/frescobaldi_app/engrave/__init__.py
+++ b/frescobaldi_app/engrave/__init__.py
@@ -42,12 +42,12 @@ import variables
 
 def engraver(mainwindow):
     return Engraver.instance(mainwindow)
-    
+
 
 class Engraver(plugin.MainWindowPlugin):
-    
+
     stickyChanged = signals.Signal()    # Document
-    
+
     def __init__(self, mainwindow):
         self._currentStickyDocument = None
         ac = self.actionCollection = Actions()
@@ -74,7 +74,7 @@ class Engraver(plugin.MainWindowPlugin):
         self.loadSettings()
         app.languageChanged.connect(self.updateStickyActionText)
         self.updateStickyActionText()
-        
+
     def document(self):
         """Return the Document that should be engraved."""
         doc = self.stickyDocument()
@@ -89,14 +89,14 @@ class Engraver(plugin.MainWindowPlugin):
                     except IOError:
                         pass
         return doc
-                
+
     def runningJob(self):
         """Returns a Job for the sticky or current document if that is running."""
         doc = self.document()
         job = jobmanager.job(doc)
         if job and job.is_running() and not jobattributes.get(job).hidden:
             return job
-    
+
     def updateActions(self):
         job = jobmanager.job(self.document())
         running = bool(job and job.is_running())
@@ -109,28 +109,28 @@ class Engraver(plugin.MainWindowPlugin):
         ac.engrave_runner.setIcon(icons.get('process-stop' if visible else 'lilypond-run'))
         ac.engrave_runner.setToolTip(_("Abort engraving job") if visible else
                     _("Engrave (preview; press Shift for custom)"))
-    
+
     def openDefaultView(self, document, job, success):
         """Called when a job finishes.
-        
+
         Open the default viewer for the created files if the user has the
         preference for this set.
-        
+
         """
         if (success and jobattributes.get(job).mainwindow is self.mainwindow()
                 and QSettings().value("lilypond_settings/open_default_view", True, bool)):
-            
+
             # which files were created by this job?
             import resultfiles
             extensions = set(os.path.splitext(filename)[1].lower()
                 for filename in resultfiles.results(document).files_lastjob())
-            
+
             mgr = panelmanager.manager(self.mainwindow())
             if '.svg' in extensions or '.svgz' in extensions:
                 mgr.svgview.activate()
             elif '.pdf' in extensions:
                 mgr.musicview.activate()
-    
+
     def engraveRunner(self):
         job = self.runningJob()
         if job:
@@ -139,19 +139,19 @@ class Engraver(plugin.MainWindowPlugin):
             self.engraveCustom()
         else:
             self.engravePreview()
-    
+
     def engravePreview(self):
         """Starts an engrave job in preview mode (with point and click turned on)."""
         self.engrave('preview')
-    
+
     def engravePublish(self):
         """Starts an engrave job in publish mode (with point and click turned off)."""
         self.engrave('publish')
-        
+
     def engraveLayoutControl(self):
         """Starts an engrave job in debug mode (using the settings in the debug tool)."""
         self.engrave('layout-control')
-        
+
     def engraveCustom(self):
         """Opens a dialog to configure the job before starting it."""
         try:
@@ -166,21 +166,21 @@ class Engraver(plugin.MainWindowPlugin):
         if dlg.exec_():
             self.saveDocumentIfDesired()
             self.runJob(dlg.getJob(doc), doc)
-    
+
     def engrave(self, mode='preview', document=None, may_save=True):
         """Starts an engraving job.
-        
-        The mode can be 'preview', 'publish', or 'layout-control'. The last 
-        one uses the settings in the Layout Control Options panel. The 
+
+        The mode can be 'preview', 'publish', or 'layout-control'. The last
+        one uses the settings in the Layout Control Options panel. The
         default mode is 'preview'.
-        
+
         If document is not specified, it is either the sticky or current
         document.
-        
+
         If may_save is False, the document will not be saved before running
         LilyPond, even if the preference setting "save document before LilyPond
         is run" is enabled.
-        
+
         """
         if mode == 'preview':
             args = ['-dpoint-and-click']
@@ -194,17 +194,17 @@ class Engraver(plugin.MainWindowPlugin):
             self.saveDocumentIfDesired()
         from . import command
         self.runJob(command.defaultJob(doc, args), doc)
-    
+
     def engraveAbort(self):
         job = jobmanager.job(self.document())
         if job and job.is_running():
             job.abort()
-    
+
     def saveDocumentIfDesired(self):
         """Saves the current document if desired and it makes sense.
-        
+
         (i.e. the document is modified and has a local filename)
-        
+
         """
         if QSettings().value("lilypond_settings/save_on_run", False, bool):
             doc = self.mainwindow().currentDocument()
@@ -216,11 +216,11 @@ class Engraver(plugin.MainWindowPlugin):
 
     def queryCloseDocument(self, doc):
         """Return True whether a document can be closed.
-        
+
         When no job is running, True is immediately returned.
         When a job is running, the user is asked whether to abort the job (not
         for autocompile ("hidden") jobs).
-        
+
         """
         job = jobmanager.job(doc)
         if not job or not job.is_running() or jobattributes.get(job).hidden:
@@ -246,11 +246,11 @@ class Engraver(plugin.MainWindowPlugin):
         if rjob and rjob.is_running():
             rjob.abort()
         jobmanager.manager(document).start_job(job)
-    
+
     def stickyToggled(self):
         """Called when the user toggles the 'Sticky' action."""
         self.setStickyDocument(None if self.stickyDocument() else self.mainwindow().currentDocument())
-    
+
     def setStickyDocument(self, doc=None):
         """Sticks to the given document or removes the 'stick' when None."""
         cur = self._currentStickyDocument
@@ -266,11 +266,11 @@ class Engraver(plugin.MainWindowPlugin):
         self.actionCollection.engrave_sticky.setChecked(bool(doc))
         self.updateStickyActionText()
         self.updateActions()
-        
+
     def stickyDocument(self):
         """Returns the document currently marked as 'Sticky', if any."""
         return self._currentStickyDocument
-    
+
     def slotUnStickDocument(self):
         """Called when the document that is currently sticky closes or reloads."""
         self.setStickyDocument(None)
@@ -283,12 +283,12 @@ class Engraver(plugin.MainWindowPlugin):
         else:
             text = _("&Always Engrave This Document")
         self.actionCollection.engrave_sticky.setText(text)
-    
+
     def engraveAutoCompileToggled(self, enabled):
         """Called when the user toggles autocompile on/off."""
         from . import autocompile
         autocompile.AutoCompiler.instance(self.mainwindow()).setEnabled(enabled)
-    
+
     def openLilyPondDatadir(self):
         """Menu action Open LilyPond Data Directory."""
         from . import command
@@ -297,20 +297,20 @@ class Engraver(plugin.MainWindowPlugin):
         if datadir:
             import helpers
             helpers.openUrl(QUrl.fromLocalFile(datadir))
-    
+
     def showAvailableFonts(self):
         """Menu action Show Available Fonts."""
         from . import command
         info = command.info(self.mainwindow().currentDocument())
         from . import lytools
         lytools.show_available_fonts(self.mainwindow(), info)
-        
+
     def slotDocumentClosed(self, doc):
         """Called when the user closes a document. Aborts a running Job."""
         job = jobmanager.job(doc)
         if job and job.is_running():
             job.abort()
-        
+
     def slotSessionChanged(self):
         """Called when the session is changed."""
         import sessions
@@ -321,7 +321,7 @@ class Engraver(plugin.MainWindowPlugin):
                 d = app.findDocument(url)
                 if d:
                     self.setStickyDocument(d)
-    
+
     def slotSaveSessionData(self):
         """Called when a session needs to save data."""
         import sessions
@@ -332,26 +332,26 @@ class Engraver(plugin.MainWindowPlugin):
                 g.setValue("sticky_url", d.url())
             else:
                 g.remove("sticky_url")
-    
+
     def saveSettings(self):
         """Save the state of some actions."""
         ac = self.actionCollection
         s = QSettings()
         s.beginGroup("engraving")
         s.setValue("autocompile", ac.engrave_autocompile.isChecked())
-        
+
     def loadSettings(self):
         """Load the state of some actions."""
         ac = self.actionCollection
         s = QSettings()
         s.beginGroup("engraving")
         ac.engrave_autocompile.setChecked(s.value("autocompile", False, bool))
-    
+
     def checkLilyPondInstalled(self, document, job, success):
         """Called when LilyPond is run for the first time.
-        
+
         Displays a helpful dialog if the process failed to start.
-        
+
         """
         app.jobFinished.disconnect(self.checkLilyPondInstalled)
         if not success and job.failed_to_start():
@@ -367,7 +367,7 @@ class Engraver(plugin.MainWindowPlugin):
 
 class Actions(actioncollection.ActionCollection):
     name = "engrave"
-    
+
     def createActions(self, parent=None):
         self.engrave_sticky = QAction(parent)
         self.engrave_sticky.setCheckable(True)
@@ -381,19 +381,19 @@ class Actions(actioncollection.ActionCollection):
         self.engrave_autocompile.setCheckable(True)
         self.engrave_show_available_fonts = QAction(parent)
         self.engrave_open_lilypond_datadir = QAction(parent)
-        
+
         self.engrave_preview.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_M))
         self.engrave_publish.setShortcut(QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_P))
         self.engrave_custom.setShortcut(QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_M))
         self.engrave_abort.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_Pause))
-        
+
         self.engrave_sticky.setIcon(icons.get('pushpin'))
         self.engrave_preview.setIcon(icons.get('lilypond-run'))
         self.engrave_publish.setIcon(icons.get('lilypond-run'))
         self.engrave_debug.setIcon(icons.get('lilypond-run'))
         self.engrave_custom.setIcon(icons.get('lilypond-run'))
         self.engrave_abort.setIcon(icons.get('process-stop'))
-        
+
 
     def translateUI(self):
         self.engrave_runner.setText(_("Engrave"))
@@ -406,5 +406,5 @@ class Actions(actioncollection.ActionCollection):
         self.engrave_autocompile.setText(_("Automatic E&ngrave"))
         self.engrave_open_lilypond_datadir.setText(_("Open LilyPond &Data Directory"))
         self.engrave_show_available_fonts.setText(_("Show Available &Fonts..."))
-        
-        
+
+

--- a/frescobaldi_app/engrave/autocompile.py
+++ b/frescobaldi_app/engrave/autocompile.py
@@ -53,7 +53,7 @@ class AutoCompiler(plugin.MainWindowPlugin):
         self._enabled = False
         self._timer = QTimer(singleShot=True)
         self._timer.timeout.connect(self.slotTimeout)
-    
+
     def setEnabled(self, enabled):
         """Switch the autocompiler on or off."""
         enabled = bool(enabled)
@@ -72,7 +72,7 @@ class AutoCompiler(plugin.MainWindowPlugin):
             app.documentUrlChanged.disconnect(self.startTimer)
             if doc:
                 self.slotDocumentChanged(None, doc)
-    
+
     def slotDocumentChanged(self, new=None, old=None):
         """Called when the mainwindow changes the current document."""
         if old:
@@ -85,11 +85,11 @@ class AutoCompiler(plugin.MainWindowPlugin):
             new.saved.connect(self.startTimer)
             if self._enabled:
                 self.startTimer()
-    
+
     def startTimer(self):
         """Called to trigger a soon auto-compile try."""
         self._timer.start(750)
-    
+
     def slotTimeout(self):
         """Called when the autocompile timer expires."""
         eng = engraver(self.mainwindow())
@@ -99,7 +99,7 @@ class AutoCompiler(plugin.MainWindowPlugin):
             # a real job is running, come back when that is done
             rjob.done.connect(self.startTimer)
             return
-        
+
         mgr = AutoCompileManager.instance(doc)
         may_compile = mgr.may_compile()
         if not may_compile:
@@ -122,7 +122,7 @@ class AutoCompileManager(plugin.DocumentPlugin):
         document.loaded.connect(self.initialize)
         jobmanager.manager(document).started.connect(self.slotJobStarted)
         self.initialize()
-    
+
     def initialize(self):
         document = self.document()
         if document.isModified():
@@ -139,7 +139,7 @@ class AutoCompileManager(plugin.DocumentPlugin):
                 ext = '.pdf'
             self._dirty = not resultfiles.results(document).files(ext)
         self._hash = None if self._dirty else documentinfo.docinfo(document).token_hash()
-    
+
     def may_compile(self):
         """Return True if we could need to compile the document."""
         if self._dirty:
@@ -155,7 +155,7 @@ class AutoCompileManager(plugin.DocumentPlugin):
                     if h != hash(tuple()):
                         return True
             self._dirty = False
-    
+
     def slotDocumentContentsChanged(self):
         """Called when the user modifies the document."""
         doc = self.document()
@@ -165,9 +165,9 @@ class AutoCompileManager(plugin.DocumentPlugin):
     @contextlib.contextmanager
     def slotDocumentSaving(self):
         """Called while the document is being saved.
-        
+
         Forces auto-compile once if the document was modified before saving.
-        
+
         """
         modified = self.document().isModified()
         try:
@@ -176,7 +176,7 @@ class AutoCompileManager(plugin.DocumentPlugin):
             if modified:
                 self._dirty = True
                 self._hash = None
-    
+
     def slotJobStarted(self):
         """Called when an engraving job is started on this document."""
         if self._dirty:

--- a/frescobaldi_app/engrave/command.py
+++ b/frescobaldi_app/engrave/command.py
@@ -41,19 +41,19 @@ def info(document):
 
 def defaultJob(document, args=None):
     """Return a default job for the document.
-    
+
     The 'args' argument, if given, must be a list of commandline arguments
     that are given to LilyPond, and may enable specific preview modes.
-    
+
     If args is not given, the Job will cause LilyPond to run in Publish mode,
     with point and click turned off.
-    
+
     """
     filename, includepath = documentinfo.info(document).jobinfo(True)
-    
+
     i = info(document)
     j = job.Job()
-    
+
     command = [i.abscommand() or i.command]
     s = QSettings()
     s.beginGroup("lilypond_settings")
@@ -61,13 +61,13 @@ def defaultJob(document, args=None):
         command.append('-ddelete-intermediate-files')
     else:
         command.append('-dno-delete-intermediate-files')
-    
+
     if args:
         command.extend(args)
     else:
         # publish mode
         command.append('-dno-point-and-click')
-    
+
     if s.value("default_output_target", "pdf", str) == "svg":
         # engrave to SVG
         command.append('-dbackend=svg')
@@ -79,7 +79,7 @@ def defaultJob(document, args=None):
                 command.append('-dembed-source-code')
         command.append('--pdf')
 
-        
+
     command.extend('-I' + path for path in includepath)
     j.directory = os.path.dirname(filename)
     command.append(filename)

--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -50,40 +50,40 @@ class Dialog(QDialog):
     def __init__(self, mainwindow):
         super(Dialog, self).__init__(mainwindow)
         self._document = None
-        
+
         layout = QGridLayout()
         self.setLayout(layout)
-        
+
         self.versionLabel = QLabel()
         self.lilyChooser = lilychooser.LilyChooser()
-        
+
         self.outputLabel = QLabel()
         self.outputCombo = QComboBox()
-        
+
         self.resolutionLabel = QLabel()
         self.resolutionCombo = QComboBox(editable=True)
-        
+
         self.antialiasLabel = QLabel()
         self.antialiasSpin = QSpinBox(minimum=1, maximum=128, value=1)
-        
+
         self.modeLabel = QLabel()
         self.modeCombo = QComboBox()
-        
+
         self.deleteCheck = QCheckBox()
         self.embedSourceCodeCheck = QCheckBox()
         self.englishCheck = QCheckBox()
-        
+
         self.commandLineLabel = QLabel()
         self.commandLine = QTextEdit(acceptRichText=False)
-        
+
         self.buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         self.buttons.button(QDialogButtonBox.Ok).setIcon(icons.get("lilypond-run"))
         userguide.addButton(self.buttons, "engrave_custom")
-        
+
         self.resolutionCombo.addItems(['100', '200', '300', '600', '1200'])
         self.resolutionCombo.setCurrentIndex(2)
-        
+
         self.modeCombo.addItems(['preview', 'publish', 'debug'])
         layout.addWidget(self.versionLabel, 0, 0)
         layout.addWidget(self.lilyChooser, 0, 1, 1, 3)
@@ -102,26 +102,26 @@ class Dialog(QDialog):
         layout.addWidget(self.commandLine, 8, 0, 1, 4)
         layout.addWidget(widgets.Separator(), 9, 0, 1, 4)
         layout.addWidget(self.buttons, 10, 0, 1, 4)
-        
+
         app.translateUI(self)
         qutil.saveDialogSize(self, "engrave/custom/dialog/size", QSize(480, 260))
         self.buttons.accepted.connect(self.accept)
         self.buttons.rejected.connect(self.reject)
-        
+
         model = listmodel.ListModel(formats, display=lambda f: f.title(),
             icon=lambda f: icons.file_type(f.type))
         self.outputCombo.setModel(model)
-        
+
         s = QSettings()
         s.beginGroup("lilypond_settings")
         self.englishCheck.setChecked(
             s.value("no_translation", False, bool))
         self.deleteCheck.setChecked(
             s.value("delete_intermediate_files", True, bool))
-        
+
         if s.value("default_output_target", "pdf", str) == "svg":
             self.outputCombo.setCurrentIndex(3)
-        
+
         app.jobFinished.connect(self.slotJobFinished)
         self.outputCombo.currentIndexChanged.connect(self.makeCommandLine)
         self.modeCombo.currentIndexChanged.connect(self.makeCommandLine)
@@ -131,7 +131,7 @@ class Dialog(QDialog):
         self.antialiasSpin.valueChanged.connect(self.makeCommandLine)
         self.makeCommandLine()
         panelmanager.manager(mainwindow).layoutcontrol.widget().optionsChanged.connect(self.makeCommandLine)
-    
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Engrave custom")))
         self.versionLabel.setText(_("LilyPond Version:"))
@@ -148,26 +148,26 @@ class Dialog(QDialog):
         self.commandLineLabel.setText(_("Command line:"))
         self.buttons.button(QDialogButtonBox.Ok).setText(_("Run LilyPond"))
         self.outputCombo.update()
-    
+
     def slotJobFinished(self, doc):
         if doc == self._document:
             self.buttons.button(QDialogButtonBox.Ok).setEnabled(True)
             self._document = None
-    
+
     def setDocument(self, doc):
         self.lilyChooser.setLilyPondInfo(command.info(doc))
         job = jobmanager.job(doc)
         if job and job.is_running() and not jobattributes.get(job).hidden:
             self._document = doc
             self.buttons.button(QDialogButtonBox.Ok).setEnabled(False)
-        
+
     def makeCommandLine(self):
         """Reads the widgets and builds a command line."""
         f = formats[self.outputCombo.currentIndex()]
         self.resolutionCombo.setEnabled('resolution' in f.widgets)
         self.antialiasSpin.setEnabled('antialias' in f.widgets)
         cmd = ["$lilypond"]
-        
+
         if self.modeCombo.currentIndex() == 0:   # preview mode
             cmd.append('-dpoint-and-click')
         elif self.modeCombo.currentIndex() == 1: # publish mode
@@ -175,15 +175,15 @@ class Dialog(QDialog):
         else:                                    # debug mode
             args = panelmanager.manager(self.parent()).layoutcontrol.widget().preview_options()
             cmd.extend(args)
-        
+
         if self.deleteCheck.isChecked():
             cmd.append('-ddelete-intermediate-files')
         else:
             cmd.append('-dno-delete-intermediate-files')
-        
+
         if self.embedSourceCodeCheck.isChecked():
             cmd.append('-dembed-source-code')
-        
+
         d = {
             'version': self.lilyChooser.lilyPondInfo().version,
             'resolution': self.resolutionCombo.currentText(),
@@ -193,7 +193,7 @@ class Dialog(QDialog):
         cmd.extend(f.options(d))
         cmd.append("$filename")
         self.commandLine.setText(' '.join(cmd))
-    
+
     def getJob(self, document):
         """Returns a Job to start."""
         filename, includepath = documentinfo.info(document).jobinfo(True)

--- a/frescobaldi_app/engrave/lytools.py
+++ b/frescobaldi_app/engrave/lytools.py
@@ -43,7 +43,7 @@ def show_available_fonts(mainwin, info):
     qutil.saveDialogSize(dlg, "engrave/tools/available-fonts/dialog/size", QSize(640, 400))
     dlg.setAttribute(Qt.WA_DeleteOnClose)
     dlg.show()
-    
+
 
 class Dialog(widgets.dialog.Dialog):
     """Dialog to run a certain LilyPond command and simply show the log."""

--- a/frescobaldi_app/engrave/result_menu.py
+++ b/frescobaldi_app/engrave/result_menu.py
@@ -40,10 +40,10 @@ class Menu(QMenu):
         app.jobFinished.connect(self.slotJobFinished)
         self.triggered.connect(self.actionTriggered)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_("Generated &Files"))
-        
+
     def populate(self):
         self.clear()
         doc = self.parentWidget().currentDocument()
@@ -67,11 +67,11 @@ class Menu(QMenu):
                 a.setEnabled(False)
             else:
                 qutil.addAccelerators(self.actions())
-    
+
     def actionTriggered(self, action):
         import helpers
         helpers.openUrl(QUrl.fromLocalFile(action.filename))
-    
+
     def slotJobFinished(self, doc):
         if self.isVisible() and doc == self.parentWidget().currentDocument():
             self.populate()

--- a/frescobaldi_app/exception.py
+++ b/frescobaldi_app/exception.py
@@ -39,26 +39,26 @@ class ExceptionDialog(QDialog):
     """Single-use dialog displaying a Python exception."""
     def __init__(self, exctype, excvalue, exctb):
         super(ExceptionDialog, self).__init__()
-        
+
         self._tbshort = ''.join(traceback.format_exception_only(exctype, excvalue))
         self._tbfull = ''.join(traceback.format_exception(exctype, excvalue, exctb))
- 
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.errorLabel = QLabel()
         layout.addWidget(self.errorLabel)
         textview = QTextBrowser()
         layout.addWidget(textview)
         textview.setText(self._tbfull)
         textview.moveCursor(QTextCursor.End)
-        
+
         layout.addWidget(widgets.Separator())
-        
+
         b = self.buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         b.button(QDialogButtonBox.Ok).setIcon(icons.get("tools-report-bug"))
         layout.addWidget(b)
-        
+
         b.accepted.connect(self.accept)
         b.rejected.connect(self.reject)
         self.resize(600,300)
@@ -74,7 +74,7 @@ class ExceptionDialog(QDialog):
         if result:
             self.reportBug()
         super(ExceptionDialog, self).done(result)
-        
+
     def reportBug(self):
         bugreport.email(self._tbshort, self._tbfull + '\n' + _("Optionally describe below what you were doing:"))
 

--- a/frescobaldi_app/externalchanges/__init__.py
+++ b/frescobaldi_app/externalchanges/__init__.py
@@ -57,10 +57,10 @@ def setup():
 
 def changedDocuments():
     """Return a list of really changed Documents.
-    
+
     When a document is not modified and the file on disk is exactly the same,
     the document is not considered having been changed on disk.
-    
+
     """
     import documentwatcher
     for w in documentwatcher.DocumentWatcher.instances():

--- a/frescobaldi_app/externalchanges/widget.py
+++ b/frescobaldi_app/externalchanges/widget.py
@@ -55,20 +55,20 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
         super(ChangedDocumentsListDialog, self).__init__(buttons=('close',))
         self.setWindowModality(Qt.NonModal)
         self.setAttribute(Qt.WA_QuitOnClose, False)
-        
+
         layout = QGridLayout(margin=0)
         self.mainWidget().setLayout(layout)
         self.tree = QTreeWidget(headerHidden=True, rootIsDecorated=False,
                                 columnCount=2, itemsExpandable=False)
         self.tree.setSelectionMode(QTreeWidget.ExtendedSelection)
-        
+
         self.buttonReload = QPushButton()
         self.buttonReloadAll = QPushButton()
         self.buttonSave = QPushButton()
         self.buttonSaveAll = QPushButton()
         self.buttonShowDiff = QPushButton()
         self.checkWatchingEnabled = QCheckBox(checked=enabled())
-        
+
         layout.addWidget(self.tree, 0, 0, 6, 1)
         layout.addWidget(self.buttonReload, 0, 1)
         layout.addWidget(self.buttonReloadAll, 1, 1)
@@ -77,7 +77,7 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
         layout.addWidget(self.buttonShowDiff, 4, 1)
         layout.addWidget(self.checkWatchingEnabled, 6, 0, 1, 2)
         layout.setRowStretch(5, 10)
-        
+
         app.documentClosed.connect(self.removeDocument)
         app.documentSaved.connect(self.removeDocument)
         app.documentUrlChanged.connect(self.removeDocument)
@@ -89,12 +89,12 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
         self.buttonSaveAll.clicked.connect(self.slotButtonSaveAll)
         self.buttonShowDiff.clicked.connect(self.slotButtonShowDiff)
         self.checkWatchingEnabled.toggled.connect(setEnabled)
-    
+
         app.translateUI(self)
         qutil.saveDialogSize(self, 'externalchanges/dialog/size', QSize(400, 200))
         userguide.addButton(self.buttonBox(), "externalchanges")
         self.button('close').setFocus()
-    
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Modified Files")))
         self.setMessage(_(
@@ -127,7 +127,7 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
         self.checkWatchingEnabled.setToolTip(_(
             "If checked, Frescobaldi will warn you when opened files are "
             "modified or deleted by other applications."))
-    
+
     def setDocuments(self, documents):
         """Display the specified documents in the list."""
         # clear the treewidget
@@ -153,7 +153,7 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
                 fileitem = QTreeWidgetItem()
                 diritem.addChild(fileitem)
                 if documentwatcher.DocumentWatcher.instance(document).isdeleted():
-                    itemtext = _("[deleted]") 
+                    itemtext = _("[deleted]")
                     icon = "dialog-error"
                 else:
                     itemtext = _("[modified]")
@@ -168,7 +168,7 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
         self.tree.resizeColumnToContents(0)
         self.tree.resizeColumnToContents(1)
         self.updateButtons()
-        
+
     def removeDocument(self, document):
         """Remove the specified document from our list."""
         for d in range(self.tree.topLevelItemCount()):
@@ -187,17 +187,17 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
         # hide if no documents are left
         if self.tree.topLevelItemCount() == 0:
             self.hide()
-    
+
     def selectedDocuments(self):
         """Return the selected documents."""
         return [i.doc for i in self.tree.selectedItems()]
-    
+
     def allDocuments(self):
         """Return all shown documents."""
         return [self.tree.topLevelItem(d).child(f).doc
                 for d in range(self.tree.topLevelItemCount())
                 for f in range(self.tree.topLevelItem(d).childCount())]
-    
+
     def updateButtons(self):
         """Updates the buttons regarding the selection."""
         docs_sel = self.selectedDocuments()
@@ -211,23 +211,23 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
         self.buttonReload.setEnabled(not all_deleted_sel)
         self.buttonReloadAll.setEnabled(not all_deleted_all)
         self.buttonShowDiff.setEnabled(len(docs_sel) == 1 and not all_deleted_sel)
-    
+
     def slotButtonReload(self):
         """Called when the user clicks Reload."""
         self.reloadDocuments(self.selectedDocuments())
-        
+
     def slotButtonReloadAll(self):
         """Called when the user clicks Reload All."""
         self.reloadDocuments(self.allDocuments())
-    
+
     def slotButtonSave(self):
         """Called when the user clicks Save."""
         self.saveDocuments(self.selectedDocuments())
-    
+
     def slotButtonSaveAll(self):
         """Called when the user clicks Save All."""
         self.saveDocuments(self.allDocuments())
-    
+
     def reloadDocuments(self, documents):
         """Used by slotButtonReload and slotButtonReloadAll."""
         failures = []
@@ -262,7 +262,7 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
               "Please save the documents using the \"Save As...\" dialog.",
               len(failures))
             QMessageBox.critical(self, app.caption(_("Error")), msg)
-        
+
     def slotButtonShowDiff(self):
         """Called when the user clicks Show Difference."""
         docs = self.selectedDocuments() or self.allDocuments()
@@ -271,18 +271,18 @@ class ChangedDocumentsListDialog(widgets.dialog.Dialog):
         d = docs[0]
         if documentwatcher.DocumentWatcher.instance(d).isdeleted():
             return
-        
+
         filename = d.url().toLocalFile()
         try:
             with open(filename, 'rb') as f:
                 disktext = util.decode(f.read())
         except (IOError, OSError):
             return
-        
+
         currenttext = d.toPlainText()
-        
+
         html = htmldiff.htmldiff(
-            currenttext, disktext, 
+            currenttext, disktext,
             _("Current Document"), _("Document on Disk"), numlines=5)
         dlg = widgets.dialog.Dialog(self, buttons=('close',))
         view = QTextBrowser(lineWrapMode=QTextBrowser.NoWrap)

--- a/frescobaldi_app/externalcommand.py
+++ b/frescobaldi_app/externalcommand.py
@@ -29,21 +29,21 @@ import widgets.dialog
 class ExternalCommandDialog(widgets.dialog.Dialog):
 
     """Dialog that can run an external command, displaying the output.
-    
+
     If the dialog is dismissed, the command is stopped and the cleanup()
     method is called.
-    
+
     You need to create a Job instance with the command, and call the run_job()
     method to start it. The output is displayed in the dialog.
-    
+
     When the user cancels the dialog while the command is running, cleanup() is
     called with the 'aborted' argument. When the user closes the dialog after
     the command has run, cleanup() is called with either the 'success' or
     'failure' argument, indicating whether the command exited normally.
-    
+
     You can reimplement that method to do things like removing temporary files,
     etc.
-    
+
     """
     def __init__(self, parent=None):
         super(ExternalCommandDialog, self).__init__(parent)
@@ -78,15 +78,15 @@ class ExternalCommandDialog(widgets.dialog.Dialog):
 
     def cleanup(self, state):
         """Called when the dialog is closed.
-        
+
         state is one of three values:
         - "success": the command exited normally
         - "failure": the command exited with an error
         - "aborted": the dialog was cancelled while the command was running.
-        
+
         Reimplement this method to do anything meaningful.
-        
+
         """
         pass
-        
+
 

--- a/frescobaldi_app/file_import/__init__.py
+++ b/frescobaldi_app/file_import/__init__.py
@@ -45,7 +45,7 @@ class FileImport(plugin.MainWindowPlugin):
         ac.import_musicxml.triggered.connect(self.importMusicXML)
         ac.import_midi.triggered.connect(self.importMidi)
         ac.import_abc.triggered.connect(self.importAbc)
-        
+
     def importAll(self):
         """Reads the file type and determines which import to use."""
         filetypes = ';;'.join((
@@ -67,7 +67,7 @@ class FileImport(plugin.MainWindowPlugin):
                 QMessageBox.critical(None, _("Error"),
                     _("The file {filename} could not be converted. "
                       "Wrong file type.").format(filename=imp))
-        
+
     def isImportable(self, infile):
         """Check if the file is importable."""
         ext = os.path.splitext(infile)[1]
@@ -75,10 +75,10 @@ class FileImport(plugin.MainWindowPlugin):
             return True
         else:
             return False
-            
-    def openDialog(self, infile): 
+
+    def openDialog(self, infile):
         """Check file type and open the proper dialog."""
-        self.importfile = infile   
+        self.importfile = infile
         ext = os.path.splitext(infile)[1]
         if ext == '.xml' or ext == '.mxl':
             self.openMusicxmlDialog()
@@ -97,7 +97,7 @@ class FileImport(plugin.MainWindowPlugin):
         if not self.importfile:
             return # the dialog was cancelled by user
         self.openMusicxmlDialog()
-    
+
     def openMusicxmlDialog(self):
         try:
             dlg = self._importDialog = self.mxmlDlg
@@ -107,7 +107,7 @@ class FileImport(plugin.MainWindowPlugin):
             dlg.addAction(self.mainwindow().actionCollection.help_whatsthis)
             dlg.setWindowModality(Qt.WindowModal)
         self.runImport()
-        
+
     def importMidi(self):
         """Opens an midi file. Converts it to ly by using midi2ly."""
         filetypes = '{0} (*.midi *.mid);;{1} (*)'.format(
@@ -118,7 +118,7 @@ class FileImport(plugin.MainWindowPlugin):
         if not self.importfile:
             return # the dialog was cancelled by user
         self.openMidiDialog()
-    
+
     def openMidiDialog(self):
         try:
             dlg = self._importDialog = self.midDlg
@@ -128,7 +128,7 @@ class FileImport(plugin.MainWindowPlugin):
             dlg.addAction(self.mainwindow().actionCollection.help_whatsthis)
             dlg.setWindowModality(Qt.WindowModal)
         self.runImport()
-        
+
     def importAbc(self):
         """Opens an abc file. Converts it to ly by using abc2ly."""
         filetypes = '{0} (*.abc);;{1} (*)'.format(
@@ -149,7 +149,7 @@ class FileImport(plugin.MainWindowPlugin):
             dlg.addAction(self.mainwindow().actionCollection.help_whatsthis)
             dlg.setWindowModality(Qt.WindowModal)
         self.runImport()
-    
+
     def runImport(self):
         """Generic execution of all import dialogs."""
         dlg = self._importDialog
@@ -180,8 +180,8 @@ class FileImport(plugin.MainWindowPlugin):
         doc.setUrl(QUrl.fromLocalFile(filename))
         doc.setModified(True)
         self.mainwindow().setCurrentDocument(doc)
-        return doc       
-        
+        return doc
+
     def postImport(self, settings, doc):
         """Adaptations of the source after running musicxml2ly
 
@@ -191,7 +191,7 @@ class FileImport(plugin.MainWindowPlugin):
         Remove duration scaling
         Engrave directly
         """
-        cursor = QTextCursor(doc)		
+        cursor = QTextCursor(doc)
         if settings[0]:
             import reformat
             reformat.reformat(cursor)
@@ -202,11 +202,11 @@ class FileImport(plugin.MainWindowPlugin):
         if settings[2]:
             cursor.select(QTextCursor.Document)
             from rhythm import rhythm
-            rhythm.rhythm_remove_fraction_scaling(cursor)       
+            rhythm.rhythm_remove_fraction_scaling(cursor)
         if settings[3]:
             import engrave
             engrave.engraver(self.mainwindow()).engrave('preview', doc, False)
-        
+
 
 
 class Actions(actioncollection.ActionCollection):

--- a/frescobaldi_app/file_import/abc.py
+++ b/frescobaldi_app/file_import/abc.py
@@ -20,7 +20,7 @@
 """
 Import ABC dialog.
 Uses abc2ly to create ly file from abc.
-In the dialog the options of abc2ly can be set. 
+In the dialog the options of abc2ly can be set.
 """
 
 
@@ -39,36 +39,36 @@ from . import toly_dialog
 
 
 class Dialog(toly_dialog.ToLyDialog):
-	
+
     def __init__(self, parent=None):
-        
+
         self.imp_prgm = "abc2ly"
         self.userg = "abc_import"
-        
+
         self.nobeamCheck = QCheckBox()
-        
+
         self.impChecks = [self.nobeamCheck]
-        
+
         self.nobeamCheck.setObjectName("import-beaming")
-        
+
         self.impExtra = []
-        
+
         super(Dialog, self).__init__(parent)
-        
+
         app.translateUI(self)
         qutil.saveDialogSize(self, "abc_import/dialog/size", QSize(480, 160))
-        
+
         self.makeCommandLine()
-        
+
         self.loadSettings()
-        
+
     def translateUI(self):
         self.nobeamCheck.setText(_("Import beaming"))
-        
+
         self.buttons.button(QDialogButtonBox.Ok).setText(_("Run abc2ly"))
-        
+
         super(Dialog, self).translateUI()
-    
+
     def makeCommandLine(self):
         """Reads the widgets and builds a command line."""
         cmd = ["$abc2ly"]
@@ -77,7 +77,7 @@ class Dialog(toly_dialog.ToLyDialog):
 
         cmd.append("$filename")
         self.commandLine.setText(' '.join(cmd))
-        
+
     def run_command(self):
         """ABC import (at least for now) needs a specific solution here."""
         cmd = self.getCmd('document.ly')
@@ -110,14 +110,14 @@ class Dialog(toly_dialog.ToLyDialog):
             except IOError:
                 pass
         return stdouterr
-        
+
     def loadSettings(self):
         """Get users previous settings."""
         self.imp_default = [True]
         self.settings = QSettings()
         self.settings.beginGroup('abc_import')
         super(Dialog, self).loadSettings()
-        
+
     def saveSettings(self):
         """Save users last settings."""
         self.settings = QSettings()

--- a/frescobaldi_app/file_import/midi.py
+++ b/frescobaldi_app/file_import/midi.py
@@ -20,7 +20,7 @@
 """
 Import Midi dialog.
 Uses midi2ly to create ly file from midi.
-In the dialog the options of midi2ly can be set. 
+In the dialog the options of midi2ly can be set.
 """
 
 
@@ -35,36 +35,36 @@ from . import toly_dialog
 
 
 class Dialog(toly_dialog.ToLyDialog):
-	
+
     def __init__(self, parent=None):
-        
+
         self.imp_prgm = "midi2ly"
         self.userg = "midi_import"
-        
+
         self.useAbsCheck = QCheckBox()
-        
+
         self.impChecks = [self.useAbsCheck]
-        
+
         self.useAbsCheck.setObjectName("absolute-mode")
-        
+
         self.impExtra = []
-        
+
         super(Dialog, self).__init__(parent)
-        
+
         app.translateUI(self)
         qutil.saveDialogSize(self, "midi_import/dialog/size", QSize(480, 260))
-        
+
         self.makeCommandLine()
-        
+
         self.loadSettings()
-        
+
     def translateUI(self):
         self.useAbsCheck.setText(_("Pitches in absolute mode"))
-        
+
         self.buttons.button(QDialogButtonBox.Ok).setText(_("Run midi2ly"))
-        
+
         super(Dialog, self).translateUI()
-    
+
     def makeCommandLine(self):
         """Reads the widgets and builds a command line."""
         cmd = ["$midi2ly"]
@@ -73,14 +73,14 @@ class Dialog(toly_dialog.ToLyDialog):
 
         cmd.append("$filename")
         self.commandLine.setText(' '.join(cmd))
-        
+
     def loadSettings(self):
         """Get users previous settings."""
         self.imp_default = [False]
         self.settings = QSettings()
         self.settings.beginGroup('midi_import')
         super(Dialog, self).loadSettings()
-        
+
     def saveSettings(self):
         """Save users last settings."""
         self.settings = QSettings()

--- a/frescobaldi_app/file_import/musicxml.py
+++ b/frescobaldi_app/file_import/musicxml.py
@@ -20,7 +20,7 @@
 """
 Import Music XML dialog.
 Uses musicxml2ly to create ly file from xml.
-In the dialog the options of musicxml2ly can be set. 
+In the dialog the options of musicxml2ly can be set.
 """
 
 
@@ -49,51 +49,51 @@ _langlist = [
 
 
 class Dialog(toly_dialog.ToLyDialog):
-	
+
     def __init__(self, parent=None):
-        
+
         self.imp_prgm = "musicxml2ly"
         self.userg = "musicxml_import"
-        
+
         self.noartCheck = QCheckBox()
         self.norestCheck = QCheckBox()
         self.nolayoutCheck = QCheckBox()
         self.nobeamCheck = QCheckBox()
         self.useAbsCheck = QCheckBox()
         self.commMidiCheck = QCheckBox()
-        
+
         self.langCombo = QComboBox()
         self.langLabel = QLabel()
-        
+
         self.impChecks = [self.noartCheck,
                           self.norestCheck,
                           self.nolayoutCheck,
                           self.nobeamCheck,
                           self.useAbsCheck,
                           self.commMidiCheck]
-        
+
         self.noartCheck.setObjectName("articulation-directions")
         self.norestCheck.setObjectName("rest-positions")
         self.nolayoutCheck.setObjectName("page-layout")
         self.nobeamCheck.setObjectName("import-beaming")
         self.useAbsCheck.setObjectName("absolute-mode")
         self.commMidiCheck.setObjectName("comment-out-midi")
-        
+
         self.langCombo.addItem('')
         self.langCombo.addItems(_langlist)
-        
+
         self.impExtra = [self.langLabel, self.langCombo]
-        
+
         super(Dialog, self).__init__(parent)
-        
+
         self.langCombo.currentIndexChanged.connect(self.makeCommandLine)
         app.translateUI(self)
         qutil.saveDialogSize(self, "musicxml_import/dialog/size", QSize(480, 260))
-        
+
         self.makeCommandLine()
-        
+
         self.loadSettings()
-        
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Import Music XML")))
         self.noartCheck.setText(_("Import articulation directions"))
@@ -102,14 +102,14 @@ class Dialog(toly_dialog.ToLyDialog):
         self.nobeamCheck.setText(_("Import beaming"))
         self.useAbsCheck.setText(_("Pitches in absolute mode"))
         self.commMidiCheck.setText(_("Comment out midi block"))
-        
+
         self.langLabel.setText(_("Language for pitch names"))
         self.langCombo.setItemText(0, _("Default"))
-        
+
         self.buttons.button(QDialogButtonBox.Ok).setText(_("Run musicxml2ly"))
-        
+
         super(Dialog, self).translateUI()
-    
+
     def makeCommandLine(self):
         """Reads the widgets and builds a command line."""
         cmd = ["$musicxml2ly"]
@@ -131,7 +131,7 @@ class Dialog(toly_dialog.ToLyDialog):
 
         cmd.append("$filename")
         self.commandLine.setText(' '.join(cmd))
-        
+
     def loadSettings(self):
         """Get users previous settings."""
         self.imp_default = [False, False, False, False, False, False]
@@ -144,7 +144,7 @@ class Dialog(toly_dialog.ToLyDialog):
         except ValueError:
             index = -1
         self.langCombo.setCurrentIndex(index + 1)
-        
+
     def saveSettings(self):
         """Save users last settings."""
         self.settings = QSettings()

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -36,24 +36,24 @@ import widgets
 
 
 class ToLyDialog(QDialog):
-	
+
     def __init__(self, parent=None):
         super(ToLyDialog, self).__init__(parent)
         self._info = None
         self._document = None
         self._path = None
-        
+
         mainLayout = QGridLayout()
         self.setLayout(mainLayout)
-        
+
         tabs = QTabWidget()
-        
+
         import_tab = QWidget()
         post_tab = QWidget()
-        
+
         itabLayout = QGridLayout(import_tab)
         ptabLayout = QGridLayout(post_tab)
-        
+
         tabs.addTab(import_tab, self.imp_prgm)
         tabs.addTab(post_tab, "after import")
 
@@ -66,54 +66,54 @@ class ToLyDialog(QDialog):
                            self.trimDurCheck,
                            self.removeScalesCheck,
                            self.runEngraverCheck]
-                           
+
         self.versionLabel = QLabel()
         self.lilyChooser = lilychooser.LilyChooser()
 
         self.commandLineLabel = QLabel()
         self.commandLine = QTextEdit(acceptRichText=False)
-        
+
         self.formatCheck.setObjectName("reformat")
         self.trimDurCheck.setObjectName("trim-durations")
         self.removeScalesCheck.setObjectName("remove-scaling")
         self.runEngraverCheck.setObjectName("engrave-directly")
-        
+
         self.buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         userguide.addButton(self.buttons, self.userg)
-        
+
         row = 0
         for r, w in enumerate(self.impChecks):
             row += r
             itabLayout.addWidget(w, row, 0, 1, 2)
             w.toggled.connect(self.makeCommandLine)
-        row += 1    
+        row += 1
         for r, w in enumerate(self.impExtra):
-            row += r 
+            row += r
             itabLayout.addWidget(w, row, 0, 1, 2)
-        
+
         itabLayout.addWidget(widgets.Separator(), row + 1, 0, 1, 2)
         itabLayout.addWidget(self.versionLabel, row + 2, 0, 1, 0)
         itabLayout.addWidget(self.lilyChooser, row + 3, 0, 1, 2)
         itabLayout.addWidget(widgets.Separator(), row + 4, 0, 1, 2)
         itabLayout.addWidget(self.commandLineLabel, row + 5, 0, 1, 2)
         itabLayout.addWidget(self.commandLine, row + 6, 0, 1, 2)
-        
+
         ptabLayout.addWidget(self.formatCheck, 0, 0, 1, 2)
-        ptabLayout.addWidget(self.trimDurCheck, 1, 0, 1, 2)       
+        ptabLayout.addWidget(self.trimDurCheck, 1, 0, 1, 2)
         ptabLayout.addWidget(self.removeScalesCheck, 2, 0, 1, 2)
         ptabLayout.addWidget(self.runEngraverCheck, 3, 0, 1, 2)
         ptabLayout.setRowStretch(4, 10)
-        
+
         mainLayout.addWidget(tabs, 0, 0, 9, 2)
         mainLayout.addWidget(self.buttons, 10, 0, 1, 2)
-        
+
         self.buttons.accepted.connect(self.accept)
         self.buttons.rejected.connect(self.reject)
-        
+
         self.lilyChooser.currentIndexChanged.connect(self.slotLilyPondVersionChanged)
         self.slotLilyPondVersionChanged()
-    
+
     def translateUI(self):
         self.versionLabel.setText(_("LilyPond version:"))
         self.commandLineLabel.setText(_("Command line:"))
@@ -121,14 +121,14 @@ class ToLyDialog(QDialog):
         self.trimDurCheck.setText(_("Trim durations (Make implicit per line)"))
         self.removeScalesCheck.setText(_("Remove fraction duration scaling"))
         self.runEngraverCheck.setText(_("Engrave directly"))
-    
+
     def setDocument(self, path):
         """Set the full path to the MusicXML document."""
         self._document = path
-        
+
     def slotLilyPondVersionChanged(self):
         self._info = self.lilyChooser.lilyPondInfo()
-    
+
     def getCmd(self, outputname='-'):
         """Returns the command line."""
         cmd = []
@@ -145,7 +145,7 @@ class ToLyDialog(QDialog):
                 cmd.append(t)
         cmd.extend(['--output', outputname])
         return cmd
-        
+
     def run_command(self):
         """Run command line."""
         cmd = self.getCmd()
@@ -172,14 +172,14 @@ class ToLyDialog(QDialog):
             stderr = subprocess.PIPE)
         stdouterr = proc.communicate()
         return stdouterr
-		
+
     def getPostSettings(self):
         """Returns settings in the post import tab."""
         post = []
         for p in self.postChecks:
             post.append(p.isChecked())
         return post
-        
+
     def loadSettings(self):
         """Get users previous settings."""
         post_default = [True, False, False, True]
@@ -187,7 +187,7 @@ class ToLyDialog(QDialog):
             i.setChecked(self.settings.value(i.objectName(), d, bool))
         for p, f in zip(self.postChecks, post_default):
             p.setChecked(self.settings.value(p.objectName(), f, bool))
-        
+
     def saveSettings(self):
         """Save users last settings."""
         for i in self.impChecks:

--- a/frescobaldi_app/filecache.py
+++ b/frescobaldi_app/filecache.py
@@ -28,13 +28,13 @@ import weakref
 
 class FileCache(object):
     """Caches information about files, and checks the mtime upon request.
-    
+
     Has __setitem__, __getitem__, __delitem__, clear etc. methods like a dict.
-    
+
     """
     def __init__(self):
         self._cache = {}
-        
+
     def __getitem__(self, filename):
         mtime, value = self._cache[filename]
         try:
@@ -44,30 +44,30 @@ class FileCache(object):
             pass
         del self._cache[filename]
         raise KeyError
-    
+
     def __setitem__(self, filename, value):
         try:
             self._cache[filename] = (os.path.getmtime(filename), value)
         except (IOError, OSError):
             pass
-    
+
     def __delitem__(self, filename):
         del self._cache[filename]
-        
+
     def __contains__(self, filename):
         try:
             self[filename]
             return True
         except KeyError:
             return False
-    
+
     def filename(self, value):
         """Returns the filename of the cached value (if available)."""
         for filename in self.filenames():
             mtime, obj = self._cache[filename]
             if obj == value:
                 return filename
-        
+
     def filenames(self):
         """Yields filenames that are still valid in the cache."""
         for filename in list(self._cache):
@@ -76,17 +76,17 @@ class FileCache(object):
                 yield filename
             except KeyError:
                 pass
-                
+
     def clear(self):
         self._cache.clear()
 
 
 class WeakFileCache(FileCache):
     """Caches information about files like FileCache, but with a weak reference.
-    
+
     This means the object is discarded if you don't keep a reference to it
     elsewhere.
-    
+
     """
     def __getitem__(self, filename):
         mtime, valueref = self._cache[filename]
@@ -99,7 +99,7 @@ class WeakFileCache(FileCache):
                 pass
         del self._cache[filename]
         raise KeyError
-    
+
     def __setitem__(self, filename, value):
         valueref = weakref.ref(value)
         try:

--- a/frescobaldi_app/fileinfo.py
+++ b/frescobaldi_app/fileinfo.py
@@ -89,13 +89,13 @@ def music(filename):
         import music
         c.music = music.Document(c.document)
     return c.music
-    
+
 
 def textmode(text, guess=True):
     """Returns the type of the given text ('lilypond, 'html', etc.).
-    
+
     Checks the mode variable and guesses otherwise if guess is True.
-    
+
     """
     mode = variables.variables(text).get("mode")
     if mode in ly.lex.modes:
@@ -106,20 +106,20 @@ def textmode(text, guess=True):
 
 def includefiles(dinfo, include_path=()):
     """Returns a set of filenames that are included by the DocInfo's document.
-        
-    The specified include path is used to find files. The own filename 
-    is NOT added to the set. Included files are checked recursively, 
-    relative to our file, relative to the including file, and if that 
+
+    The specified include path is used to find files. The own filename
+    is NOT added to the set. Included files are checked recursively,
+    relative to our file, relative to the including file, and if that
     still yields no file, relative to the directories in the include_path.
-    
-    If the document has no local filename, only the include_path is 
+
+    If the document has no local filename, only the include_path is
     searched for files.
-    
+
     """
     filename = dinfo.document.filename
     basedir = os.path.dirname(filename) if filename else None
     files = set()
-    
+
     def tryarg(directory, arg):
         path = os.path.realpath(os.path.join(directory, arg))
         if path not in files and os.path.isfile(path):
@@ -127,7 +127,7 @@ def includefiles(dinfo, include_path=()):
             args = docinfo(path).include_args()
             find(args, os.path.dirname(path))
             return True
-            
+
     def find(incl_args, directory):
         for arg in incl_args:
             # new, recursive, relative include
@@ -138,25 +138,25 @@ def includefiles(dinfo, include_path=()):
                     for p in include_path:
                         if tryarg(p, arg):
                             break
-    
+
     find(dinfo.include_args(), basedir)
     return files
 
 
 def basenames(dinfo, includefiles=(), filename=None, replace_suffix=True):
     """Returns the list of basenames a document is expected to create.
-    
+
     The list is created based on includefiles and the define output-suffix and
     \bookOutputName and \bookOutputSuffix commands.
     You should add '.ext' and/or '-[0-9]+.ext' to find created files.
-    
-    If filename is given, it is regarded as the filename LilyPond is run on. 
+
+    If filename is given, it is regarded as the filename LilyPond is run on.
     Otherwise, the filename of the info's document is read.
-    
-    If replace_suffix is True (the default), special characters and spaces 
-    in the suffix are replaced with underscores (in the same way as LilyPond 
+
+    If replace_suffix is True (the default), special characters and spaces
+    in the suffix are replaced with underscores (in the same way as LilyPond
     does it), using the replace_suffix_chars() function.
-    
+
     """
     basenames = []
     basepath = os.path.splitext(filename or dinfo.document.filename)[0]
@@ -164,12 +164,12 @@ def basenames(dinfo, includefiles=(), filename=None, replace_suffix=True):
 
     if basepath:
         basenames.append(basepath)
-    
+
     def args():
         yield dinfo.output_args()
         for filename in includefiles:
             yield docinfo(filename).output_args()
-                
+
     for type, arg in itertools.chain.from_iterable(args()):
         if type == "suffix":
             if replace_suffix:
@@ -184,10 +184,10 @@ def basenames(dinfo, includefiles=(), filename=None, replace_suffix=True):
 
 def replace_suffix_chars(s):
     """Replace spaces and most non-alphanumeric characters with underscores.
-    
+
     This is used to mimic the behaviour of LilyPond, which also does this,
     for the output-suffix. (See scm/lily-library.scm:223.)
-    
+
     """
     return _suffix_chars_re.sub('_', s)
 

--- a/frescobaldi_app/fileprinter.py
+++ b/frescobaldi_app/fileprinter.py
@@ -37,10 +37,10 @@ lpr_commands = (
 
 def lprCommand():
     """Returns a suitable 'lpr'-like command to send a file to the printer queue.
-    
+
     Returns None if no such command could be found.
     Prefers the CUPS command 'lpr' or 'lp' if it can be found.
-    
+
     """
     paths = os.environ.get("PATH", os.defpath).split(os.pathsep)
     for cmd, path in itertools.product(lpr_commands, paths):
@@ -50,21 +50,21 @@ def lprCommand():
 
 def printCommand(cmd, printer, filename):
     """Returns a commandline (list) to print a PDF file.
-    
+
     cmd:      "lpr" or "lp" (or something like that)
     printer:  a QPrinter instance
     filename: the filename of the PDF document to print.
-    
+
     """
     command = [cmd]
-    
+
     # printer name
     if cmd == "lp":
         command.append('-d')
     else:
         command.append('-P')
     command.append(printer.printerName())
-    
+
     # copies
     numCopies = 1
     try:
@@ -74,20 +74,20 @@ def printCommand(cmd, printer, filename):
             numCopies = printer.actualNumCopies()
         except AttributeError: # only in Qt >= 4.6
             numCopies = printer.numCopies()
-    
+
     if cmd == "lp":
         command.append('-n')
         command.append(format(numCopies))
     else:
         command.append('-#{0}'.format(numCopies))
-    
+
     # job name
     if cmd == "lp":
         command.append('-t')
     else:
         command.append('-J')
     command.append(printer.docName() or os.path.basename(filename))
-    
+
     # page range
     if printer.printRange() == QPrinter.PageRange:
         pageRange = "{0}-{1}".format(printer.fromPage(), printer.toPage())
@@ -97,13 +97,13 @@ def printCommand(cmd, printer, filename):
         else:
             command.append('-o')
             command.append('page-ranges=' + pageRange)
-    
+
     # duplex mode
     if printer.duplex() == QPrinter.DuplexLongSide:
         command.extend(['-o', 'sides=two-sided-long-edge'])
     elif printer.duplex() == QPrinter.DuplexShortSide:
         command.extend(['-o', 'sides=two-sided-short-edge'])
-    
+
     command.append(filename)
     return command
 

--- a/frescobaldi_app/folding.py
+++ b/frescobaldi_app/folding.py
@@ -42,7 +42,7 @@ class Folder(widgets.folding.Folder):
                 yield widgets.folding.START
             elif isinstance(t, (ly.lex.Dedent, ly.lex.BlockCommentEnd)):
                 yield widgets.folding.STOP
-    
+
     def mark(self, block, state=None):
         if state is None:
             try:

--- a/frescobaldi_app/gadgets/arbitraryhighlighter.py
+++ b/frescobaldi_app/gadgets/arbitraryhighlighter.py
@@ -32,25 +32,25 @@ from PyQt5.QtWidgets import QTextEdit
 
 class ArbitraryHighlighter(QObject):
     """Manages highlighting of arbitrary sections in a Q(Plain)TextEdit.
-    
+
     Stores and highlights lists of QTextCursors on a per-format basis.
-    
+
     """
     def __init__(self, edit):
         """Initializes ourselves with a Q(Plain)TextEdit as parent."""
         QObject.__init__(self, edit)
         self._selections = {}
         self._formats = {} # store the QTextFormats
-    
+
     def highlight(self, format, cursors, priority=0, msec=0):
         """Highlights the selection of an arbitrary list of QTextCursors.
-        
+
         format can be a name for a predefined text format or a QTextCharFormat;
         in the first case the textFormat() method should return a qtextformat to use.
         priority determines the order of drawing, highlighting with higher priority
         is drawn over highlighting with lower priority.
         msec, if > 0, removes the highlighting after that many milliseconds.
-        
+
         """
         if isinstance(format, QTextFormat):
             fmt = format

--- a/frescobaldi_app/gadgets/borderlayout.py
+++ b/frescobaldi_app/gadgets/borderlayout.py
@@ -27,38 +27,38 @@ from PyQt5.QtCore import QEvent, QObject, QPoint, QRect, QSize
 LEFT, TOP, RIGHT, BOTTOM = 0, 1, 2, 3
 
 class BorderLayout(QObject):
-    
+
     # order in which the widget spaces are filled.
     # if top and bottom are first, they get the full width.
     order = TOP, BOTTOM, LEFT, RIGHT
-    
+
     def __init__(self, scrollarea):
         super(BorderLayout, self).__init__(scrollarea)
         self._resizing = False
         self._margins = 0, 0, 0, 0
         self._widgets = ([], [], [], [])
         scrollarea.viewport().installEventFilter(self)
-    
+
     @classmethod
     def get(cls, scrollarea):
         """Gets the BorderLayout for the given scrollarea.
-        
+
         If None exists, creates and returns a new instance.
-        
+
         """
         for c in scrollarea.children():
             if type(c) is cls:
                 return c
         return cls(scrollarea)
-    
+
     def scrollarea(self):
         """Returns our scrollarea instance (our parent)."""
         return self.parent()
-    
+
     def addWidget(self, widget, side):
         """Adds a widget to our scrollarea."""
         self.insertWidget(widget, side, -1)
-        
+
     def insertWidget(self, widget, side, position):
         """Inserts a widget in a specific position."""
         assert side in (LEFT, TOP, RIGHT, BOTTOM)
@@ -78,7 +78,7 @@ class BorderLayout(QObject):
         if new:
             widget.show()
         self.updateGeometry()
-            
+
     def removeWidget(self, widget):
         """Removes the widget, it is not deleted."""
         for l in self._widgets:
@@ -87,7 +87,7 @@ class BorderLayout(QObject):
                 widget.removeEventFilter(self)
                 widget.setParent(None)
                 self.updateGeometry()
-    
+
     def setViewportMargins(self, left, top, right, bottom):
         """(Internal) Sets the viewport margins and remembers them."""
         self._margins = (left, top, right, bottom)
@@ -97,13 +97,13 @@ class BorderLayout(QObject):
             # this can happen when the scrollarea already is deleted by Python
             # because setViewportMargins is a protected method
             pass
-    
+
     def viewportGeometry(self):
         """(Internal) Returns the viewport geometry as if with 0 margins."""
         g = self.scrollarea().viewport().geometry()
         left, top, right, bottom = self._margins
         return g.adjusted(-left, -top, right, bottom)
-        
+
     def eventFilter(self, obj, ev):
         """Reimplemented to handle resizes and avoid resize loops."""
         if self._resizing:
@@ -120,7 +120,7 @@ class BorderLayout(QObject):
                     self.updateGeometry()
                     break
         return False
-    
+
     def updateGeometry(self):
         """(Internal) Positions all widgets in the scrollarea edges."""
         self._resizing = True
@@ -128,7 +128,7 @@ class BorderLayout(QObject):
         pos = g.topLeft()
         size = g.size()
         left, right, top, bottom = 0, 0, 0, 0
-        
+
         for side in self.order:
             def widgets():
                 for w in self._widgets[side][::-1]:

--- a/frescobaldi_app/gadgets/cursorkeys.py
+++ b/frescobaldi_app/gadgets/cursorkeys.py
@@ -28,32 +28,32 @@ from PyQt5.QtGui import QKeySequence, QTextCursor
 
 class KeyPressHandler(QObject):
     """Handles various keypress events in a configurable way.
-    
+
     Instance attributes (default at class level):
-    
+
     handle_home (False):    handles the Home/Shift Home keys so that initial
                             whitespace is skipped
-    
+
     handle_horizontal (False): don't move to the previous or next
                             block when using the horizontal arrow keys
-    
+
     handle_vertical (False): go to the end of a block when Down or PageDown
                             is pressed in the last block, or Up or PageUp in the
                             first block.
-                            
+
     """
-    
+
     # special home/shift home behaviour
     handle_home = False
-    
+
     # stay in block on horizontal arrow keys
     handle_horizontal = False
-    
+
     # go to first character when Up or PgUp pressed in first block, or to
     # last character when Dn or PgDn is pressed in the last block.
     handle_vertical = False
-    
-    
+
+
     def eventFilter(self, obj, ev):
         """Reimplemented to dispatch keypress events to the handle() method."""
         if ev.type() == QEvent.KeyPress:
@@ -62,12 +62,12 @@ class KeyPressHandler(QObject):
 
     def handle(self, edit, ev):
         """Return True or False, handling the event if applicable.
-        
+
         This method is called by eventFilter() for KeyPress events.
-        
+
         edit: Q(Plain)TextEdit instance
         ev: the KeyPress QEvent
-        
+
         """
         result = None
         if self.handle_home:
@@ -76,16 +76,16 @@ class KeyPressHandler(QObject):
             result = self.handleHorizontal(edit, ev)
         if result is None and self.handle_vertical:
             result = self.handleVertical(edit, ev)
-        
+
         return bool(result) # None becomes False
-    
+
     def handleHome(self, edit, ev):
         """Return None, False or True.
-        
+
         None when Home was not pressed,
         True when the event was handled,
         False when the event was not handled and should be handled normally.
-        
+
         """
         home = ev == QKeySequence.MoveToStartOfLine
         s_home = ev == QKeySequence.SelectStartOfLine
@@ -100,14 +100,14 @@ class KeyPressHandler(QObject):
                 edit.setTextCursor(cursor)
                 return True
             return False
-        
+
     def handleHorizontal(self, edit, ev):
         """Return None, False or True.
-        
+
         None when no horizontal arrow key was pressed,
         True when the event was handled,
         False when the event was not handled and should be handled normally.
-        
+
         """
         if ev == QKeySequence.MoveToNextChar or ev == QKeySequence.SelectNextChar:
             return edit.textCursor().atBlockEnd()
@@ -116,11 +116,11 @@ class KeyPressHandler(QObject):
 
     def handleVertical(self, edit, ev):
         """Return None, False or True.
-        
+
         None when no horizontal arrow key was pressed,
         True when the event was handled,
         False when the event was not handled and should be handled normally.
-        
+
         """
         cursor = edit.textCursor()
         pos = cursor.position()

--- a/frescobaldi_app/gadgets/customtooltip.py
+++ b/frescobaldi_app/gadgets/customtooltip.py
@@ -47,7 +47,7 @@ def hide():
         _widget.hide()
         _widget = None
         QApplication.instance().removeEventFilter(_handler)
-    
+
 def show(widget, pos=None, timeout=10000):
     """Show the widget at position."""
     if pos is None:
@@ -61,7 +61,7 @@ def show(widget, pos=None, timeout=10000):
         if _handler is None:
             _handler = EventHandler()
         QApplication.instance().installEventFilter(_handler)
-    
+
     # where to display the tooltip
     screen = QApplication.desktop().availableGeometry(pos)
     x = pos.x() + 2
@@ -78,7 +78,7 @@ def show(widget, pos=None, timeout=10000):
     if widget.windowFlags() & Qt.ToolTip != Qt.ToolTip:
         widget.setWindowFlags(Qt.ToolTip)
         widget.ensurePolished()
-    
+
     widget.show()
     _widget = widget
     _timer.start(timeout)

--- a/frescobaldi_app/gadgets/drag.py
+++ b/frescobaldi_app/gadgets/drag.py
@@ -29,22 +29,22 @@ from PyQt5.QtWidgets import QApplication, QFileIconProvider
 
 class ComboDrag(QObject):
     """Enables dragging from a QComboBox.
-    
+
     Instantiate this with a QComboBox as parent to enable dragging the
     current item.
-    
+
     By default, drags a filename got from the current index under the
     Qt.EditRole. Change the role by changing the 'role' instance attribute.
-    
+
     """
     column = 0
     role = Qt.EditRole
-    
+
     def __init__(self, combobox):
         super(ComboDrag, self).__init__(combobox)
         self._dragpos = None
         combobox.installEventFilter(self)
-    
+
     def eventFilter(self, combobox, ev):
         if ev.type() == QEvent.MouseButtonPress and ev.button() == Qt.LeftButton:
             self._dragpos = ev.pos()
@@ -56,14 +56,14 @@ class ComboDrag(QObject):
             and ev.button() == Qt.LeftButton and not combobox.isEditable()):
             combobox.mousePressEvent(ev)
         return False
-    
+
     def mouseMoved(self, combobox, pos):
         if (self._dragpos is not None
             and (pos - self._dragpos).manhattanLength()
                 >= QApplication.startDragDistance()):
             self.startDrag(combobox)
             return True
-    
+
     def startDrag(self, combobox):
         index = combobox.model().index(combobox.currentIndex(), self.column)
         filename = combobox.model().data(index, self.role)
@@ -73,7 +73,7 @@ class ComboDrag(QObject):
 
 class Dragger(QObject):
     """Drags anything from any widget.
-    
+
     Use dragger.installEventFilter(widget) to have it drag.
 
     """
@@ -82,7 +82,7 @@ class Dragger(QObject):
         self._dragpos = None
         if parent:
             parent.installEventFilter(self)
-        
+
     def eventFilter(self, widget, ev):
         if ev.type() == QEvent.MouseButtonPress and ev.button() == Qt.LeftButton:
             self._dragpos = ev.pos()
@@ -90,14 +90,14 @@ class Dragger(QObject):
         elif ev.type() == QEvent.MouseMove and ev.buttons() & Qt.LeftButton:
             return self.mouseMoved(widget, ev.pos()) or False
         return False
-    
+
     def mouseMoved(self, widget, pos):
         if (self._dragpos is not None
             and (pos - self._dragpos).manhattanLength()
                 >= QApplication.startDragDistance()):
             self.startDrag(widget)
             return True
-    
+
     def startDrag(self, widget):
         """Reimplement to start a drag."""
 
@@ -105,7 +105,7 @@ class Dragger(QObject):
 class FileDragger(Dragger):
     def filename(self):
         """Should return the filename to drag."""
-    
+
     def startDrag(self, widget):
         filename = self.filename()
         if filename:

--- a/frescobaldi_app/gadgets/indenter.py
+++ b/frescobaldi_app/gadgets/indenter.py
@@ -35,35 +35,35 @@ class Indenter(QObject):
     When instantiated it automatically installs itself
     as an event filter for the textedit, catching some
     keypresses:
-    
+
     Return:
         enters a newline and the same indent as the current line
     Tab:
         indents the current line
     Backtab:
         dedents the current line
-    
+
     These instance attributes may be set:
-    
+
     indentWidth:
         how many characters to indent (default 2)
     indentChar:
         which character to use (default " ")
-    
+
     """
 
     indentWidth = 2
     indentChar = ' '
-    
+
     def __init__(self, textedit):
         """Installs ourselves as event filter for textedit.
-        
+
         The textedit also becomes our parent.
-        
+
         """
         super(Indenter, self).__init__(textedit)
         textedit.installEventFilter(self)
-    
+
     def eventFilter(self, edit, ev):
         """Handles Return, Tab and Backtab."""
         if ev.type() == QEvent.KeyPress:
@@ -85,12 +85,12 @@ class Indenter(QObject):
         """Inserts a newline and then the same indent as the current line."""
         indent = self.get_indent(cursor)
         cursor.insertText('\n' + indent)
-    
+
     def get_indent(self, cursor):
         """Returns the whitespace with which the current line starts."""
         text = cursor.document().findBlock(cursor.selectionStart()).text()
         return text[:len(text) - len(text.lstrip())]
-        
+
     def indent(self, cursor):
         """Indents the line with the cursor or the selected lines (one step more)."""
         with compress_undo(cursor):
@@ -98,7 +98,7 @@ class Indenter(QObject):
                 cursor.setPosition(block.position())
                 cursor.setPosition(block.position() + len(self.get_indent(cursor)))
                 cursor.insertText(self.indentChar * self.indentWidth)
-    
+
     def dedent(self, cursor):
         """Dedents the line with the cursor or the selected lines (one step less)."""
         with compress_undo(cursor):

--- a/frescobaldi_app/gadgets/matcher.py
+++ b/frescobaldi_app/gadgets/matcher.py
@@ -29,44 +29,44 @@ from PyQt5.QtWidgets import QTextEdit
 
 class Matcher(QObject):
     """Highlights matching characters in a textedit.
-    
+
     The following attributes are available at the class level,
     and may be overridden by setting them as instance attributes:
-    
+
     matchPairs: a string of characters that match in pairs with each other
                 default: "{}()[]"
     format:     a QTextCharFormat used to highlight matching characters with
                 default: a red foreground color
     time:       how many milliseconds to show the highlighting (0=forever)
                 default: 2000
-    
+
     """
-    
+
     matchPairs = "{}()[]"
     format = QTextCharFormat()
     format.setForeground(Qt.red)
     time = 2000
-    
+
     def __init__(self, edit):
         """Initialize the Matcher; edit is a Q(Plain)TextEdit instance."""
         super(Matcher, self).__init__(edit)
         self._timer = QTimer(singleShot=True, timeout=self.clear)
         edit.cursorPositionChanged.connect(self.slotCursorPositionChanged)
-    
+
     def edit(self):
         """Returns our Q(Plain)TextEdit."""
         return self.parent()
-    
+
     def slotCursorPositionChanged(self):
         """Called whenever the cursor position changes.
-        
+
         Highlights matching characters if the cursor is at one of them.
-        
+
         """
         cursor = self.edit().textCursor()
         block = cursor.block()
         text = block.text()
-        
+
         # try both characters at the cursor
         col = cursor.position() - block.position()
         end = col + 1
@@ -78,11 +78,11 @@ class Matcher(QObject):
         else:
             self.clear()
             return
-        
+
         # the cursor is at a character from matchPairs
         i = self.matchPairs.index(c)
         cursor.setPosition(block.position() + col)
-        
+
         # find the matching character
         new = QTextCursor(cursor)
         if i & 1:
@@ -94,7 +94,7 @@ class Matcher(QObject):
             match = self.matchPairs[i+1]
             flags = QTextDocument.FindFlags()
             new.movePosition(QTextCursor.Right)
-        
+
         # search, also nesting
         rx = QRegExp(QRegExp.escape(c) + '|' + QRegExp.escape(match))
         nest = 0
@@ -106,7 +106,7 @@ class Matcher(QObject):
             nest += 1 if new.selectedText() == c else -1
         cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
         self.highlight([cursor, new])
-    
+
     def highlight(self, cursors):
         """Highlights the selections of the specified QTextCursor instances."""
         selections = []
@@ -118,7 +118,7 @@ class Matcher(QObject):
         self.edit().setExtraSelections(selections)
         if self.time and selections:
             self._timer.start(self.time)
-    
+
     def clear(self):
         """Removes the highlighting."""
         self.edit().setExtraSelections([])

--- a/frescobaldi_app/gadgets/matcher_ah.py
+++ b/frescobaldi_app/gadgets/matcher_ah.py
@@ -25,9 +25,9 @@ using an ArbitraryHighlighter.
 from . import matcher
 
 class Matcher(matcher.Matcher):
-    
+
     priority = 0
-    
+
     def __init__(self, highlighter):
         """Initialize the Matcher; highlighter is an ArbitraryHighlighter instance."""
         super(matcher.Matcher, self).__init__(highlighter)
@@ -36,11 +36,11 @@ class Matcher(matcher.Matcher):
     def edit(self):
         """Reimplemented to return the parent of our parent:)"""
         return self.parent().parent()
-    
+
     def highlight(self, cursors):
         """Highlights the selections of the specified QTextCursor instances."""
         self.parent().highlight(self.format, cursors, self.priority, self.time)
-    
+
     def clear(self):
         """Removes the highlighting."""
         self.parent().clear(self.format)

--- a/frescobaldi_app/gadgets/toolboxwheeler.py
+++ b/frescobaldi_app/gadgets/toolboxwheeler.py
@@ -32,13 +32,13 @@ class ToolBoxWheeler(QObject):
         super(ToolBoxWheeler, self).__init__(toolbox)
         self._wheeldelta = 0
         toolbox.installEventFilter(self)
-    
+
     def eventFilter(self, toolbox, ev):
         if ev.type() == QEvent.Wheel and ev.modifiers() & Qt.CTRL:
             self.wheelEvent(toolbox, ev)
             return True
         return False
-        
+
     def wheelEvent(self, toolbox, ev):
         self._wheeldelta -= ev.angleDelta().y()
         steps, self._wheeldelta = divmod(self._wheeldelta, 120)

--- a/frescobaldi_app/gadgets/wordboundary.py
+++ b/frescobaldi_app/gadgets/wordboundary.py
@@ -58,40 +58,40 @@ _move_operations = (
 
 
 class BoundaryHandler(QObject):
-    
+
     _double_click_time = 0.0
     word_regexp = re.compile(r'\\?\w+|^|$', re.UNICODE)
-    
+
     def boundaries(self, block):
         """Return a list of tuples specifying the position of words in the block.
-        
+
         Each tuple denotes the start and end position of a "word" in the
         specified block.
-        
+
         You can return other boundaries by changing the word_regexp or by
         inheriting from this class and overwriting this method.
-        
+
         """
         return [m.span() for m in self.word_regexp.finditer(block.text())]
-    
+
     def left_boundaries(self, block):
         left = operator.itemgetter(0)
         return [left(b) for b in self.boundaries(block)]
-        
+
     def right_boundaries(self, block):
         right = operator.itemgetter(1)
         return [right(b) for b in self.boundaries(block)]
-        
+
     def move(self, cursor, operation, mode=QTextCursor.MoveAnchor, n=1):
         """Reimplements Word-related cursor operations:
-        
+
         StartOfWord
         PreviousWord
         WordLeft
         EndOfWord
         NextWord
         WordRight
-        
+
         Other move operations are delegated to the QTextCursor itself.
         """
         block = cursor.block()
@@ -139,12 +139,12 @@ class BoundaryHandler(QObject):
                 boundaries = self.left_boundaries(block)
         else:
             return cursor.movePosition(operation, mode, n)
-        
+
     def select(self, cursor, selection):
         """Reimplements the WordUnderCursor selection type.
-        
+
         Other selection types are delegated to the QTextCursor itself.
-        
+
         """
         if selection == QTextCursor.WordUnderCursor:
             self.move(cursor, QTextCursor.StartOfWord)
@@ -156,17 +156,17 @@ class BoundaryHandler(QObject):
         """Install ourselves as event filter on the textedit and its viewport."""
         edit.installEventFilter(self)
         edit.viewport().installEventFilter(self)
-    
+
     def remove_textedit(self, edit):
         """Remove ourselves as event filter from the textedit and its viewport."""
         edit.removeEventFilter(self)
         edit.viewport().removeEventFilter(self)
-    
+
     def get_textedit(self, obj):
         """Return the textedit widget if obj is its viewport.
-        
+
         If obj is not the viewport of its parent, obj itself is returned.
-        
+
         """
         parent = obj.parent()
         try:
@@ -175,7 +175,7 @@ class BoundaryHandler(QObject):
         except AttributeError:
             pass
         return obj
-    
+
     def eventFilter(self, obj, ev):
         """Intercept key events from a Q(Plain)TextEdit and handle them."""
         if ev.type() == QEvent.KeyPress:
@@ -184,7 +184,7 @@ class BoundaryHandler(QObject):
             edit = self.get_textedit(obj)
             return self.mouseDoubleClickEvent(edit, ev)
         return False
-    
+
     def keyPressEvent(self, obj, ev):
         """Handles the Word-related key events for the Q(Plain)TextEdit."""
         c = obj.textCursor()

--- a/frescobaldi_app/globalfontdialog.py
+++ b/frescobaldi_app/globalfontdialog.py
@@ -37,29 +37,29 @@ class GlobalFontDialog(widgets.dialog.Dialog):
     def __init__(self, parent=None):
         super(GlobalFontDialog, self).__init__(parent)
         self._messageLabel.setWordWrap(True)
-        
+
         layout = QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.mainWidget().setLayout(layout)
-        
+
         self.romanLabel = QLabel()
         self.romanCombo = QFontComboBox()
         self.sansLabel = QLabel()
         self.sansCombo = QFontComboBox()
         self.typewriterLabel = QLabel()
         self.typewriterCombo = QFontComboBox(fontFilters=QFontComboBox.MonospacedFonts)
-        
+
         layout.addWidget(self.romanLabel, 0, 0)
         layout.addWidget(self.romanCombo, 0, 1, 1, 2)
         layout.addWidget(self.sansLabel, 1, 0)
         layout.addWidget(self.sansCombo, 1, 1, 1, 2)
         layout.addWidget(self.typewriterLabel, 2, 0)
         layout.addWidget(self.typewriterCombo, 2, 1, 1, 2)
-        
+
         self.loadSettings()
         self.finished.connect(self.saveSettings)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Global Fonts")))
         self.setMessage(_(
@@ -69,25 +69,25 @@ class GlobalFontDialog(widgets.dialog.Dialog):
         self.romanLabel.setText(_("Roman Font:"))
         self.sansLabel.setText(_("Sans Font:"))
         self.typewriterLabel.setText(_("Typewriter Font:"))
-    
+
     def romanFont(self):
         return self.romanCombo.currentFont().family()
-    
+
     def setromanFont(self, family):
         self.romanCombo.setCurrentFont(QFont(family))
-    
+
     def sansFont(self):
         return self.sansCombo.currentFont().family()
-    
+
     def setSansFont(self, family):
         self.sansCombo.setCurrentFont(QFont(family))
-    
+
     def typewriterFont(self):
         return self.typewriterCombo.currentFont().family()
-    
+
     def settypewriterFont(self, family):
         self.typewriterCombo.setCurrentFont(QFont(family))
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("global_font_dialog")
@@ -97,7 +97,7 @@ class GlobalFontDialog(widgets.dialog.Dialog):
         self.sansCombo.setCurrentFont(QFont(sans))
         typewriter = s.value("typewriter", "monospace", str)
         self.typewriterCombo.setCurrentFont(QFont(typewriter))
-    
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup("global_font_dialog")

--- a/frescobaldi_app/guistyle.py
+++ b/frescobaldi_app/guistyle.py
@@ -37,7 +37,7 @@ def keys():
 
 def setStyle():
     global _system_default
-    
+
     style = QSettings().value("guistyle", "", str).lower()
     if style not in keys():
         style = _system_default
@@ -48,7 +48,7 @@ def setStyle():
 def initialize():
     """Initializes the GUI style setup. Called op app startup."""
     global _system_default
-    
+
     _system_default = app.qApp.style().objectName()
     app.settingsChanged.connect(setStyle)
     setStyle()

--- a/frescobaldi_app/helpers.py
+++ b/frescobaldi_app/helpers.py
@@ -33,26 +33,26 @@ from PyQt5.QtWidgets import QMessageBox
 
 def shell_split(cmd):
     """Split a string like the UNIX shell, returning a list.
-    
+
     Double quoted parts are kept together with the quotes removed.
-    
+
     """
     # remove double quotes, keeping quoted parts together
     # (because shlex does not yet work with unicode...)
-    return [item.replace('"', '') for item in 
+    return [item.replace('"', '') for item in
         re.findall(r'[^\s"]*"[^"]*"[^\s"]*|[^\s"]+', cmd)]
 
 
 def command(type):
     """Returns the command for the specified type as a list.
-    
+
     Returns None if no command was specified.
-    
+
     """
     cmd = QSettings().value("helper_applications/" + type, "")
     if not cmd:
         return
-    
+
     if os.path.isabs(cmd) and os.access(cmd, os.X_OK):
         return [cmd]
 
@@ -74,7 +74,7 @@ def openUrl(url, type="browser"):
             type = "image"
         elif ext in ('.midi', '.mid'):
             type = "midi"
-    
+
     # get the command
     cmd = command(type)
     if not cmd:
@@ -83,15 +83,15 @@ def openUrl(url, type="browser"):
             return
         for cmd in terminalCommands():
             break # get the first
-    
+
     prog = cmd.pop(0)
-    
+
     workdir = None
     if url.toLocalFile():
         workdir = url.toLocalFile()
         if type != "shell":
             workdir = os.path.dirname(workdir)
-    
+
     if any('$f' in a or '$u' in a for a in cmd):
         cmd = [a.replace('$u', url.toString())
                 if '$u' in a else a.replace('$f', url.toLocalFile())
@@ -100,7 +100,7 @@ def openUrl(url, type="browser"):
         cmd.append(url.toString())
     elif type != "shell":
         cmd.append(url.toLocalFile())
-    
+
     try:
         subprocess.Popen([prog] + cmd, cwd=workdir)
     except OSError:
@@ -111,9 +111,9 @@ def openUrl(url, type="browser"):
 
 def terminalCommands():
     """Yields suitable commands to open a terminal/shell window.
-    
+
     There is always yielded at least one, which is suitable as default.
-    
+
     """
     if os.name == "nt":
         yield ['cmd.exe']

--- a/frescobaldi_app/highlighter.py
+++ b/frescobaldi_app/highlighter.py
@@ -46,10 +46,10 @@ metainfo.define('highlighting', True)
 
 def mapping(data):
     """Return a dictionary mapping token classes from ly.lex to QTextCharFormats.
-    
+
     The QTextFormats are queried from the specified TextFormatData instance.
     The returned dictionary is a ly.colorize.Mapping instance.
-    
+
     """
     return ly.colorize.Mapper((cls, data.textFormat(mode, style.name))
                         for mode, styles in ly.colorize.default_mapping()
@@ -85,15 +85,15 @@ app.settingsChanged.connect(_reset_highlight_mapping, -100) # before all others
 
 class Highlighter(plugin.Plugin, QSyntaxHighlighter):
     """A QSyntaxHighlighter that can highlight a QTextDocument.
-    
+
     It can be used for both generic QTextDocuments as well as
     document.Document objects. In the latter case it automatically:
     - initializes whether highlighting is enabled from the document's metainfo
     - picks the mode from the variables if they specify that
-    
+
     The Highlighter automatically re-reads the highlighting settings if they
     are changed.
-    
+
     """
     def __init__(self, document):
         QSyntaxHighlighter.__init__(self, document)
@@ -103,16 +103,16 @@ class Highlighter(plugin.Plugin, QSyntaxHighlighter):
         self._highlighting = True
         self._mode = None
         self.initializeDocument()
-    
+
     def initializeDocument(self):
         """This method is always called by the __init__ method.
-        
+
         The default implementation does nothing for generic QTextDocuments,
         but for document.Document instances it connects to some additional
         signals to keep the mode up-to-date (reading it from the variables if
         needed) and initializes whether to enable visual highlighting from the
         document's metainfo.
-        
+
         """
         document = self.document()
         if hasattr(document, 'url'):
@@ -120,18 +120,18 @@ class Highlighter(plugin.Plugin, QSyntaxHighlighter):
             document.loaded.connect(self._resetHighlighting)
             self._mode = documentinfo.mode(document, False)
             variables.manager(document).changed.connect(self._variablesChange)
-        
+
     def _variablesChange(self):
         """Called whenever the variables have changed. Checks the mode."""
         mode = documentinfo.mode(self.document(), False)
         if mode != self._mode:
             self._mode = mode
             self.rehighlight()
-            
+
     def _resetHighlighting(self):
         """Switch highlighting on or off depending on saved metainfo."""
         self.setHighlighting(metainfo.info(self.document()).highlighting)
-        
+
     def highlightBlock(self, text):
         """Called by Qt when the highlighting of the current line needs updating."""
         # find the state of the previous line
@@ -144,11 +144,11 @@ class Highlighter(plugin.Plugin, QSyntaxHighlighter):
         # collect and save the tokens
         tokens = tuple(state.tokens(text))
         cursortools.data(self.currentBlock()).tokens = tokens
-        
+
         # if blank thus far, keep the highlighter coming back
         # because the parsing state is not yet known; else save the state
         self.setCurrentBlockState(prev - 1 if blank else self._fridge.freeze(state))
-        
+
         # apply highlighting if desired
         if self._highlighting:
             setFormat = lambda f: self.setFormat(token.pos, len(token), f)
@@ -157,32 +157,32 @@ class Highlighter(plugin.Plugin, QSyntaxHighlighter):
                 f = mapping[token]
                 if f:
                     setFormat(f)
-        
+
     def setHighlighting(self, enable):
         """Enable or disable highlighting."""
         changed = enable != self._highlighting
         self._highlighting = enable
         if changed:
             self.rehighlight()
-            
+
     def isHighlighting(self):
         """Return whether highlighting is active."""
         return self._highlighting
-        
+
     def state(self, block):
         """Return a thawed ly.lex.State() object at the *end* of the QTextBlock.
-        
+
         Do not use this method directly. Instead use tokeniter.state() or
         tokeniter.state_end(), because that assures the highlighter has run
         at least once.
-        
+
         """
         return self._fridge.thaw(block.userState()) or self.initialState()
 
     def setInitialState(self, state):
         """Force the initial state. Use None to enable auto-detection."""
         self._initialState = self._fridge.freeze(state) if state else None
-        
+
     def initialState(self):
         """Return the initial State for this document."""
         if self._initialState is None:
@@ -193,12 +193,12 @@ class Highlighter(plugin.Plugin, QSyntaxHighlighter):
 
 def html_copy(cursor, scheme='editor', number_lines=False):
     """Return a new QTextDocument with highlighting set as HTML textcharformats.
-    
-    The cursor is a cursor of a document.Document instance. If the cursor 
+
+    The cursor is a cursor of a document.Document instance. If the cursor
     has a selection, only the selection is put in the new document.
-    
+
     If number_lines is True, line numbers are added.
-    
+
     """
     data = textformats.formatData(scheme)
     doc = QTextDocument()
@@ -240,12 +240,12 @@ def html_copy(cursor, scheme='editor', number_lines=False):
 
 def highlight(document, mapping=None, state=None):
     """Highlight a generic QTextDocument once.
-    
-    mapping is an optional Mapping instance, defaulting to the current 
+
+    mapping is an optional Mapping instance, defaulting to the current
     configured editor highlighting formats (returned by highlight_mapping()).
-    state is an optional ly.lex.State instance. By default the text type is 
+    state is an optional ly.lex.State instance. By default the text type is
     guessed.
-    
+
     """
     if mapping is None:
         mapping = highlight_mapping()

--- a/frescobaldi_app/historymanager.py
+++ b/frescobaldi_app/historymanager.py
@@ -37,10 +37,10 @@ _setCurrentDocument = signals.Signal()  # Document
 
 class HistoryManager(object):
     """Keeps the history of document switches by the user.
-    
+
     If a document is closed, the previously active document is set active.
     If no documents remain, nothing is done.
-    
+
     """
     def __init__(self, mainwindow, othermanager=None):
         self.mainwindow = weakref.ref(mainwindow)
@@ -50,7 +50,7 @@ class HistoryManager(object):
         app.documentCreated.connect(self.addDocument, 1)
         app.documentClosed.connect(self.removeDocument, 1)
         _setCurrentDocument.connect(self._listen)
-        
+
     def addDocument(self, doc):
         self._documents.insert(-1, doc)
 
@@ -63,14 +63,14 @@ class HistoryManager(object):
                 # last document removed; listen to setCurrentDocument from others
                 self._has_current = False
         self._documents.remove(doc)
-    
+
     def setCurrentDocument(self, doc):
         self._documents.remove(doc)
         self._documents.append(doc)
         self._has_current = True
         # notify possible interested parties
         _setCurrentDocument(doc)
-    
+
     def documents(self):
         """Returns the documents in order of most recent been active."""
         return self._documents[::-1]

--- a/frescobaldi_app/htmldiff.py
+++ b/frescobaldi_app/htmldiff.py
@@ -29,9 +29,9 @@ import difflib
 def htmldiff(oldtext, newtext, oldtitle="", newtitle="",
              context=True, numlines=3, tabsize=8, wrapcolumn=None):
     """Return a HTML diff from oldtext to newtext.
-    
+
     See also the Python documentation for difflib.HtmlDiff().make_table().
-    
+
     """
     table = difflib.HtmlDiff(tabsize=tabsize, wrapcolumn=wrapcolumn).make_table(
         oldtext.splitlines(), newtext.splitlines(),

--- a/frescobaldi_app/hyphenator.py
+++ b/frescobaldi_app/hyphenator.py
@@ -43,17 +43,17 @@ _hex_repl = lambda matchObj: chr(int(matchObj.group(1), 16))
 def replace_hex(text):
     """Replaces ^^xx (where xx is a two-digit hexadecimal value) occurrences
     by the corresponding unicode character.
-    
+
     """
     return _hex_re.sub(_hex_repl, text)
 
 
 class ParsedAlternative(object):
     """Parse nonstandard hyphen pattern alternative.
-    
+
     when called with an odd value, the instance returns an integer with data
     attribute (DataInt) about the current position in the pattern.
-    
+
     """
     def __init__(self, pat, alt):
         alt = alt.split(',')
@@ -78,10 +78,10 @@ class ParsedAlternative(object):
 
 class DataInt(int):
     """An integer with a data attribute.
-    
+
     Just an int some other data can be stuck to in a data attribute.
     Instantiate with ref=other to use the data from the other DataInt.
-    
+
     """
     def __new__(cls, value, data=None, ref=None):
         obj = int.__new__(cls, value)
@@ -94,10 +94,10 @@ class DataInt(int):
 
 class HyphenationDictionary(object):
     """Reads a hyph_*.dic file and stores the hyphenation patterns.
-    
+
     Parameters:
     filename : filename of hyph_*.dic pattern file to read
-    
+
     """
     def __init__(self, filename):
         self.patterns = {}
@@ -112,7 +112,7 @@ class HyphenationDictionary(object):
                         pass
             else:
                 decoder = codecs.getreader('latin1')
-            
+
             for pat in decoder(f):
                 pat = pat.strip()
                 if not pat or pat[0] == '%':
@@ -141,7 +141,7 @@ class HyphenationDictionary(object):
 
     def positions(self, word):
         """Returns a list of positions where the word can be hyphenated.
-        
+
         E.g. for the dutch word 'lettergrepen' this method returns
         the list [3, 6, 9].
 
@@ -156,7 +156,7 @@ class HyphenationDictionary(object):
             point
         cut: how many characters to remove while substituting the nonstandard
             hyphenation
-        
+
         """
         word = word.lower()
         try:
@@ -180,7 +180,7 @@ class HyphenationDictionary(object):
 
 class Hyphenator(object):
     """Reads a hyph_*.dic file and stores the hyphenation patterns.
-    
+
     Provides methods to hyphenate strings in various ways.
     Parameters:
     -filename : filename of hyph_*.dic to read
@@ -191,7 +191,7 @@ class Hyphenator(object):
     left and right may also later be changed:
       h = Hyphenator(file)
       h.left = 1
-    
+
     """
     def __init__(self, filename, left=2, right=2, cache=True):
         self.left  = left
@@ -202,10 +202,10 @@ class Hyphenator(object):
 
     def positions(self, word):
         """Returns a list of positions where the word can be hyphenated.
-        
+
         See also HyphenationDictionary.positions. The points that are too far to
         the left or right are removed.
-        
+
         """
         right = len(word) - self.right
         return [i for i in self.hd.positions(word) if self.left <= i <= right]
@@ -226,11 +226,11 @@ class Hyphenator(object):
     def wrap(self, word, width, hyphen='-'):
         """Returns the longest possible first part and the last part of the
         hyphenated word.
-        
+
         The first part has the hyphen already attached. Returns None, if there
         is no hyphenation point before width, or if the word could not be
         hyphenated.
-        
+
         """
         width -= len(hyphen)
         for w1, w2 in self.iterate(word):
@@ -239,11 +239,11 @@ class Hyphenator(object):
 
     def inserted(self, word, hyphen='-'):
         """Returns the word as a string with all the possible hyphens inserted.
-        
+
         E.g. for the dutch word 'lettergrepen' this method returns the string
         'let-ter-gre-pen'. The hyphen string to use can be given as the second
         parameter, that defaults to '-'.
-        
+
         """
         l = list(word)
         for p in reversed(self.positions(word)):

--- a/frescobaldi_app/hyphendialog.py
+++ b/frescobaldi_app/hyphendialog.py
@@ -69,7 +69,7 @@ def directories():
     """ Yields a list of existing paths based on config """
     # prefixes to look in for relative paths
     prefixes = ['/usr/', '/usr/local/']
-    
+
     def gen():
         # if the path is not absolute, add it to all prefixes.
         paths = settings().value("paths", default_paths, str)
@@ -85,7 +85,7 @@ def directories():
 
 def findDicts():
     """ Find installed hyphen dictionary files """
-    
+
     # now find the hyph_xx_XX.dic files
     dicfiles = (f for p in directories()
                   for f in glob.glob(os.path.join(p, 'hyph_*.dic')) if os.access(f, os.R_OK))
@@ -101,26 +101,26 @@ class HyphenDialog(QDialog):
         self.setLayout(layout)
         self.topLabel = QLabel()
         self.listWidget = QListWidget()
-        
+
         layout.addWidget(self.topLabel)
         layout.addWidget(self.listWidget)
         layout.addWidget(widgets.Separator())
-        
+
         self.buttons = b = QDialogButtonBox()
         layout.addWidget(b)
         b.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         userguide.addButton(b, "lyrics")
         b.rejected.connect(self.reject)
         b.accepted.connect(self.accept)
-        
+
         self.load()
         app.translateUI(self)
         qutil.saveDialogSize(self, "hyphenation/dialog/size")
-        
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Hyphenate Lyrics Text")))
         self.topLabel.setText(_("Please select a language:"))
-        
+
     def load(self):
         current = po.setup.current()
         self._langs = [(language_names.languageName(lang, current), lang, dic)
@@ -128,7 +128,7 @@ class HyphenDialog(QDialog):
         self._langs.sort()
         for name, lang, dic in self._langs:
             self.listWidget.addItem("{0}  ({1})".format(name, lang))
-            
+
         def select():
             lastused = settings().value("lastused", "", str)
             if lastused:
@@ -136,7 +136,7 @@ class HyphenDialog(QDialog):
             lang = po.setup.preferred()[0]
             yield lang
             yield lang.split('_')[0]
-        
+
         langs = [item[1] for item in self._langs]
         for preselect in select():
             try:
@@ -144,7 +144,7 @@ class HyphenDialog(QDialog):
                 break
             except ValueError:
                 continue
-   
+
     def hyphenator(self):
         if self.exec_() and self._langs:
             lang, dic = self._langs[self.listWidget.currentRow()][1:]

--- a/frescobaldi_app/icons/__init__.py
+++ b/frescobaldi_app/icons/__init__.py
@@ -65,7 +65,7 @@ def file_type(name):
 
 def initialize():
     """Initialize support for the icons. Called on app startup."""
-    
+
     # find the icons in this directory, after that also search in the included
     # icon theme folders (this fallback is used if the "Use system icons"
     # setting is enabled, but the system does not provide a certain icon.
@@ -79,7 +79,7 @@ def initialize():
         if os.path.isdir(p):
             path.append(p)
     QDir.setSearchPaths("icons", path)
-    
+
     # use our icon theme (that builds on Tango) if there are no system icons
     if (not QIcon.themeName() or QIcon.themeName() == "hicolor"
         or not QSettings().value("system_icons", True, bool)):

--- a/frescobaldi_app/indent.py
+++ b/frescobaldi_app/indent.py
@@ -34,10 +34,10 @@ import lydocument
 
 def indent_variables(document=None):
     """Return a dictionary with indentation preferences.
-    
-    If a document (a Frescobaldi/QTextDocument) is specified, the document 
+
+    If a document (a Frescobaldi/QTextDocument) is specified, the document
     variables are also read.
-    
+
     For the variables and their default variables, see userguide/docvars.md.
 
     """
@@ -54,7 +54,7 @@ def indent_variables(document=None):
         'document-tab-width': 8 if dspaces == 0 else dspaces,
     }
     return variables.update(document, prefs) if document else prefs
-    
+
 def indenter(document=None):
     """Return a ly.indent.Indenter, setup for the document."""
     indent_vars = indent_variables(document)
@@ -62,7 +62,7 @@ def indenter(document=None):
     i.indent_width = indent_vars['indent-width']
     i.indent_tabs = indent_vars['indent-tabs']
     return i
-    
+
 def auto_indent_block(block):
     """Auto-indents the given block."""
     i = indenter(block.document())
@@ -87,10 +87,10 @@ def indentable(cursor):
 
 def increase_indent(cursor):
     """Increases the indent of the line the cursor is at (or the selected lines).
-    
+
     If there is no selection or the cursor is not in the first indent space,
     just inserts a Tab (or spaces).
-    
+
     """
     c = lydocument.cursor(cursor)
     indenter(cursor.document()).increase_indent(c)
@@ -102,11 +102,11 @@ def decrease_indent(cursor):
 
 def re_indent(cursor, indent_blank_lines=False):
     """Re-indents the selected region or the whole document.
-    
-    If indent_blank_lines is True, the indent of blank lines is made larger 
-    if necessary. If False (the default), the indent of blank lines if not 
+
+    If indent_blank_lines is True, the indent of blank lines is made larger
+    if necessary. If False (the default), the indent of blank lines if not
     changed if it is shorter than it should be.
-    
+
     """
     c = lydocument.cursor(cursor, select_all=True)
     indenter(cursor.document()).indent(c, indent_blank_lines)

--- a/frescobaldi_app/inputdialog.py
+++ b/frescobaldi_app/inputdialog.py
@@ -44,9 +44,9 @@ def getText(
         complete = None,
         ):
     """Asks a string of text from the user.
-    
+
     Arguments:
-    
+
     parent: parent widget or None
     title: dialog window title (without appname)
     message: message, question
@@ -58,8 +58,8 @@ def getText(
         validation method using a QRegExpValidator.
     wordWrap: whether to word-wrap the message text (default: True).
     complete: a string list or QAbstractItemModel to provide completions.
-    
-    """    
+
+    """
     dlg = widgets.dialog.TextDialog(parent,
         title=app.caption(title), message=message, icon=icon)
     dlg.setText(text)

--- a/frescobaldi_app/install/__init__.py
+++ b/frescobaldi_app/install/__init__.py
@@ -33,13 +33,13 @@ SETTINGS_VERSION = 1
 
 def update_settings():
     """Checks whether settings needs to be migrated to a new structure."""
-    
+
     version = QSettings().value("settings_version", 0, int)
 
     if version != SETTINGS_VERSION:
         from . import update
         update.update(version)
-        
+
         #uncomment next lines when the upgrade from 0 to 1 works
         QSettings().setValue("settings_version", SETTINGS_VERSION)
         QSettings().sync() # just to be sure

--- a/frescobaldi_app/install/update.py
+++ b/frescobaldi_app/install/update.py
@@ -33,12 +33,12 @@ import appinfo
 
 def update(version):
     """Call subroutines listed below for version upgrades."""
-    
+
     if version < 1:
         moveSettingsToNewRoot()
-    
+
     # ... add other setting updates here...
-    
+
 
 
 def moveSettingsToNewRoot():
@@ -57,4 +57,4 @@ def moveSettingsToNewRoot():
             for k in keys:
                 s.setValue(k, o.value(k))
             o.clear()
-    
+

--- a/frescobaldi_app/jobattributes.py
+++ b/frescobaldi_app/jobattributes.py
@@ -33,18 +33,18 @@ def get(job):
 
 class JobAttributes(plugin.AttributePlugin):
     """Manages attributes of a Job.
-    
+
     The attributes can be set simply as instance attributes.
     If possible, weak references are made so the attributes do not keep
     references to the objects they refer to.
-    
+
     If an attribute is requested but not set, None is returned.
-    
+
     Usage e.g.:
-    
+
     attrs = jobattributes.get(job)
     attrs.mainwindow = mainwindow
-    
+
     """
     def job(self):
         return self._parent()

--- a/frescobaldi_app/jobmanager.py
+++ b/frescobaldi_app/jobmanager.py
@@ -46,13 +46,13 @@ def is_running(document):
 
 
 class JobManager(plugin.DocumentPlugin):
-    
+
     started = signals.Signal()  # Job
     finished = signals.Signal() # Job, success
-    
+
     def __init__(self, document):
         self._job = None
-        
+
     def start_job(self, job):
         """Starts a Job on our behalf."""
         if not self.is_running():
@@ -61,11 +61,11 @@ class JobManager(plugin.DocumentPlugin):
             job.start()
             self.started(job)
             app.jobStarted(self.document(), job)
-        
+
     def _finished(self, success):
         self.finished(job, success)
         app.jobFinished(self.document(), self._job, success)
-    
+
     def job(self):
         """Returns the last job if any."""
         return self._job

--- a/frescobaldi_app/language_names/__init__.py
+++ b/frescobaldi_app/language_names/__init__.py
@@ -24,35 +24,35 @@ __all__ = ['languageName']
 
 def languageName(code, language=None):
     """Returns a human-readable name for a language.
-    
+
     The language must be given in the 'code' attribute.
     The 'language' attribute specifies in which language
     the name must be translated and defaults to the current locale.
-    
+
     """
     if language is None:
         try:
             language = locale.getdefaultlocale()[0]
         except ValueError:
             pass
-            
+
     langs = []
     if language:
         langs.append(language)
         if '_' in language:
             langs.append(language.split('_')[0])
     langs.append("C")
-    
+
     codes = [code]
     if '_' in code:
         codes.append(code.split('_')[0])
-    
+
     for lang in langs:
         try:
             d = language_names[lang]
         except KeyError:
             continue
-        
+
         for c in codes:
             try:
                 return d[c]

--- a/frescobaldi_app/language_names/generate.py
+++ b/frescobaldi_app/language_names/generate.py
@@ -50,9 +50,9 @@ lang_names = [
 
 def generate_kde(fileName="/usr/share/locale/all_languages"):
     """Uses the KDE file to extract language names.
-    
+
     Returns the dictionary. All strings are in unicode form.
-    
+
     """
     langs = collections.defaultdict(dict)
 
@@ -68,30 +68,30 @@ def generate_kde(fileName="/usr/share/locale/all_languages"):
                 if m:
                     lang, name = m.group(1) or "C", m.group(2)
                     langs[lang][group] = name
-    
+
     # correct KDE mistake
     langs["cs"]["gl"] = "Galicijský"
     langs["zh_HK"]["gl"] = "加利西亞語"
     langs["zh_HK"]["zh_HK"] = "繁體中文（香港）"
     return dict(langs)
-    
+
 
 def makestring(text):
     """Returns the text wrapped in quotes, usable as Python input (expecting unicode_literals)."""
     return '"' + re.sub(r'([\\"])', r'\\\1', text) + '"'
-    
+
 
 def write_dict(langs):
     """Writes the dictionary file to the 'data.py' file."""
-    
+
     keys = sorted(filter(lambda k: k in langs, lang_names) if lang_names else langs)
 
     with codecs.open("data.py", "w", "utf-8") as output:
         output.write("# -*- coding: utf-8;\n\n")
         output.write("# Do not edit, this file is generated. See generate.py.\n")
         output.write("\nfrom __future__ import unicode_literals\n")
-        output.write("\n\n")    
-        
+        output.write("\n\n")
+
         output.write("language_names = {\n")
         for key in keys:
             output.write('{0}: {{\n'.format(makestring(key)))

--- a/frescobaldi_app/lasptyqu.py
+++ b/frescobaldi_app/lasptyqu.py
@@ -103,11 +103,11 @@ def available():
 
 def quote_set(primary_left, primary_right, secondary_left, secondary_right):
     """Return a QuoteSet object for the specified four quote character strings.
-    
+
     This function is not needed normally, but should you ever want to create
     a custom QuoteSet object and access the attributes in the same way as with
     the predefined quote sets, this function can be used.
-    
+
     """
     return QuoteSet(
         primary=Quotes(primary_left, primary_right),
@@ -116,9 +116,9 @@ def quote_set(primary_left, primary_right, secondary_left, secondary_right):
 
 def quotes(language="C"):
     """Return a quotes set for the specified language (default C).
-    
+
     May return None, in case there are no quotes defined for the language.
-    
+
     """
     try:
         return _quotes[language]
@@ -135,19 +135,19 @@ def default():
 
 def preferred():
     """Return the quotes desired by the Frescobaldi user.
-    
+
     Always returns a quote set.
     Only this function depends on Qt and Frescobaldi.
-    
+
     """
-    
+
     from PyQt5.QtCore import QSettings
     import po.setup
 
     s = QSettings()
     s.beginGroup("typographical_quotes")
     language = s.value("language", "current", str)
-    
+
     default = _quotes["C"]
     if language == "current":
         language = po.setup.current()

--- a/frescobaldi_app/layoutcontrol/__init__.py
+++ b/frescobaldi_app/layoutcontrol/__init__.py
@@ -31,42 +31,42 @@ import panel
 
 # dictionary mapping internal option names to command line switches
 _debugmodes = {
-    'annotate-spacing': 
+    'annotate-spacing':
         ('-ddebug-annotate-spacing',
-        lambda: _("Annotate Spacing"), 
+        lambda: _("Annotate Spacing"),
         lambda: _("Use LilyPond's \"annotate spacing\" option to\n"
-          "display measurement information")), 
-    'control-points': 
-        ('-ddebug-control-points', 
-        lambda: _("Display Control Points"), 
+          "display measurement information")),
+    'control-points':
+        ('-ddebug-control-points',
+        lambda: _("Display Control Points"),
         lambda: _("Display the control points that "
-          "determine curve shapes")), 
-    'directions': 
+          "determine curve shapes")),
+    'directions':
         ('-ddebug-directions',
-        lambda: _("Color explicit directions"), 
-        lambda: _("Highlight elements that are explicitly switched up- or downwards")), 
-    'grob-anchors': 
+        lambda: _("Color explicit directions"),
+        lambda: _("Highlight elements that are explicitly switched up- or downwards")),
+    'grob-anchors':
         ('-ddebug-grob-anchors',
-        lambda: _("Display Grob Anchors"), 
-        lambda: _("Display a dot at the anchor point of each grob")), 
-    'grob-names': 
+        lambda: _("Display Grob Anchors"),
+        lambda: _("Display a dot at the anchor point of each grob")),
+    'grob-names':
         ('-ddebug-grob-names',
-        lambda: _("Display Grob Names"), 
-        lambda: _("Display the name of each grob")), 
-    'paper-columns': 
-        ('-ddebug-paper-columns', 
-        lambda: _("Display Paper Columns"), 
-        lambda: _("Display info on the paper columns")), 
-    'skylines': 
-        ('-ddebug-display-skylines', 
-        lambda: _("Display Skylines"), 
+        lambda: _("Display Grob Names"),
+        lambda: _("Display the name of each grob")),
+    'paper-columns':
+        ('-ddebug-paper-columns',
+        lambda: _("Display Paper Columns"),
+        lambda: _("Display info on the paper columns")),
+    'skylines':
+        ('-ddebug-display-skylines',
+        lambda: _("Display Skylines"),
         lambda: _("Display the skylines that LilyPond "
-          "uses to detect collisions.")), 
-    'voices': 
-        ('-ddebug-voices', 
-        lambda: _("Color \\voiceXXX"), 
+          "uses to detect collisions.")),
+    'voices':
+        ('-ddebug-voices',
+        lambda: _("Color \\voiceXXX"),
         lambda: _("Highlight notes that are explicitly "
-        "set to \\voiceXXX")), 
+        "set to \\voiceXXX")),
 }
 
 def modelist():
@@ -87,7 +87,7 @@ def option(mode):
     Return the command line option for a key
     """
     return _debugmodes[mode][0]
-    
+
 def label(mode):
     """
     Return the label of a mode as a translatable string
@@ -111,7 +111,7 @@ class LayoutControlOptions(panel.Panel):
     def translateUI(self):
         self.setWindowTitle(_("Layout Control Options"))
         self.toggleViewAction().setText(_("Layout &Control Options"))
-        
+
     def createWidget(self):
         from . import widget
         w = widget.Widget(self)

--- a/frescobaldi_app/layoutcontrol/widget.py
+++ b/frescobaldi_app/layoutcontrol/widget.py
@@ -36,30 +36,30 @@ import userguide
 
 
 class Widget(QWidget):
-    
+
     optionsChanged = pyqtSignal()
-    
+
     def __init__(self, tool):
         super(Widget, self).__init__(tool)
-        
+
         layout = QVBoxLayout(spacing=1)
         self.setLayout(layout)
-        
+
         # manual mode UI elements that need special treatment
         self.CBverbose = QCheckBox(clicked=self.optionsChanged)
         self.CBpointandclick = QCheckBox(clicked=self.optionsChanged)
         self.CBcustomfile = QCheckBox(clicked=self.optionsChanged)
         self.LEcustomfile = QLineEdit(enabled=False)
-        
+
         # run Lily button
         self.engraveButton = QToolButton()
         self.engraveButton.setDefaultAction(
             engrave.engraver(tool.mainwindow()).actionCollection.engrave_debug)
-        
+
         # help button
         self.helpButton = QToolButton(clicked=self.helpButtonClicked)
         self.helpButton.setIcon(icons.get('help-contents'))
-        
+
         # add manual widgets
         hbox = QHBoxLayout()
         hbox.setContentsMargins(0, 0, 0, 0)
@@ -69,26 +69,26 @@ class Widget(QWidget):
         layout.addLayout(hbox)
         layout.addWidget(self.CBverbose)
         layout.addWidget(self.CBpointandclick)
-        
+
         # automatically processed modes
         self.checkboxes = {}
         for mode in layoutcontrol.modelist():
             self.checkboxes[mode] = cb = QCheckBox(clicked=self.optionsChanged)
             layout.addWidget(cb)
-        
+
         # add manual widgets
         layout.addWidget(self.CBcustomfile)
         layout.addWidget(self.LEcustomfile)
         layout.addStretch(1)
-        
+
         # connect manual widgets
         self.CBcustomfile.toggled.connect(self.LEcustomfile.setEnabled)
         self.LEcustomfile.textEdited.connect(self.optionsChanged)
-        
+
         app.translateUI(self)
         self.loadSettings()
         tool.mainwindow().aboutToClose.connect(self.saveSettings)
-    
+
     def translateUI(self):
         for mode in layoutcontrol.modelist():
             label = layoutcontrol.label(mode)
@@ -105,7 +105,7 @@ class Widget(QWidget):
         self.CBcustomfile.setToolTip(_("Include a custom file with definitions\n"
                       "for additional Layout Control Modes"))
         self.LEcustomfile.setToolTip(_("Filename to be included"))
-    
+
     def loadSettings(self):
         """Called on construction. Load settings and set checkboxes state."""
         s = QSettings()
@@ -116,7 +116,7 @@ class Widget(QWidget):
         self.CBpointandclick.setChecked(s.value('point-and-click', True, bool))
         self.CBcustomfile.setChecked(s.value('custom-file', False, bool))
         self.LEcustomfile.setText(s.value('custom-filename', '', str))
-        
+
     def saveSettings(self):
         """Called on close. Save settings and checkboxes state."""
         s = QSettings()
@@ -130,36 +130,36 @@ class Widget(QWidget):
 
     def helpButtonClicked(self):
         userguide.show("engrave_layout")
-        
+
     def preview_options(self):
         """Return a list of Debug Mode command line options for LilyPond."""
         args = []
-        
+
         # 'automatic' widgets
         for mode in layoutcontrol.modelist():
             if self.checkboxes[mode].isChecked():
                 args.append(layoutcontrol.option(mode))
-        
+
         # manual widgets
         if self.CBcustomfile.isChecked():
             file_to_include = self.LEcustomfile.text()
             args.append('-ddebug-custom-file=' + file_to_include)
-        
+
         # if at least one debug mode is used, add the directory with the
         # preview-mode files to the search path
         if args:
             args.insert(0, '-I' + layoutcontrol.__path__[0])
             # File that conditionally includes different formatters
-            args.insert(1, '-dinclude-settings=debug-layout-options.ly') 
-        
+            args.insert(1, '-dinclude-settings=debug-layout-options.ly')
+
         if self.CBpointandclick.isChecked():
             args.insert(0, '-dpoint-and-click')
         else:
             args.insert(0, '-dno-point-and-click')
-        
+
         if self.CBverbose.isChecked():
             args.insert(0, '--verbose')
-        
+
         if self.CBcustomfile.isChecked():
             file_to_include = self.LEcustomfile.text()
             if file_to_include:

--- a/frescobaldi_app/lilychooser.py
+++ b/frescobaldi_app/lilychooser.py
@@ -36,22 +36,22 @@ class LilyChooser(QComboBox):
         app.translateUI(self)
         app.settingsChanged.connect(self.load)
         self.load()
-    
+
     def translateUI(self):
         self.setToolTip(_("Choose the desired LilyPond version."""))
-    
+
     def setLilyPondInfo(self, info):
         """Set the current LilyPond info (one of lilypondinfo.infos())."""
         try:
             self.setCurrentIndex(self._infos.index(info))
         except IndexError:
             pass
-    
+
     def lilyPondInfo(self):
         """Get the current LilyPond info."""
         if self._infos:
             return self._infos[self.currentIndex()]
-    
+
     def load(self):
         """Load the available LilyPond infos."""
         infos = lilypondinfo.infos() or [lilypondinfo.default()]

--- a/frescobaldi_app/lilydoc/documentation.py
+++ b/frescobaldi_app/lilydoc/documentation.py
@@ -34,19 +34,19 @@ from . import network
 class Documentation(QObject):
     """An instance of LilyPond documentation."""
     versionLoaded = pyqtSignal(bool)
-    
+
     def __init__(self, url):
         QObject.__init__(self)
         self._url = url
         self._localFile = url.toLocalFile()
         self._versionString = None
-        
+
         # determine version
         url = self.url()
         sep = '/' if not url.path().endswith('/') else ''
         url.setPath(url.path() + sep + 'VERSION')
         self._request(url)
-    
+
     def _request(self, url):
         """Request a URL to read the version from."""
         reply = self._reply = network.get(url)
@@ -54,7 +54,7 @@ class Documentation(QObject):
             self._handleReply()
         else:
             reply.finished.connect(self._handleReply)
-    
+
     def _handleReply(self):
         self._reply.deleteLater()
         if self._reply.error():
@@ -77,10 +77,10 @@ class Documentation(QObject):
                 else:
                     self._versionString = v[:16].decode('utf-8', 'replace')
         self.versionLoaded.emit(bool(self._versionString))
-        
+
     def url(self):
         return QUrl(self._url)
-    
+
     def home(self):
         """Returns the url with 'Documentation' appended."""
         url = self.url()
@@ -91,26 +91,26 @@ class Documentation(QObject):
         else:
             url.setPath(url.path() + '/index')
         return url
-    
+
     def versionString(self):
         """Returns the version as a string.
-        
+
         If the version is not yet determined, returns None.
         If the version could not be determined, returns the empty string.
-        
+
         """
         return self._versionString
-    
+
     def version(self):
         """Returns the version as a tuple of ints.
-        
+
         If the version is not yet determined, returns None.
         If the version could not be determined, returns the empty tuple.
-        
+
         """
         if self._versionString is not None:
             return tuple(map(int, re.findall(r"\d+", self._versionString)))
-    
+
     def isLocal(self):
         """Returns True if the documentation is on the local system."""
         return bool(self._localFile)

--- a/frescobaldi_app/lilydoc/manager.py
+++ b/frescobaldi_app/lilydoc/manager.py
@@ -63,12 +63,12 @@ app.settingsChanged.connect(clear, -100)
 
 def loaded():
     """Returns True if all Documentation are loaded (i.e. know their version).
-    
+
     If this function returns False, you can connect to the allLoaded signal
     to get a notification when all Documentation instances have loaded their
     version information. This signal will only be emitted once, after that all
     connections will be removed from the signal.
-    
+
     """
     for d in docs():
         if d.versionString() is None:
@@ -78,10 +78,10 @@ def loaded():
 
 def _check_doc_versions():
     """Checks if all documentation instances have their version loaded.
-    
+
     Emits the allLoaded signal when all are loaded, also sorts the documentation
     instances then on local/remote and then version number.
-    
+
     """
     for d in _documentations:
         if d.versionString() is None:
@@ -104,18 +104,18 @@ def _sort_docs():
 
 def urls():
     """Returns a list of QUrls where documentation can be found.
-    
+
     Remote urls (from the users settings) are not checked but simply returned.
     For user-set local directories, if the directory itself does not contain
     LilyPond documentation, all directories one level deep are searched.
-    
+
     This makes it possible to set one directory for local documentation and
     put there multiple sets of documentation in subdirectories (e.g. with the
     version number in the path name).
-    
+
     The paths in the settings are read, and also the usual system directories
     are scanned.
-    
+
     """
     user_paths = qsettings.get_string_list(QSettings(), "documentation/paths")
     system_prefixes = [p for p in (
@@ -131,7 +131,7 @@ def urls():
     for p in user_paths:
         user_prefixes.append(p) if os.path.isdir(p) else remote.append(p)
     remote.sort(key=util.naturalsort)
-    
+
     # now find all instances of LilyPond documentation in the local paths
     def paths(path):
         """Yields possible places where LilyPond documentation could live."""
@@ -139,13 +139,13 @@ def urls():
         path = os.path.join(path, 'share', 'doc', 'lilypond', 'html')
         yield path
         yield os.path.join(path, 'offline-root')
-    
+
     def find(path):
         """Finds LilyPond documentation."""
         for p in paths(path):
             if os.path.isdir(os.path.join(p, 'Documentation')):
                 return p
-    
+
     # search in the user-set directories, if no docs, scan one level deeper
     for p in user_prefixes:
         n = find(p)

--- a/frescobaldi_app/lilydoc/manual.py
+++ b/frescobaldi_app/lilydoc/manual.py
@@ -27,16 +27,16 @@ from PyQt5.QtCore import QObject, QUrl, pyqtSignal
 
 
 class Manual(QObject):
-    
+
     loaded = pyqtSignal(bool)
-    
+
     def __init__(self, lilydoc):
         self._loaded = None
-    
+
     def isLoaded(self):
         """True: successfully loaded, False: load failed, None: load pending."""
         return self._loaded
-    
+
 
 
 class NotationManual(Manual):
@@ -45,7 +45,7 @@ class NotationManual(Manual):
 
 class LearningManual(Manual):
     """Represents the Learning Manual."""
-    
+
 
 class InternalsReference(Manual):
     """Represents the Internals Reference."""

--- a/frescobaldi_app/lilydoc/network.py
+++ b/frescobaldi_app/lilydoc/network.py
@@ -47,11 +47,11 @@ def get(url):
 
 def langs():
     """Returns a list of language codes wished for documentation.
-    
+
     If the list is empty, english (untranslated) is assumed.
     If a language code also has a country suffix, a hyphen will be used
     as separator (as required per RFC2616, Accept-Language header).
-    
+
     """
     s = QSettings()
     langs = []
@@ -62,7 +62,7 @@ def langs():
     if lang and lang != "C":
         langs.append(lang)
     langs.extend(po.setup.preferred())
-    
+
     # now fixup the list, remove dups and
     # language/country codes in Accept-Language headers must have '-' and not '_'
     result = []
@@ -85,7 +85,7 @@ class NetworkAccessManager(networkaccessmanager.NetworkAccessManager):
         super(NetworkAccessManager, self).__init__(parent)
         app.settingsChanged.connect(self.readSettings)
         self.readSettings()
-    
+
     def readSettings(self):
         l = langs()
         if 'en' not in l:

--- a/frescobaldi_app/listmodel.py
+++ b/frescobaldi_app/listmodel.py
@@ -48,13 +48,13 @@ class ListModel(QAbstractListModel):
     """A simple QAbstractListModel around a Python list."""
     def __init__(self, data, parent=None, display=display, edit=None, tooltip=None, icon=None):
         """Initializes the list.
-        
+
         parent may be a parent QObject.
         display, tooltip and icon may be functions that extract the data from an item
         for the respective role (DisplayRole, ToolTipRole or DecorationRole).
-        
+
         The original data can be found in the _data attribute.
-        
+
         """
         super(ListModel, self).__init__(parent)
         self._data = data
@@ -69,22 +69,22 @@ class ListModel(QAbstractListModel):
             self._roles[Qt.ToolTipRole] = tooltip
         if icon:
             self._roles[Qt.DecorationRole] = icon
-    
+
     def setRoleFunction(self, role, function):
         """Sets a function that returns a value for a Qt.ItemDataRole.
-        
+
         The function accepts an item in the data list given on construction
         as argument. If function is None, deletes a previously set function.
-        
+
         """
         if function:
             self._roles[role] = function
         elif role in self._roles:
             del self._roles[role]
-    
+
     def rowCount(self, parent):
         return 0 if parent.isValid() else len(self._data)
-    
+
     def data(self, index, role):
         try:
             data = self._data[index.row()]
@@ -98,9 +98,9 @@ class ListModel(QAbstractListModel):
 
     def update(self):
         """Emits the dataChanged signal for all entries.
-        
+
         This can e.g. be used to request that translated strings are redisplayed.
-        
+
         """
         self.dataChanged.emit(
             self.createIndex(0, 0),

--- a/frescobaldi_app/log.py
+++ b/frescobaldi_app/log.py
@@ -42,39 +42,39 @@ class Log(QTextBrowser):
         self._types = job.ALL
         self._lasttype = None
         self._formats = self.logformats()
-        
+
     def setMessageTypes(self, types):
         """Set the types of Job output to display.
-        
+
         types is a constant bitmask from job, like job.STDOUT etc.
         By default job.ALL is used.
-        
+
         """
         self._types = types
-    
+
     def messageTypes(self):
         """Return the set message types (job.ALL by default)."""
         return self._types
-    
+
     def connectJob(self, job):
         """Gives us the output from the Job (past and upcoming)."""
         for msg, type in job.history():
             self.write(msg, type)
         job.output.connect(self.write)
-        
+
     def textFormat(self, type):
         """Returns a QTextFormat() for the given type."""
         return self._formats[type]
 
     def write(self, message, type):
         """Writes the given message with the given type to the log.
-        
+
         The keepScrolledDown context manager is used to scroll the log further
         down if it was scrolled down at that moment.
-        
+
         If two messages of a different type are written after each other a newline
         is inserted if otherwise the message would continue on the same line.
-        
+
         """
         if type & self._types:
             with self.keepScrolledDown():
@@ -83,11 +83,11 @@ class Log(QTextBrowser):
                 if changed and self.cursor.block().text() and not message.startswith('\n'):
                     self.cursor.insertText('\n')
                 self.writeMessage(message, type)
-    
+
     def writeMessage(self, message, type):
         """Inserts the given message in the text with the textformat belonging to type."""
         self.cursor.insertText(message, self.textFormat(type))
-    
+
     @contextlib.contextmanager
     def keepScrolledDown(self):
         """Performs a function, ensuring the log stays scrolled down if it was scrolled down on start."""
@@ -98,50 +98,50 @@ class Log(QTextBrowser):
         finally:
             if scrolleddown:
                 vbar.setValue(vbar.maximum())
-    
+
     def logformats(self):
         """Returns a dictionary with QTextCharFormats for the different types of messages.
-        
+
         Besides the STDOUT, STDERR, NEUTRAL, FAILURE and SUCCESS formats there is also
         a "link" format, that looks basically the same as the output formats, but blueish
         and underlined, to make parts of the output (e.g. filenames) look clickable.
-        
+
         """
         textColor = QApplication.palette().color(QPalette.WindowText)
         successColor = qutil.addcolor(textColor, 0, 128, 0) # more green
         failureColor = qutil.addcolor(textColor, 128, 0, 0) # more red
         linkColor    = qutil.addcolor(textColor, 0, 0, 128) # more blue
         stdoutColor  = qutil.addcolor(textColor, 64, 64, 0) # more purple
-        
+
         s = QSettings()
         s.beginGroup("log")
         outputFont = QFont(s.value("fontfamily", "monospace", str))
         outputFont.setPointSizeF(s.value("fontsize", 9.0, float))
-        
+
         output = QTextCharFormat()
         output.setFont(outputFont)
         # enable zooming the log font size
         output.setProperty(QTextFormat.FontSizeAdjustment, 0)
-        
+
         stdout = QTextCharFormat(output)
         stdout.setForeground(stdoutColor)
-        
+
         stderr = QTextCharFormat(output)
         link   = QTextCharFormat(output)
         link.setForeground(linkColor)
         link.setFontUnderline(True)
-        
+
         status = QTextCharFormat()
         status.setFontWeight(QFont.Bold)
-        
+
         neutral = QTextCharFormat(status)
-        
+
         success = QTextCharFormat(status)
         success.setForeground(successColor)
-        
+
         failure = QTextCharFormat(status)
         failure.setForeground(failureColor)
-        
+
         return {
             job.STDOUT: stdout,
             job.STDERR: stderr,

--- a/frescobaldi_app/logtool/__init__.py
+++ b/frescobaldi_app/logtool/__init__.py
@@ -45,15 +45,15 @@ class LogTool(panel.Panel):
         mainwindow.addDockWidget(Qt.BottomDockWidgetArea, self)
         app.jobStarted.connect(self.slotJobStarted)
         app.jobFinished.connect(self.slotJobFinished)
-    
+
     def translateUI(self):
         self.setWindowTitle(_("LilyPond Log"))
         self.toggleViewAction().setText(_("LilyPond &Log"))
-        
+
     def createWidget(self):
         from . import logwidget
         return logwidget.LogWidget(self)
-    
+
     def slotJobStarted(self, doc, job):
         """Called whenever job starts, decides whether to follow it and show the log."""
         import jobattributes
@@ -69,27 +69,27 @@ class LogTool(panel.Panel):
                 and not jobattributes.get(job).hidden
                 and document == self.mainwindow().currentDocument()):
             self.show()
-    
+
     def slotNextError(self):
         """Jumps to the position pointed to by the next error message."""
         self.activate()
         self.widget().gotoError(1)
-    
+
     def slotPreviousError(self):
         """Jumps to the position pointed to by the next error message."""
         self.activate()
         self.widget().gotoError(-1)
-        
+
 
 class Actions(actioncollection.ActionCollection):
     name = "logtool"
     def createActions(self, parent=None):
         self.log_next_error = QAction(parent)
         self.log_previous_error = QAction(parent)
-        
+
         self.log_next_error.setShortcut(QKeySequence("Ctrl+E"))
         self.log_previous_error.setShortcut(QKeySequence("Ctrl+Shift+E"))
-        
+
     def translateUI(self):
         self.log_next_error.setText(_("Next Error Message"))
         self.log_previous_error.setText(_("Previous Error Message"))

--- a/frescobaldi_app/logtool/errors.py
+++ b/frescobaldi_app/logtool/errors.py
@@ -49,20 +49,20 @@ def errors(document):
 
 class Errors(plugin.DocumentPlugin):
     """Maintains the list of references (errors/warnings) to documents after a Job run."""
-    
+
     def __init__(self, document):
         self._refs = {}
         mgr = jobmanager.manager(document)
         if mgr.job():
             self.connectJob(mgr.job())
         mgr.started.connect(self.connectJob)
-        
+
     def connectJob(self, job):
         """Starts collecting the references of a started Job.
-        
+
         Output already created by the Job is read and we start
         listening for new output.
-        
+
         """
         # do not collect errors for auto-engrave jobs if the user has disabled it
         if jobattributes.get(job).hidden and QSettings().value("log/hide_auto_engrave", False, bool):
@@ -80,13 +80,13 @@ class Errors(plugin.DocumentPlugin):
         for msg, type in job.history():
             self.slotJobOutput(msg, type)
         job.output.connect(self.slotJobOutput)
-    
+
     def slotJobOutput(self, message, type):
         """Called whenever the job has output.
-        
+
         The output is checked for error messages that contain
         a filename:line:column expression.
-        
+
         """
         if type == job.STDERR:
             enc = sys.getfilesystemencoding()
@@ -96,14 +96,14 @@ class Errors(plugin.DocumentPlugin):
                 filename = util.normpath(filename)
                 line, column = int(m.group(3)), int(m.group(4) or 0)
                 self._refs[url] = Reference(filename, line, column)
-        
+
     def cursor(self, url, load=False):
         """Returns a QTextCursor belonging to the url (string).
-        
+
         If load (defaulting to False) is True, the document is loaded
         if it wasn't already loaded.
         Returns None if the url was not valid or the document could not be loaded.
-        
+
         """
         return self._refs[url].cursor(load)
 
@@ -112,32 +112,32 @@ class Reference(object):
     """Represents a reference to a line/column pair (a cursor position) in a Document."""
     def __init__(self, filename, line, column):
         """Creates the reference to filename, line and column.
-        
+
         lines start numbering with 1, columns with 0 (LilyPond convention).
-        
+
         If a document with the given filename is already loaded (or the filename
         refers to the scratchdir for a document) a QTextCursor is created immediately.
-        
+
         Otherwise, when a Document is loaded later with our filename, a QTextCursor
         is created then (by the bind() method).
-        
+
         """
         self._filename = filename
         self._line = line
         self._column = column
         self._cursor = None
-        
+
         app.documentLoaded.connect(self.trybind)
         d = scratchdir.findDocument(filename)
         if d:
             self.bind(d)
-    
+
     def bind(self, document):
         """Called when a document is loaded this Reference points to.
-        
+
         Creates a QTextCursor so the position is maintained even if the document
         changes.
-        
+
         """
         b = document.findBlockByNumber(max(0, self._line - 1))
         if b.isValid():
@@ -148,11 +148,11 @@ class Reference(object):
                 bookmarks.bookmarks(document).setMark(self._line - 1, "error")
         else:
             self._cursor = None
-            
+
     def unbind(self):
         """Called when previously "bound" document is closed."""
         self._cursor = None
-    
+
     def trybind(self, document):
         """Called whenever a new Document is loaded, checks the filename."""
         if document.url().toLocalFile() == self._filename:
@@ -160,10 +160,10 @@ class Reference(object):
 
     def cursor(self, load):
         """Returns a QTextCursor for this reference.
-        
+
         load should be True or False and determines if a not-loaded document should be loaded.
         Returns None if the document could not be loaded.
-        
+
         """
         if self._cursor:
             return self._cursor

--- a/frescobaldi_app/logtool/logwidget.py
+++ b/frescobaldi_app/logtool/logwidget.py
@@ -59,13 +59,13 @@ class LogWidget(log.Log):
         doc = logtool.mainwindow().currentDocument()
         if doc:
             self.switchDocument(doc)
-    
+
     def readSettings(self):
         self._formats = self.logformats()
         self._rawView = QSettings().value("log/rawview", True, bool)
         if self._document():
             self.switchDocument(self._document()) # reload
-    
+
     def switchDocument(self, doc):
         """Called when the document is changed."""
         job = jobmanager.job(doc)
@@ -81,7 +81,7 @@ class LogWidget(log.Log):
             self._document = weakref.ref(doc)
             self.clear()
             self.connectJob(job)
-            
+
     def documentClosed(self, doc):
         if doc == self._document():
             self.clear()
@@ -91,14 +91,14 @@ class LogWidget(log.Log):
         self._currentErrorIndex = -1
         self.setExtraSelections([])
         super(LogWidget, self).clear()
-    
+
     def writeMessage(self, message, type):
         """This writes both status and output messages to the log.
-        
+
         For output messages also the correct encoding is re-applied:
         LilyPond writes filenames out in the system's filesystemencoding,
         while the messages are always written in UTF-8 encoding...
-        
+
         """
         if type == job.STDERR:
             # find filenames in message:
@@ -106,7 +106,7 @@ class LogWidget(log.Log):
             msg = next(parts).decode('utf-8', 'replace')
             self.cursor.insertText(msg, self.textFormat(type))
             enc = sys.getfilesystemencoding()
-            
+
             for url, path, line, col, msg in zip(*itertools.repeat(parts, 5)):
                 url = url.decode(enc)
                 path = path.decode(enc)
@@ -120,7 +120,7 @@ class LogWidget(log.Log):
                 fmt.setAnchor(True)
                 fmt.setAnchorHref(str(len(self._errors)))
                 fmt.setToolTip(_("Click to edit this file"))
-                
+
                 pos = self.cursor.position()
                 self.cursor.insertText(display_url, fmt)
                 self.cursor.insertText(msg, self.textFormat(type))
@@ -138,7 +138,7 @@ class LogWidget(log.Log):
         index = int(url.toString())
         if 0 <= index < len(self._errors):
             self.highlightError(index)
-    
+
     def gotoError(self, direction):
         """Jumps to the next (1) or previous (-1) error message."""
         if self._errors:
@@ -148,7 +148,7 @@ class LogWidget(log.Log):
             elif i >= len(self._errors):
                 i = 0
             self.highlightError(i)
-    
+
     def highlightError(self, index):
         """Hihglights the error message at the given index and jumps to its location."""
         self._currentErrorIndex = index

--- a/frescobaldi_app/lydocinfo.py
+++ b/frescobaldi_app/lydocinfo.py
@@ -20,10 +20,10 @@
 """
 Harvest information from a ly.document.DocumentBase instance.
 
-This extends the ly.docinfo.DocInfo class with some behaviour specific to 
+This extends the ly.docinfo.DocInfo class with some behaviour specific to
 Frescobaldi, such as variables.
 
-With this module, information extracted from tokenized LilyPond source is 
+With this module, information extracted from tokenized LilyPond source is
 available to both text documents on disk and loaded Frescobaldi documents.
 
 """
@@ -37,12 +37,12 @@ import ly.docinfo
 
 class DocInfo(ly.docinfo.DocInfo):
     """Add Frescobaldi-specific stuff to ly.docinfo.DocInfo."""
-    
+
     def __init__(self, doc, variables):
         """Initialize with ly.document instance and variables dictionary."""
         super(DocInfo, self).__init__(doc)
         self.variables = variables
-    
+
     @ly.docinfo._cache
     def version_string(self):
         """Return the version, but also looks in the variables and comments."""

--- a/frescobaldi_app/lydocument.py
+++ b/frescobaldi_app/lydocument.py
@@ -26,7 +26,7 @@ a Frescobaldi document.Document).
 This can be used to perform operations from the ly module on a loaded
 Frescobaldi document.
 
-You don't need to save a Document instance. Just create it and use it, then 
+You don't need to save a Document instance. Just create it and use it, then
 discard it.
 
 """
@@ -42,23 +42,23 @@ import highlighter
 
 def cursor(cursor, select_all=False):
     """Return a Cursor for the specified QTextCursor.
-    
+
     The ly Cursor is instantiated with a Document proxying for the
     original cursors document.
-    
+
     So you can call all operations in the ly module and they will work on a
     Frescobaldi document (which is a subclass of QTextDocument).
-    
-    If select_all is True, the ly Cursor selects the whole document if the 
+
+    If select_all is True, the ly Cursor selects the whole document if the
     original cursor has no selection.
-    
+
     """
     if not select_all or cursor.hasSelection():
         start, end = cursor.selectionStart(), cursor.selectionEnd()
     else:
         start, end = 0, None
     return Cursor(Document(cursor.document()), start, end)
-    
+
 
 class Cursor(ly.document.Cursor):
     """A ly.document.Cursor with an extra cursor() method."""
@@ -72,65 +72,65 @@ class Cursor(ly.document.Cursor):
 
 class Document(ly.document.DocumentBase):
     """Document proxies a loaded Frescobaldi document (QTextDocument).
-    
+
     This is used to let the tools in the ly module operate on Frescobaldi
     documents.
-    
-    Creating a Document is very fast, you do not need to save it. When 
-    applying the changes, Document starts an editblock, so that the 
+
+    Creating a Document is very fast, you do not need to save it. When
+    applying the changes, Document starts an editblock, so that the
     operations appears as one undo-item.
-    
-    It is recommended to not nest calls to QTextCursor.beginEditBlock(), as 
-    the highlighter is not called to update the tokens until the last 
+
+    It is recommended to not nest calls to QTextCursor.beginEditBlock(), as
+    the highlighter is not called to update the tokens until the last
     endEditBlock() is called.
-    
-    Therefore Document provides a simple mechanism for combining several 
+
+    Therefore Document provides a simple mechanism for combining several
     change operations via the combine_undo attribute.
-    
+
     If combine_undo is None (the default), the first time changes are applied
-    QTextCursor.beginEditBlock() will be called, but subsequent times 
-    QTextCursor.joinPreviousEditBlock() will be used. So the highlighter 
-    updates the tokens between the operations, but they will appear as one 
+    QTextCursor.beginEditBlock() will be called, but subsequent times
+    QTextCursor.joinPreviousEditBlock() will be used. So the highlighter
+    updates the tokens between the operations, but they will appear as one
     undo-item.
-    
-    If you want to combine the very first operation already with an earlier 
-    change, set combine_undo to True before the changes are applied (e.g. 
+
+    If you want to combine the very first operation already with an earlier
+    change, set combine_undo to True before the changes are applied (e.g.
     before entering or exiting the context).
-    
+
     If you do not want to combine operations into a single undo-item at all,
     set combine_undo to False.
-    
-    (Of course you can nest calls to QTextCursor.beginEditBlock(), but in 
-    that case the tokens will not be updated between your operations. If 
-    your operations do not depend on the tokens, it is no problem 
-    whatsoever. The tokens *are* updated after the last call to 
+
+    (Of course you can nest calls to QTextCursor.beginEditBlock(), but in
+    that case the tokens will not be updated between your operations. If
+    your operations do not depend on the tokens, it is no problem
+    whatsoever. The tokens *are* updated after the last call to
     QTextCursor.endEditBlock().)
-    
+
     """
-    
+
     def __init__(self, document):
         self._d = document
         super(Document, self).__init__()
         self.combine_undo = None
-    
+
     def __len__(self):
         """Return the number of blocks"""
         return self._d.blockCount()
-    
+
     def __getitem__(self, index):
         """Return the block at the specified index."""
         return self._d.findBlockByNumber(index)
-        
+
     @property
     def document(self):
         """Return the QTextDocument we were instantiated with."""
         return self._d
-    
+
     @property
     def filename(self):
         """Return the document's local filename, if any."""
         return self.document.url().toLocalFile()
-    
+
     def plaintext(self):
         """The document contents as a plain text string."""
         return self._d.toPlainText()
@@ -145,19 +145,19 @@ class Document(ly.document.DocumentBase):
 
     def block(self, position):
         """Return the text block at the specified character position.
-        
+
         The text block itself has no methods, but it can be used as an
         argument to other methods of this class.
-        
+
         (Blocks do have to support the '==' operator.)
-        
+
         """
         return self._d.findBlock(position)
-    
+
     def index(self, block):
         """Return the linenumber of the block (starting with 0)."""
         return block.blockNumber()
-         
+
     def position(self, block):
         """Return the position of the specified block."""
         return block.position()
@@ -165,19 +165,19 @@ class Document(ly.document.DocumentBase):
     def text(self, block):
         """Return the text of the specified block."""
         return block.text()
-    
+
     def next_block(self, block):
         """Return the next block, which may be invalid."""
         return block.next()
-    
+
     def previous_block(self, block):
         """Return the previous block, which may be invalid."""
         return block.previous()
-    
+
     def isvalid(self, block):
         """Return True if the block is a valid block."""
         return block.isValid()
-    
+
     def apply_changes(self):
         """Apply the changes and update the tokens."""
         c = QTextCursor(self._d)
@@ -193,19 +193,19 @@ class Document(ly.document.DocumentBase):
             c.endEditBlock()
             if self.combine_undo is None:
                 self.combine_undo = True
-        
+
     def tokens(self, block):
         """Return the tuple of tokens of the specified block."""
         return tokeniter.tokens(block)
-        
+
     def initial_state(self):
         """Return the state at the beginning of the document."""
         return highlighter.highlighter(self._d).initialState()
-        
+
     def state(self, block):
         """Return the state at the start of the specified block."""
         return tokeniter.state(block)
-            
+
     def state_end(self, block):
         """Return the state at the end of the specified block."""
         return tokeniter.state_end(block)
@@ -215,12 +215,12 @@ class Runner(ly.document.Runner):
     """A Runner that adds a cursor() method, returning a QTextCursor."""
     def cursor(self, start=0, end=None):
         """Returns a QTextCursor for the last token.
-        
+
         If start is given the cursor will start at position start in the token
         (from the beginning of the token). Start defaults to 0.
         If end is given, the cursor will end at that position in the token (from
         the beginning of the token). End defaults to the length of the token.
-        
+
         """
         if end is None:
             end = len(self.token())
@@ -234,12 +234,12 @@ class Source(ly.document.Source):
     """A Source that adds a cursor() method, returning a QTextCursor."""
     def cursor(self, token, start=0, end=None):
         """Returns a QTextCursor for the specified token.
-        
+
         If start is given the cursor will start at position start in the token
         (from the beginning of the token). Start defaults to 0.
         If end is given, the cursor will end at that position in the token (from
         the beginning of the token). End defaults to the length of the token.
-        
+
         """
         if end is None:
             end = len(token)

--- a/frescobaldi_app/lyrics.py
+++ b/frescobaldi_app/lyrics.py
@@ -42,7 +42,7 @@ _word_re = re.compile(r"[^\W0-9_]+", re.UNICODE)
 
 def lyrics(mainwindow):
     return Lyrics.instance(mainwindow)
-    
+
 
 class Lyrics(plugin.MainWindowPlugin):
     def __init__(self, mainwindow):
@@ -53,11 +53,11 @@ class Lyrics(plugin.MainWindowPlugin):
         ac.lyrics_copy_dehyphenated.triggered.connect(self.copy_dehyphenated)
         mainwindow.selectionStateChanged.connect(self.updateSelection)
         self.updateSelection(mainwindow.hasSelection())
-        
+
     def updateSelection(self, selection):
         self.actionCollection.lyrics_dehyphenate.setEnabled(selection)
         self.actionCollection.lyrics_copy_dehyphenated.setEnabled(selection)
-    
+
     def hyphenate(self):
         """Hyphenates selected Lyrics text."""
         view = self.mainwindow().currentView()
@@ -95,7 +95,7 @@ class Lyrics(plugin.MainWindowPlugin):
                         hyph_word = h.inserted(word, ' -- ')
                         if word != hyph_word:
                             d[start:end] = hyph_word
-            
+
     def dehyphenate(self):
         """De-hyphenates selected Lyrics text."""
         view = self.mainwindow().currentView()
@@ -104,7 +104,7 @@ class Lyrics(plugin.MainWindowPlugin):
         if ' --' in text:
             with cursortools.keep_selection(cursor, view):
                 cursor.insertText(removehyphens(text))
-            
+
     def copy_dehyphenated(self):
         """Copies selected lyrics text to the clipboard with hyphenation removed."""
         text = self.mainwindow().textCursor().selection().toPlainText()
@@ -113,15 +113,15 @@ class Lyrics(plugin.MainWindowPlugin):
 
 class Actions(actioncollection.ActionCollection):
     name = "lyrics"
-    
+
     def createActions(self, parent=None):
-        
+
         self.lyrics_hyphenate = QAction(parent)
         self.lyrics_dehyphenate = QAction(parent)
         self.lyrics_copy_dehyphenated = QAction(parent)
-        
+
         self.lyrics_hyphenate.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_L))
-        
+
     def translateUI(self):
         self.lyrics_hyphenate.setText(_("&Hyphenate Lyrics Text..."))
         self.lyrics_dehyphenate.setText(_("&Remove hyphenation"))

--- a/frescobaldi_app/macosx/__init__.py
+++ b/frescobaldi_app/macosx/__init__.py
@@ -50,10 +50,10 @@ def use_osx_menu_roles():
 
 def system_python():
     """Return a list containing the command line to run the system Python.
-    
+
     (One of) the system-provided Python interpreter(s) is selected to run
     the tools included in LilyPond, e.g. convert-ly.
-    
+
     The system-provided Python interpreter must be explicitly called:
     - the LilyPond-provided interpreter lacks many modules (and is
       difficult to run properly from outside the application bundle);
@@ -63,7 +63,7 @@ def system_python():
       the PATH variable is not set;
     - the interpreter included in Frescobaldi's application bundle,
       when present, lacks some modules.
-    
+
     The earliest Python version >= 2.4 is called in 32 bit mode, for
     compatibility with midi2ly and lilysong, although Frescobaldi does not
     currently support the latter.
@@ -72,7 +72,7 @@ def system_python():
     - Python >= 2.5 gives a "C API version mismatch" RuntimeWarning
       on `import midi`;
     - Python >= 2.6 gives a DeprecationWarning on `import popen2`.
-    
+
     """
     for v in ['4', '5', '6', '7']:
         python = '/System/Library/Frameworks/Python.framework/Versions/2.' + v

--- a/frescobaldi_app/macosx/file_open_eventhandler.py
+++ b/frescobaldi_app/macosx/file_open_eventhandler.py
@@ -36,11 +36,11 @@ handler = None
 
 def openUrl(url):
     """Open Url.
-    
+
     If there is an active MainWindow, the document is made the current
     document in that window. If there is no MainWindow at all, it is
     created.
-    
+
     """
     win = app.activeWindow()
     if not win:

--- a/frescobaldi_app/macosx/globalmenu.py
+++ b/frescobaldi_app/macosx/globalmenu.py
@@ -120,7 +120,7 @@ def menu_file_import(parent):
     m.setTitle(_("submenu title", "&Import"))
     m.addAction(_("Import MusicXML..."), file_import_musicxml)
     return m
-    
+
 def menu_edit(parent):
     m = QMenu(parent)
     m.setTitle(_("menu title", "&Edit"))
@@ -143,8 +143,8 @@ def menu_sessions(parent):
         a = m.addAction(name.replace('&', '&&'))
         a.setObjectName(name)
     qutil.addAccelerators(m.actions())
-    return m    
-    
+    return m
+
 def menu_help(parent):
     m = QMenu(parent)
     m.setTitle(_('menu title', '&Help'))

--- a/frescobaldi_app/macosx/setup.py
+++ b/frescobaldi_app/macosx/setup.py
@@ -44,12 +44,12 @@ def initialize():
     # multiple documents drastically.
     from . import file_open_eventhandler
     file_open_eventhandler.initialize()
-    
+
     # handle window icon drag events
     from . import icon_drag_eventhandler
     icon_drag_eventhandler.initialize()
-    
-    # on mac os, the app should remain running, even if there is no main window 
+
+    # on mac os, the app should remain running, even if there is no main window
     # anymore. In this case, we setup a basic global menu.
     app.qApp.setQuitOnLastWindowClosed(False)
 

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -44,10 +44,10 @@ import remote           # IPC with other Frescobaldi instances
 
 def parse_commandline():
     """Parses the command line; returns options and filenames.
-    
+
     If --version, --help or invalid options were given, the application will
     exit.
-    
+
     """
     import argparse
     argparse._ = _ # let argparse use our translations
@@ -72,9 +72,9 @@ def parse_commandline():
         help=_("List the session names and exit"))
     parser.add_argument('-n', '--new', action="store_true", default=False,
         help=_("Always start a new instance"))
-    parser.add_argument('files', metavar=_("file"), nargs='*', 
+    parser.add_argument('files', metavar=_("file"), nargs='*',
         help=_("File to be opened"))
-    
+
     # Make sure debugger options are recognized as valid. These are passed automatically
     # from PyDev in Eclipse to the inferior process.
     if "pydevd" in sys.modules:
@@ -147,17 +147,17 @@ def patch_pyqt():
 
 def check_ly():
     """Check if ly is installed and has the correct version.
-    
+
     If python-ly is not available or too old, we display a critical message
     and exit.  In the future we will probably remove this function.
     In a good software distribution this should never happen, but it can happen
     when a user leaves the old stale 'ly' package in the frescobaldi_app
     directory, or has not installed python-ly at all.
-    
+
     Because that yields unexpected behaviour and error messages, we better
     check for the availability of the 'ly' module beforehand.
     Importing ly.pkginfo is not expensive.
-    
+
     """
     ly_required = (0, 9, 4)
     try:
@@ -183,23 +183,23 @@ def check_ly():
 def main():
     """Main function."""
     args = parse_commandline()
-    
+
     if args.version_debug:
         import debuginfo
         sys.stdout.write(debuginfo.version_info_string() + '\n')
         sys.exit(0)
-    
+
     check_ly()
     patch_pyqt()
-    
+
     if args.list_sessions:
         import sessions
         for name in sessions.sessionNames():
             sys.stdout.write(name + '\n')
         sys.exit(0)
-    
+
     urls = list(map(url, args.files))
-    
+
     if not app.qApp.isSessionRestored():
         if not args.new and remote.enabled():
             api = remote.get()
@@ -207,7 +207,7 @@ def main():
                 api.command_line(args, urls)
                 api.close()
                 sys.exit(0)
-    
+
         if QSettings().value("splash_screen", True, bool):
             import splashscreen
             splashscreen.show()
@@ -215,9 +215,9 @@ def main():
     # application icon
     import icons
     QApplication.setWindowIcon(icons.get("frescobaldi"))
-    
+
     QTimer.singleShot(0, remote.setup)  # Start listening for IPC
-    
+
     import mainwindow       # contains MainWindow class
     import session          # Initialize QSessionManager support
     import sessions         # Initialize our own named session support
@@ -228,11 +228,11 @@ def main():
     import musicpos         # shows music time in statusbar
     import autocomplete     # auto-complete input
     import wordboundary     # better wordboundary behaviour for the editor
-    
+
     if sys.platform.startswith('darwin'):
         import macosx.setup
         macosx.setup.initialize()
-    
+
     if app.qApp.isSessionRestored():
         # Restore session, we are started by the session manager
         session.restoreSession(app.qApp.sessionKey())
@@ -242,19 +242,19 @@ def main():
     doc = None
     if args.session and args.session != "-":
         doc = sessions.loadSession(args.session)
-    
+
     # Just create one MainWindow
     win = mainwindow.MainWindow()
     win.show()
     win.activateWindow()
-    
+
     # load documents given as arguments
     import document
     for u in urls:
         doc = win.openUrl(u, args.encoding, ignore_errors=True)
         if not doc:
             doc = document.Document(u, args.encoding)
-    
+
     # were documents loaded?
     if not doc:
         if app.documents:
@@ -262,12 +262,12 @@ def main():
         elif not args.session:
             # no docs, load default session
             doc = sessions.loadDefaultSession()
-    
+
     if doc:
         win.setCurrentDocument(doc)
     else:
         win.cleanStart()
-    
+
     if urls and args.line is not None:
         # set the last loaded document active and apply navigation if requested
         pos = doc.findBlockByNumber(args.line - 1).position() + args.column

--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -337,7 +337,7 @@ class MainWindow(QMainWindow):
             else:
                 allow_close = res == QMessageBox.Discard
         return allow_close and engrave.engraver(self).queryCloseDocument(doc)
-    
+
     def createPopupMenu(self):
         """ Adds an entry to the popup menu to show/hide the tab bar. """
         menu = QMainWindow.createPopupMenu(self)
@@ -529,7 +529,7 @@ class MainWindow(QMainWindow):
                         break
                 else:
                     directory = app.basedir() # default directory to save to
-                
+
                 import documentinfo
                 import ly.lex
                 filename = os.path.join(directory, documentinfo.defaultfilename(doc))

--- a/frescobaldi_app/matcher.py
+++ b/frescobaldi_app/matcher.py
@@ -60,15 +60,15 @@ class AbstractMatcher(object):
             view.cursorPositionChanged.connect(self.showMatches)
         else:
             self._view = lambda: None
-    
+
     def view(self):
         """Return the current View."""
         return self._view()
-    
+
     def highlighter(self):
         """Implement to return an ArbitraryHighlighter for the current View."""
         pass
-    
+
     def showMatches(self):
         """Highlights matching tokens if the view's cursor is at such a token."""
         cursors = matches(self.view().textCursor(), self.view())
@@ -91,18 +91,18 @@ class Matcher(AbstractMatcher, plugin.MainWindowPlugin):
         view = mainwindow.currentView()
         if view:
             self.setView(view)
-        
+
     def highlighter(self):
         return viewhighlighter.highlighter(self.view())
 
     def moveto_match(self):
         """Jump to the matching token."""
         self.goto_match(False)
-        
+
     def select_match(self):
         """Select from the current to the matching token."""
         self.goto_match(True)
-        
+
     def goto_match(self, select=False):
         """Jump to the matching token, selecting the text if select is True."""
         cursor = self.view().textCursor()
@@ -126,7 +126,7 @@ class Actions(actioncollection.ActionCollection):
     def createActions(self, parent):
         self.view_matching_pair = QAction(parent)
         self.view_matching_pair_select = QAction(parent)
-    
+
     def translateUI(self):
         self.view_matching_pair.setText(_("Matching Pai&r"))
         self.view_matching_pair_select.setText(_("&Select Matching Pair"))
@@ -134,20 +134,20 @@ class Actions(actioncollection.ActionCollection):
 
 def matches(cursor, view=None):
     """Return a list of zero to two cursors specifying matching tokens.
-    
+
     If the list is empty, the cursor was not at a MatchStart/MatchEnd token,
     if the list only contains one cursor the matching token could not be found,
     if the list contains two cursors, the first is the token the cursor was at,
     and the second is the matching token.
-    
+
     If view is given, only the visible part of the document is searched.
-    
+
     """
     block = cursor.block()
     column = cursor.position() - block.position()
     tokens = lydocument.Runner(lydocument.Document(cursor.document()))
     tokens.move_to_block(block)
-    
+
     if view is not None:
         first_block = view.firstVisibleBlock()
         bottom = view.contentOffset().y() + view.viewport().height()
@@ -156,7 +156,7 @@ def matches(cursor, view=None):
     else:
         pred_forward = lambda: True
         pred_backward = lambda: True
-    
+
     source = None
     for token in tokens.forward_line():
         if token.pos <= column <= token.end:

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -57,7 +57,7 @@ _ = lambda *args: lambda: builtins._(*args)
 def createMenus(mainwindow):
     """Adds all the menus to the mainwindow's menubar."""
     m = mainwindow.menuBar()
-    
+
     m.addMenu(menu_file(mainwindow))
     m.addMenu(menu_edit(mainwindow))
     m.addMenu(menu_view(mainwindow))
@@ -82,7 +82,7 @@ class Menu(QMenu):
         self.setToolTipsVisible(True)
         self.title_func = title_func
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(self.title_func())
 
@@ -90,7 +90,7 @@ class Menu(QMenu):
 def menu_file(mainwindow):
     m = Menu(_("menu title", "&File"), mainwindow)
     ac = mainwindow.actionCollection
-    
+
     m.addAction(ac.file_new)
     m.addAction(scorewiz.ScoreWizard.instance(mainwindow).actionCollection.scorewiz)
     m.addMenu(snippet.menu.TemplateMenu(mainwindow))
@@ -128,7 +128,7 @@ def menu_file(mainwindow):
 def menu_file_import(mainwindow):
     m = Menu(_("submenu title", "&Import"), mainwindow)
     ac = file_import.FileImport.instance(mainwindow).actionCollection
-    
+
     m.addAction(ac.import_all)
     m.addSeparator()
     m.addAction(ac.import_musicxml)
@@ -141,13 +141,13 @@ def menu_file_export(mainwindow):
     m = Menu(_("submenu title", "&Export"), mainwindow)
     ac = mainwindow.actionCollection
     acfe = file_export.FileExport.instance(mainwindow).actionCollection
-    
+
     if vcs.app_is_git_controlled() or QSettings().value("experimental-features", False, bool):
         m.addAction(acfe.export_audio)
         m.addAction(acfe.export_musicxml)
     m.addAction(ac.export_colored_html)
     return m
-    
+
 
 def menu_edit(mainwindow):
     m = Menu(_("menu title", "&Edit"), mainwindow)
@@ -174,13 +174,13 @@ def menu_edit(mainwindow):
     m.addAction(ac.edit_replace)
     m.addSeparator()
     m.addAction(ac.edit_preferences)
-    return m    
+    return m
 
 
 def menu_view(mainwindow):
     m = Menu(_("menu title", "&View"), mainwindow)
     ac = mainwindow.actionCollection
-    
+
     m.addAction(ac.view_next_document)
     m.addAction(ac.view_previous_document)
     m.addSeparator()
@@ -214,7 +214,7 @@ def menu_view(mainwindow):
 def menu_view_folding(mainwindow):
     m = Menu(_("submenu title", "&Folding"), mainwindow)
     ac = sidebar.SideBarManager.instance(mainwindow).actionCollection
-    
+
     m.addAction(ac.folding_enable)
     m.addSeparator()
     m.addAction(ac.folding_fold_current)
@@ -229,7 +229,7 @@ def menu_view_folding(mainwindow):
 def menu_music(mainwindow):
     m = Menu(_("menu title", "&Music"), mainwindow)
     ac = panelmanager.manager(mainwindow).musicview.actionCollection
-    
+
     m.addAction(ac.music_reload)
     m.addSeparator()
     m.addAction(ac.music_zoom_in)
@@ -261,7 +261,7 @@ def menu_snippets(mainwindow):
 def menu_lilypond(mainwindow):
     m = Menu(_("menu title", "&LilyPond"), mainwindow)
     ac = engrave.engraver(mainwindow).actionCollection
-    
+
     m.addAction(ac.engrave_sticky)
     m.addAction(ac.engrave_autocompile)
     m.addSeparator()
@@ -284,7 +284,7 @@ def menu_lilypond_generated_files(mainwindow):
 
 def menu_tools(mainwindow):
     m = Menu(_('menu title', '&Tools'), mainwindow)
-    
+
     ac = documentactions.get(mainwindow).actionCollection
     m.addAction(ac.tools_indent_auto)
     m.addAction(ac.tools_indent_indent)
@@ -326,7 +326,7 @@ def menu_tools_pitch(mainwindow):
     m = Menu(_('submenu title', "&Pitch"), mainwindow)
     m.setIcon(icons.get('tools-pitch'))
     ac = pitch.Pitch.instance(mainwindow).actionCollection
-    
+
     m.addAction(ac.pitch_language)
     m.addSeparator()
     m.addAction(ac.pitch_relative_assume_first_pitch_absolute)
@@ -345,7 +345,7 @@ def menu_tools_rest(mainwindow):
     m = Menu(_('submenu title', "Rest"), mainwindow)
     m.setIcon(icons.get('tools-rest'))
     ac = rest.Rest.instance(mainwindow).actionCollection
-    
+
     m.addAction(ac.rest_fmrest2spacer)
     m.addAction(ac.rest_spacer2fmrest)
     m.addSeparator()
@@ -357,7 +357,7 @@ def menu_tools_rhythm(mainwindow):
     m = Menu(_('submenu title', "&Rhythm"), mainwindow)
     m.setIcon(icons.get('tools-rhythm'))
     ac = rhythm.Rhythm.instance(mainwindow).actionCollection
-    
+
     m.addAction(ac.rhythm_double)
     m.addAction(ac.rhythm_halve)
     m.addSeparator()
@@ -382,7 +382,7 @@ def menu_tools_quick_remove(mainwindow):
     m = Menu(_('submenu title', "&Quick Remove"), mainwindow)
     m.setIcon(icons.get('edit-clear'))
     ac = documentactions.DocumentActions.instance(mainwindow).actionCollection
-    
+
     m.addAction(ac.tools_quick_remove_comments)
     m.addAction(ac.tools_quick_remove_articulations)
     m.addAction(ac.tools_quick_remove_ornaments)

--- a/frescobaldi_app/metainfo.py
+++ b/frescobaldi_app/metainfo.py
@@ -44,10 +44,10 @@ def info(document):
 
 def define(name, default, readfunc=None):
     """Define a variable and its default value to be stored in the metainfo.
-    
+
     Should be defined before it is requested or set.
     If readfunc is not given it defaults to a suitable function for bool or int types.
-    
+
     """
     if readfunc is None:
         if isinstance(default, bool):
@@ -60,7 +60,7 @@ def define(name, default, readfunc=None):
         else:
             readfunc = lambda v: v
     _defaults[name] = [default, readfunc]
-    
+
     # read this value for already loaded metainfo items
     for minfo in MetaInfo.instances():
         minfo.loadValue(name)
@@ -72,19 +72,19 @@ class MetaInfo(plugin.DocumentPlugin):
         self.load()
         document.loaded.connect(self.load, -999) # before all others
         document.closed.connect(self.save,  999) # after all others
-        
+
     def settingsGroup(self):
         url = self.document().url()
         if not url.isEmpty():
             s = app.settings('metainfo')
             s.beginGroup(url.toString().replace('\\', '_').replace('/', '_'))
             return s
-        
+
     def load(self):
         s = self.settingsGroup()
         for name in _defaults:
             self.loadValue(name, s)
-        
+
     def loadValue(self, name, settings=None):
         s = settings or self.settingsGroup()
         default, readfunc = _defaults[name]
@@ -100,7 +100,7 @@ class MetaInfo(plugin.DocumentPlugin):
             for name in _defaults:
                 value = self.__dict__[name]
                 s.remove(name) if value == _defaults[name][0] else s.setValue(name, value)
-            
+
 
 @app.aboutToQuit.connect
 def prune():

--- a/frescobaldi_app/midifile/event.py
+++ b/frescobaldi_app/midifile/event.py
@@ -35,10 +35,10 @@ PitchBendEvent = collections.namedtuple('PitchBendEvent', 'channel value')
 
 class EventFactory(object):
     """Factory for parsed MIDI events.
-    
+
     The default 'methods' create namedtuple objects.
     You can override one or more of those names to return other objects.
-    
+
     """
     note_event = NoteEvent
     controller_event = ControllerEvent

--- a/frescobaldi_app/midifile/parser.py
+++ b/frescobaldi_app/midifile/parser.py
@@ -46,9 +46,9 @@ unpack_int = struct.Struct(b'>i').unpack
 
 def get_chunks(s):
     """Splits a MIDI file bytes string into chunks.
-    
+
     Yields (b'Name', b'data') tuples.
-    
+
     """
     pos = 0
     while pos < len(s):
@@ -57,15 +57,15 @@ def get_chunks(s):
         yield name, s[pos+8:pos+8+size]
         pos += size + 8
 
-    
+
 def parse_midi_data(s):
     """Parses MIDI file data from the bytes string s.
-    
+
     Returns a three tuple (format_type, time_division, tracks).
     Every track is an unparsed bytes string.
-    
+
     May raise ValueError or IndexError in case of invalid MIDI data.
-    
+
     """
     chunks = get_chunks(s)
     for name, data in chunks:
@@ -79,9 +79,9 @@ def parse_midi_data(s):
 
 def read_var_len(s, pos):
     """Reads variable-length integer from byte string s starting on pos.
-    
+
     Returns the value and the new position.
-    
+
     """
     value = 0
     while True:
@@ -94,28 +94,28 @@ def read_var_len(s, pos):
 
 def parse_midi_events(s, factory=None):
     """Parses the bytes string s (typically a track) for MIDI events.
-    
+
     If factory is given, it should be an EventFactory instance that
     returns objects describing the event.
-    
+
     Yields two-tuples (delta, event).
-    
+
     Raises ValueError or IndexError on invalid MIDI data.
-    
+
     """
     if factory is None:
         factory = event.EventFactory()
-        
+
     running_status = None
-    
+
     if PY2:
         s = bytearray(s)
-    
+
     pos = 0
     while pos < len(s):
-        
+
         delta, pos = read_var_len(s, pos)
-        
+
         status = s[pos]
         if status & 0x80:
             running_status = status
@@ -124,10 +124,10 @@ def parse_midi_events(s, factory=None):
             raise ValueError("invalid running status")
         else:
             status = running_status
-        
+
         ev_type = status >> 4
         channel = status & 0x0F
-        
+
         if ev_type <= 0x0A:
             # note on, off or aftertouch
             note = s[pos]
@@ -175,10 +175,10 @@ def parse_midi_events(s, factory=None):
 
 def time_events(track, time=0):
     """Yields two-tuples (time, event).
-    
+
     The track is the generator returned by parse_midi_events,
     the time is accumulated from the given starting time (defaulting to 0).
-    
+
     """
     for delta, ev in track:
         time += delta
@@ -187,11 +187,11 @@ def time_events(track, time=0):
 
 def time_events_grouped(track, time=0):
     """Yields two-tuples (time, event_list).
-    
+
     Every event_list is a Python list of all events happening on that time.
     The track is the generator returned by parse_midi_events,
     the time is accumulated from the given starting time (defaulting to 0).
-    
+
     """
     evs = []
     for delta, ev in track:

--- a/frescobaldi_app/midifile/player.py
+++ b/frescobaldi_app/midifile/player.py
@@ -30,11 +30,11 @@ from . import song
 
 class Player(object):
     """The base class for a MIDI player.
-    
+
     Use set_output() to set a MIDI output instance (see output.py).
     You can override: timer_midi_time(), timer_start() and timer_stop()
     to use another timing source than the Python threading.Timer instances.
-    
+
     """
     def __init__(self):
         self._song = None
@@ -46,35 +46,35 @@ class Player(object):
         self._tempo_factor = 1.0
         self._output = None
         self._last_exception = None
-    
+
     def set_output(self, output):
         """Sets an Output instance that handles the MIDI events.
-        
+
         Use None to disable all output.
-        
+
         """
         self._output = output
-    
+
     def output(self):
         """Returns the currently set Output instance."""
         return self._output
-        
+
     def load(self, filename, time=1000, beat=True):
         """Convenience function, loads a MIDI file.
-        
+
         See set_song() for the other arguments.
-        
+
         """
         self.set_song(song.load(filename), time, beat)
-    
+
     def set_song(self, song, time=1000, beat=True):
         """Loads the specified Song (see song.py).
-        
+
         If time is not None, it specifies at which interval (in msec) the
         time() method will be called. Default: 1000.
         If beat is True (default), the beat() method will be called on every
         beat.
-        
+
         """
         playing = self._playing
         if playing:
@@ -85,11 +85,11 @@ class Player(object):
         self._offset = 0
         if playing:
             self.timer_start_playing()
-    
+
     def song(self):
         """Returns the current Song."""
         return self._song
-    
+
     def clear(self):
         """Unloads a loaded Song."""
         if self._playing:
@@ -98,13 +98,13 @@ class Player(object):
         self._events = []
         self._position = 0
         self._offset = 0
-        
+
     def total_time(self):
         """Returns the length in msec of the current song."""
         if self._events:
             return self._events[-1][0]
         return 0
-    
+
     def current_time(self):
         """Returns the current time position."""
         if self._position >= len(self._events):
@@ -114,28 +114,28 @@ class Player(object):
         if self._playing:
             return time - self.timer_offset()
         return time - self._offset
-    
+
     def start(self):
         """Starts playing."""
         if self.has_events():
             self.timer_start_playing()
-        
+
     def stop(self):
         """Stops playing."""
         self.timer_stop_playing()
-    
+
     def is_playing(self):
         """Returns True if the player is playing, else False."""
         return self._playing
-    
+
     def set_tempo_factor(self, factor):
         """Sets the tempo factor as a floating point value (1.0 is normal)."""
         self._tempo_factor = float(factor)
-    
+
     def tempo_factor(self):
         """Returns the tempo factor (by default: 1.0)."""
         return self._tempo_factor
-    
+
     def seek(self, time):
         """Goes to the specified time (in msec)."""
         pos = 0
@@ -152,12 +152,12 @@ class Player(object):
             if pos < len(self._events):
                 offset = self._events[pos][0] - time
         self.set_position(pos, offset)
-    
+
     def seek_measure(self, measnum, beat=1):
         """Goes to the specified measure and beat (beat defaults to 1).
-        
-        Returns whether the measure position could be found (True or False).        
-        
+
+        Returns whether the measure position could be found (True or False).
+
         """
         result = False
         for i, (t, e) in enumerate(self._events):
@@ -173,12 +173,12 @@ class Player(object):
             self.set_position(position)
             return True
         return False
-        
+
     def set_position(self, position, offset=0):
         """(Private) Goes to the specified position in the internal events list.
-        
+
         This method is called by seek() and seek_measure().
-        
+
         """
         old, self._position = self._position, position
         if old != self._position:
@@ -188,20 +188,20 @@ class Player(object):
             self.timer_schedule(offset, False)
         else:
             self._offset = offset
-        
+
     def has_events(self):
         """Returns True if there are events left to play."""
         return bool(self._events) and self._position < len(self._events)
-        
+
     def next_event(self):
         """(Private) Handles the current event and advances to the next.
-        
+
         Returns the time in ms (not adjusted by tempo factor!) before
         next_event should be called again.
-        
+
         If there is no event to handle anymore, returns 0.
         If this event was the last, calls finish() and returns 0.
-        
+
         """
         if self.has_events():
             time, event = self._events[self._position]
@@ -210,7 +210,7 @@ class Player(object):
             if self._position < len(self._events):
                 return self._events[self._position][0] - time
         return 0
-    
+
     def handle_event(self, time, event):
         """(Private) Called for every event."""
         if event.midi:
@@ -221,77 +221,77 @@ class Player(object):
             self.beat_event(*event.beat)
         if event.user is not None:
             self.user_event(event.user)
-    
+
     def midi_event(self, midi):
         """(Private) Plays the specified MIDI events.
-        
+
         The format depends on the way MIDI events are stored in the Song.
-        
+
         """
         if self._output:
             try:
                 self._output.midi_event(midi)
             except BaseException as e:
                 self.exception_event(e)
-    
+
     def time_event(self, msec):
         """(Private) Called on every time update."""
-    
+
     def user_event(self, obj):
         """(Private) Called when there is a user event."""
-    
+
     def beat_event(self, measnum, beat, num, den):
         """(Private) Called on every beat."""
-    
+
     def start_event(self):
         """Called when playback is started."""
-    
+
     def stop_event(self):
         """Called when playback is stopped by the user."""
         if self._output:
             self._output.all_sounds_off()
-        
+
     def finish_event(self):
         """Called when a song reaches the end by itself."""
-    
+
     def position_event(self, old, new):
         """Called when the user seeks and the position changes.
-        
-        This means MIDI events are skipped and it might be necessary to 
+
+        This means MIDI events are skipped and it might be necessary to
         issue an all notes off command to the MIDI output, or to perform
         program changes.
-        
+
         The default implementation issues an all_notes_off if the
         player is playing.
-        
+
         """
         if self._playing and self._output:
             self._output.all_sounds_off()
-    
+
     def exception_event(self, exception):
         """Called when an exception occurs while writing to a MIDI output.
-        
+
         The default implementation stores the exception in self._last_exception
         and sets the output to None.
-        
+
         """
         self._last_exception = exception
         self.set_output(None)
-        
+
     def timer_midi_time(self):
         """Should return a continuing time value in msec, used while playing.
-        
+
         The default implementation returns the time in msec from the Python
         time module.
-        
+
         """
         return int(time.time() * 1000)
-    
+
     def timer_schedule(self, delay, sync=True):
         """Schedules the upcoming event.
-        
+
         If sync is False, don't look at the previous synchronisation time.
-        
+
         """
         msec = delay / self._tempo_factor
         if sync:
@@ -300,7 +300,7 @@ class Player(object):
         else:
             self._sync_time = self.timer_midi_time() + msec
         self.timer_start(max(0, msec))
-    
+
     def timer_start(self, msec):
         """Starts the timer to fire once, the specified msec from now."""
         self._timer = None
@@ -315,12 +315,12 @@ class Player(object):
 
     def timer_offset(self):
         """Returns the time before the next event.
-        
+
         This value is only useful while playing.
-        
+
         """
         return int((self._sync_time - self.timer_midi_time()) * self._tempo_factor)
-    
+
     def timer_start_playing(self):
         """Starts playing by starting the timer for the first upcoming event."""
         reset = self.current_time() == 0
@@ -332,13 +332,13 @@ class Player(object):
             except BaseException as e:
                 self.exception_event(e)
         self.timer_schedule(self._offset, False)
-    
+
     def timer_timeout(self):
         """Called when the timer times out.
-        
+
         Handles an event and schedules the next.
         If the end of a song is reached, calls finish_event()
-        
+
         """
         offset = self.next_event()
         if offset:
@@ -347,7 +347,7 @@ class Player(object):
             self._offset = 0
             self._playing = False
             self.finish_event()
-    
+
     def timer_stop_playing(self):
         self.timer_stop()
         self._offset = self.timer_offset()
@@ -357,14 +357,14 @@ class Player(object):
 
 class Event(object):
     """Any event (MIDI, Time and/or Beat).
-    
+
     Has three attributes that determine what the Player does:
-    
+
     time: if True, time_event() is called with the current music time.
     beat: None or (measnum, beat, num, den), then beat_event() is called.
     midi: If not None, midi_event() is called with the midi.
     user: Any object, if not None, user_event() is called with the object.
-    
+
     """
     __slots__ = ['midi', 'time', 'beat', 'user']
     def __init__(self):
@@ -388,27 +388,27 @@ class Event(object):
 
 def make_event_list(song, time=None, beat=None):
     """Returns a list of all the events in Song.
-    
+
     Each item is a two-tuple(time, Event).
-    
+
     If time is given, a time event is generated every that many microseconds
     If beat is True, beat events are generated as well.
     MIDI events are always created.
-    
+
     """
     d = collections.defaultdict(Event)
-    
+
     for t, evs in song.music:
         d[t].midi = evs
-    
+
     if time:
         for t in range(0, song.length+1, time):
             d[t].time = True
-    
+
     if beat:
         for i in song.beats:
             d[i[0]].beat = i[1:]
-    
+
     return [(t, d[t]) for t in sorted(d)]
 
 

--- a/frescobaldi_app/midifile/song.py
+++ b/frescobaldi_app/midifile/song.py
@@ -29,9 +29,9 @@ from . import parser
 
 def load(filename):
     """Convenience function to instantiate a Song from a filename.
-    
+
     If the filename is a type 2 MIDI file, just returns the first track.
-    
+
     """
     with open(filename, 'rb') as midifile:
         fmt, div, tracks = parser.parse_midi_data(midifile.read())
@@ -42,9 +42,9 @@ def load(filename):
 
 def events_dict(tracks):
     """Returns all events from the track grouped per and mapped to time-step.
-    
+
     every time step has a dictionary with the events per track at that time.
-    
+
     """
     d = collections.defaultdict(dict)
     for n, track in enumerate(tracks):
@@ -56,9 +56,9 @@ def events_dict(tracks):
 
 def events_dict_together(tracks):
     """Returns all events from the track grouped per and mapped to time-step.
-    
+
     every time step has a list with all the events at that time.
-    
+
     """
     d = collections.defaultdict(list)
     for track in tracks:
@@ -99,10 +99,10 @@ def smpte_division(div):
 
 def events_iter(d):
     """Return an iterator function over the events in one value of dict d.
-    
+
     The values in d can be dicts (per-track) or lists (single track).
     Returns None if the events dictionary is empty.
-    
+
     """
     for k in d:
         return iter_events_dict if isinstance(d[k], dict) else iter
@@ -131,7 +131,7 @@ class TempoMap(object):
                         break
         if not times or times[0][0] != 0:
             times.insert(0, (0, 500000))
-        
+
     def real_time(self, midi_time):
         """Returns the real time in microseconds for the given MIDI time."""
         real_time = 0
@@ -144,7 +144,7 @@ class TempoMap(object):
         else:
             real_time += (midi_time - times[-1][0]) * times[-1][1]
         return real_time // self.division
-    
+
     def msec(self, midi_time):
         """Returns the real time in milliseconds."""
         return self.real_time(midi_time) // 1000
@@ -152,13 +152,13 @@ class TempoMap(object):
 
 def beats(d, division):
     """Yields tuples for every beat in the events dictionary d.
-    
+
     Each tuple is:
         (midi_time, beat_num, beat_total, denominator)
-    
+
     With this you can easily add measure numbers and find measure positions
     in the MIDI.
-    
+
     """
     events = events_iter(d)
     if not events:
@@ -172,19 +172,19 @@ def beats(d, division):
     if not time_sigs or time_sigs[0][0] != 0:
         # default time signature at start
         time_sigs.insert(0, (0, (4, 4, 24, 8)))
-    
+
     # now yield a tuple for every beat
     time = 0
     sigs_index = 0
     while time <= times[-1]:
-        
+
         if sigs_index < len(time_sigs) and time >= time_sigs[sigs_index][0]:
             # new time signature
             time, (num, den, clocks, n32s) = time_sigs[sigs_index]
             step = (4 * division) // (2 ** den)
             beat = 1
             sigs_index += 1
-            
+
         yield time, beat, num, den
         time += step
         beat = beat % num + 1
@@ -192,19 +192,19 @@ def beats(d, division):
 
 class Song(object):
     """A loaded MIDI file.
-    
+
     The following instance attributes are set on init:
-    
+
     division: the division set in the MIDI header
     ntracks: the number of tracks
     events: a dict mapping MIDI times to a dict with per-track lists of events.
     tempo_map: TempoMap instance that computes real time from MIDI time.
     length: the length in milliseconds of the song (same as the time of the last
             event).
-    
+
     beats: a list of tuples(msec, measnum, beat, num, den) for every beat
     music: a list of tuples(msec, d) where d is a dict mapping tracknr to events
-    
+
     """
     def __init__(self, division, tracks):
         """Initialize the Song with the given division and track chunks."""

--- a/frescobaldi_app/midihub.py
+++ b/frescobaldi_app/midihub.py
@@ -58,7 +58,7 @@ def restart():
     portmidi.quit()
     portmidi.init()
     settingsChanged()
-    
+
 def refresh_ports():
     """Refreshes the port list."""
     restart()

--- a/frescobaldi_app/midiinput/__init__.py
+++ b/frescobaldi_app/midiinput/__init__.py
@@ -5,7 +5,7 @@ provides a dock which allows to capture midi events and insert notes
 - input is static, not dynamic
 - special midi events (e. g. damper pedal) can modify notes (e. g. duration)
   or insert elements (e. g. slurs)
- 
+
 current limitations:
 - special events not implemented yet
 
@@ -32,23 +32,23 @@ class MidiIn(object):
         self._portmidiinput = None
         self._listener = None
         self._chord = None
-    
+
     def __del__(self):
         if isinstance(self._listener, Listener):
             self.capturestop()
-    
+
     def widget(self):
         return self._widget()
-    
+
     def open(self):
         s = QSettings()
         self._portname = s.value("midi/midi/input_port", midihub.default_input(), str)
         self._pollingtime = s.value("midi/polling_time", 10, int)
         self._portmidiinput = midihub.input_by_name(self._portname)
-        
+
         self._listener = Listener(self._portmidiinput, self._pollingtime)
         self._listener.NoteEventSignal.connect(self.analyzeevent)
-    
+
     def close(self):
         # self._portmidiinput.close()
         # this will end in segfault with pyportmidi 0.0.7 in ubuntu
@@ -59,7 +59,7 @@ class MidiIn(object):
             self._portmidiinput._input = None
         self._portmidiinput = None
         self._listener = None
-    
+
     def capture(self):
         if not self._portmidiinput:
             self.open()
@@ -69,18 +69,18 @@ class MidiIn(object):
         self._language = documentinfo.docinfo(doc).language() or 'nederlands'
         self._activenotes = 0
         self._listener.start()
-    
+
     def capturestop(self):
         self._listener.stop()
         if not self._listener.isFinished():
             self._listener.wait()
         self._activenotes = 0
         self.close()
-    
+
     def analyzeevent(self, event):
         if isinstance(event, midifile.event.NoteEvent):
             self.noteevent(event.type, event.channel, event.note, event.value)
-    
+
     def noteevent(self, notetype, channel, notenumber, value):
         targetchannel = self.widget().channel()
         if targetchannel == 0 or channel == targetchannel-1: # '0' captures all
@@ -102,7 +102,7 @@ class MidiIn(object):
                         self.printwithspace(self._chord.output(self.widget().relativemode(), self._language))
                     self._activenotes = 0    # reset in case it was negative
                     self._chord = None
-    
+
     def printwithspace(self, text):
         cursor = self.widget().mainwindow().textCursor()
         # check if there is a space before cursor or beginning of line
@@ -112,14 +112,14 @@ class MidiIn(object):
             cursor.insertText(text)
         else:
             cursor.insertText(' ' +  text)
-    
+
 class Listener(QThread):
     NoteEventSignal = pyqtSignal(midifile.event.NoteEvent)
     def __init__(self, portmidiinput, pollingtime):
         QThread.__init__(self)
         self._portmidiinput = portmidiinput
         self._pollingtime = pollingtime
-    
+
     def run(self):
         self._capturing = True
         while self._capturing:
@@ -130,16 +130,16 @@ class Listener(QThread):
             if not self._capturing:
                 break
             data = self._portmidiinput.read(1)
-            
+
             # midifile.parser.parse_midi_events is a generator which expects a long "byte string" from a file,
             # so we feed it one. But since it's just one event, we only need the first "generated" element.
             # First byte is time, which is unnecessary in our case, so we feed a dummy byte 77
             # and strip output by just using [1]. 77 is chosen randomly ;)
             s = bytearray([77, data[0][0][0], data[0][0][1], data[0][0][2], data[0][0][3]])
             event = next(midifile.parser.parse_midi_events(s))[1]
-            
+
             if isinstance(event,midifile.event.NoteEvent):
                 self.NoteEventSignal.emit(event)
-    
+
     def stop(self):
         self._capturing = False

--- a/frescobaldi_app/midiinput/elements.py
+++ b/frescobaldi_app/midiinput/elements.py
@@ -10,7 +10,7 @@ import ly.pitch
 
 class Note:
     LastPitch = ly.pitch.Pitch()
-    
+
     def __init__(self, midinote, notemapping):
         # get correct note 0...11 = c...b
         # and octave corresponding to octave modifiers ',' & '''
@@ -18,7 +18,7 @@ class Note:
         octave, note = divmod(midinote, 12)
         octave -= 4
         self._pitch = ly.pitch.Pitch(notemapping[note][0] % 7, notemapping[note][1], octave + notemapping[note][0] // 7)
-    
+
     def output(self, relativemode=False, language='nederlands'):
         if relativemode:
             pitch = self._pitch.copy()
@@ -29,7 +29,7 @@ class Note:
             pitch = self._pitch
         # also octavecheck if Shift is held
         return pitch.output(language) + (('='+ly.pitch.octaveToString(self._pitch.octave)) if QApplication.keyboardModifiers() & Qt.SHIFT else '')
-    
+
     def midinote(self):
         return self._midinote
 
@@ -37,10 +37,10 @@ class Note:
 class Chord(object):
     def __init__(self):
         self._notes = list()
-        
+
     def add(self, note):
         self._notes.append(note)
-    
+
     def output(self, relativemode=False, language='nederlands'):
         if len(self._notes) == 1:    # only one note, no chord
             return self._notes[0].output(relativemode, language)
@@ -111,7 +111,7 @@ class NoteMappings:
                 sharpmap[k] = self.to_flat(*sharpmap[k])
             self.flat_mappings.append(flatmap)
             self.sharp_mappings.append(sharpmap)
-    
+
         self.sharp_mappings.append(self.sharps) # Append C major signature -> no key alteration
         self.flat_mappings.append(self.flats) # Append C major signature -> no key alteration
 

--- a/frescobaldi_app/midiinput/tool.py
+++ b/frescobaldi_app/midiinput/tool.py
@@ -25,14 +25,14 @@ class MidiInputTool(panel.Panel):
         ac.accidental_switch.triggered.connect(self.slotAccidentalSwitch)
         actioncollectionmanager.manager(mainwindow).addActionCollection(ac)
         mainwindow.addDockWidget(Qt.BottomDockWidgetArea, self)
-    
+
     def translateUI(self):
         self.setWindowTitle(_("MIDI Input"))
         self.toggleViewAction().setText(_("MIDI I&nput"))
-    
+
     def slotStartCapturing(self):
         self.widget().startcapturing()
-    
+
     def slotStopCapturing(self):
         self.widget().stopcapturing()
 
@@ -49,16 +49,16 @@ class Actions(actioncollection.ActionCollection):
         self.capture_start = QAction(parent)
         self.capture_stop = QAction(parent)
         self.accidental_switch = QAction(parent)
-        
+
         self.capture_start.setIcon(icons.get('media-record'))
         self.capture_stop.setIcon(icons.get('process-stop'))
 
         self.accidental_switch.setShortcut(QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_3))
-        
+
     def translateUI(self):
         self.capture_start.setText(_("midi input", "Start capturing"))
         self.capture_start.setToolTip(_("midi input", "Start MIDI capturing"))
         self.capture_stop.setText(_("midi input", "Stop capturing"))
         self.capture_stop.setToolTip(_("midi input", "Stop MIDI capturing"))
-        self.accidental_switch.setText(_("midi input", "Switch accidental style"))    
+        self.accidental_switch.setText(_("midi input", "Switch accidental style"))
         self.accidental_switch.setToolTip(_("midi input", "Change accidental style (flats or sharps)"))

--- a/frescobaldi_app/midiinput/widget.py
+++ b/frescobaldi_app/midiinput/widget.py
@@ -21,17 +21,17 @@ class Widget(QWidget):
         self._document = None
         self._midiin = midiinput.MidiIn(self)
         self._dockwidget = weakref.ref(dockwidget)
-        
+
         signals = list()
-        
+
         self._labelmidichannel = QLabel()
         self._midichannel = QComboBox()
         signals.append(self._midichannel.currentIndexChanged)
-        
+
         self._labelkeysignature = QLabel()
         self._keysignature = QComboBox()
         signals.append(self._keysignature.currentIndexChanged)
-        
+
         self._labelaccidentals = QLabel()
         self._accidentalssharps = QRadioButton()
         signals.append(self._accidentalssharps.clicked)
@@ -47,19 +47,19 @@ class Widget(QWidget):
 
         self._chordmode = QCheckBox()
         signals.append(self._chordmode.clicked)
-        
+
         self._relativemode = QCheckBox()
         signals.append(self._relativemode.clicked)
 
         self._labeldamper = QLabel()
         self._damper = QComboBox()
-        
+
         self._labelsostenuto = QLabel()
         self._sostenuto = QComboBox()
-        
+
         self._labelsoft = QLabel()
         self._soft = QComboBox()
-        
+
         ac = self.parentWidget().actionCollection
         self._capture = QToolButton()
         self._capture.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
@@ -67,13 +67,13 @@ class Widget(QWidget):
         self.addAction(ac.accidental_switch)
 
         self._notemode = QLabel()
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
         grid = QGridLayout(spacing=0)
         layout.addLayout(grid)
         layout.addStretch()
-        
+
         grid.addWidget(self._labelmidichannel, 0, 0)
         grid.addWidget(self._midichannel, 0, 1)
         grid.addWidget(self._labelkeysignature, 1, 0)
@@ -93,31 +93,31 @@ class Widget(QWidget):
         layout.addLayout(hbox)
         hbox.addWidget(self._capture)
         hbox.addStretch()
-        
+
         app.translateUI(self)
-        
+
         self.loadsettings()
         for s in signals:
             s.connect(self.savesettings)
-    
+
     def mainwindow(self):
         return self._dockwidget().mainwindow()
-    
+
     def channel(self):
         return self._midichannel.currentIndex()
-    
+
     def keysignature(self):
         return self._keysignature.currentIndex()
-    
+
     def accidentals(self):
         if self._accidentalsflats.isChecked():
             return 'flats'
         else:
             return 'sharps'
-    
+
     def chordmode(self):
         return self._chordmode.isChecked()
-    
+
     def relativemode(self):
         return self._relativemode.isChecked()
 
@@ -127,14 +127,14 @@ class Widget(QWidget):
         while self._capture.actions():    # remove all old actions
             self._capture.removeAction(self._capture.actions()[0])
         self._capture.setDefaultAction(ac.capture_stop)
-    
+
     def stopcapturing(self):
         self._midiin.capturestop()
         ac = self.parentWidget().actionCollection
         while self._capture.actions():    # remove all old actions
             self._capture.removeAction(self._capture.actions()[0])
         self._capture.setDefaultAction(ac.capture_start)
-    
+
     def switchaccidental(self):
         if self.accidentals() == 'flats':
             self._accidentalssharps.setChecked(True)
@@ -152,7 +152,7 @@ class Widget(QWidget):
             s.setValue("accidentals", 'sharps')
         s.setValue("chordmode", self._chordmode.isChecked())
         s.setValue("relativemode", self._relativemode.isChecked())
-    
+
     def loadsettings(self):
         s = QSettings()
         s.beginGroup("midiinputdock")

--- a/frescobaldi_app/miditool/__init__.py
+++ b/frescobaldi_app/miditool/__init__.py
@@ -46,27 +46,27 @@ class MidiTool(panel.Panel):
         ac.midi_restart.triggered.connect(self.slotRestart)
         actioncollectionmanager.manager(mainwindow).addActionCollection(ac)
         mainwindow.addDockWidget(Qt.TopDockWidgetArea, self)
-    
+
     def translateUI(self):
         self.setWindowTitle(_("MIDI"))
         self.toggleViewAction().setText(_("MIDI &Player"))
-    
+
     def createWidget(self):
         from . import widget
         return widget.Widget(self)
-        
+
     def slotPause(self):
         """Called on action Pause."""
         self.widget().stop()
-        
+
     def slotPlay(self):
         """Called on action Play."""
         self.widget().play()
-    
+
     def slotStop(self):
         """Called on action Stop."""
         self.widget().stop()
-    
+
     def slotRestart(self):
         """Called on action Restart."""
         self.widget().restart()
@@ -79,7 +79,7 @@ class Actions(actioncollection.ActionCollection):
         self.midi_play = QAction(parent)
         self.midi_stop = QAction(parent)
         self.midi_restart = QAction(parent)
-        
+
         try:
             self.midi_pause.setShortcut(QKeySequence(Qt.Key_MediaPause))
         except AttributeError:
@@ -87,12 +87,12 @@ class Actions(actioncollection.ActionCollection):
         self.midi_play.setShortcut(QKeySequence(Qt.Key_MediaPlay))
         self.midi_stop.setShortcut(QKeySequence(Qt.Key_MediaStop))
         self.midi_restart.setShortcut(QKeySequence(Qt.Key_MediaPrevious))
-        
+
         self.midi_pause.setIcon(icons.get('media-playback-pause'))
         self.midi_play.setIcon(icons.get('media-playback-start'))
         self.midi_stop.setIcon(icons.get('media-playback-stop'))
         self.midi_restart.setIcon(icons.get('media-skip-backward'))
-        
+
     def translateUI(self):
         self.midi_pause.setText(_("midi player", "Pause"))
         self.midi_play.setText(_("midi player", "Play"))

--- a/frescobaldi_app/miditool/midifiles.py
+++ b/frescobaldi_app/miditool/midifiles.py
@@ -41,10 +41,10 @@ class MidiFiles(plugin.DocumentPlugin):
         self.current = 0
         document.loaded.connect(self.invalidate, -100)
         jobmanager.manager(document).finished.connect(self.invalidate, -100)
-    
+
     def invalidate(self):
         self._files = None
-        
+
     def update(self):
         files = resultfiles.results(self.document()).files('.mid*')
         self._files = files
@@ -52,10 +52,10 @@ class MidiFiles(plugin.DocumentPlugin):
         if files and self.current >= len(files):
             self.current = len(files) - 1
         return bool(files)
-    
+
     def __bool__(self):
         return bool(self._files)
-    
+
     def song(self, index):
         if self._files is None:
             self.update()
@@ -63,7 +63,7 @@ class MidiFiles(plugin.DocumentPlugin):
         if not song:
             song = self._songs[index] = midifile.song.load(self._files[index])
         return song
-    
+
     def model(self):
         """Returns a model for a combobox."""
         if self._files is None:

--- a/frescobaldi_app/miditool/widget.py
+++ b/frescobaldi_app/miditool/widget.py
@@ -53,22 +53,22 @@ class Widget(QWidget):
         self._display = Display()
         self._tempoFactor = QSlider(Qt.Vertical, minimum=-50, maximum=50,
             singleStep=1, pageStep=5)
-        
+
         grid = QGridLayout(spacing=0)
         self.setLayout(grid)
-        
+
         grid.addWidget(self._fileSelector, 0, 0, 1, 3)
         grid.addWidget(self._stopButton, 1, 0)
         grid.addWidget(self._playButton, 1, 1)
         grid.addWidget(self._timeSlider, 1, 2)
         grid.addWidget(self._display, 2, 0, 1, 3)
         grid.addWidget(self._tempoFactor, 0, 3, 3, 1)
-        
+
         # size policy of combo
         p = self._fileSelector.sizePolicy()
         p.setHorizontalPolicy(QSizePolicy.Ignored)
         self._fileSelector.setSizePolicy(p)
-        
+
         # size policy of combo popup
         p = self._fileSelector.view().sizePolicy()
         p.setHorizontalPolicy(QSizePolicy.MinimumExpanding)
@@ -102,21 +102,21 @@ class Widget(QWidget):
 
     def translateUI(self):
         self._tempoFactor.setToolTip(_("Tempo"))
-    
+
     def slotAboutToRestart(self):
         self.stop()
         self._player.set_output(None)
-    
+
     def clearMidiSettings(self):
         """Called first when settings are changed."""
         self.stop()
         self._outputCloseTimer.stop()
         self._player.set_output(None)
-        
+
     def readMidiSettings(self):
         """Called after clearMidiSettings(), and on first init."""
         pass
-            
+
     def openOutput(self):
         """Called when playing starts. Ensures an output port is opened."""
         self._outputCloseTimer.stop()
@@ -125,11 +125,11 @@ class Widget(QWidget):
             o = midihub.output_by_name(p)
             if o:
                 self._player.set_output(output.Output(o))
-    
+
     def closeOutput(self):
         """Called when the output close timer fires. Closes the output."""
         self._player.set_output(None)
-        
+
     def slotPlayerStateChanged(self, playing):
         ac = self.parentWidget().actionCollection
         # setDefaultAction also adds the action
@@ -148,7 +148,7 @@ class Widget(QWidget):
             # close the output if the preference is set
             if QSettings().value("midi/close_outputs", False, bool):
                 self._outputCloseTimer.start()
-        
+
     def play(self):
         """Starts the MIDI player, opening an output if necessary."""
         if not self._player.is_playing() and not self._player.has_events():
@@ -157,17 +157,17 @@ class Widget(QWidget):
         if not self._player.output():
             self._display.statusMessage(_("No output found!"))
         self._player.start()
-    
+
     def stop(self):
         """Stops the MIDI player."""
         self._player.stop()
-    
+
     def restart(self):
         """Restarts the MIDI player.
-        
+
         If another file is in the file selector, or the file was updated,
         the new file is loaded.
-        
+
         """
         self._player.seek(0)
         self.updateTimeSlider()
@@ -177,25 +177,25 @@ class Widget(QWidget):
             index = self._fileSelector.currentIndex()
             if files and (files.song(index) is not self._player.song()):
                 self.loadSong(index)
-        
+
     def slotTempoChanged(self, value):
         """Called when the user drags the tempo."""
         # convert -50 to 50 to 0.5 to 2.0
         factor = 2 ** (value / 50.0)
         self._player.set_tempo_factor(factor)
         self._display.setTempo("{0}%".format(int(factor * 100)))
-    
+
     def slotTimeSliderChanged(self, value):
         self._player.seek(value)
         self._display.setTime(value)
         if self._player.song():
             self._display.setBeat(*self._player.song().beat(value)[1:])
-    
+
     def slotTimeSliderMoved(self, value):
         self._display.setTime(value)
         if self._player.song():
             self._display.setBeat(*self._player.song().beat(value)[1:])
-    
+
     def updateTimeSlider(self):
         if not self._timeSlider.isSliderDown():
             with qutil.signalsBlocked(self._timeSlider):
@@ -205,23 +205,23 @@ class Widget(QWidget):
     def updateDisplayBeat(self, measnum, beat, num, den):
         if not self._timeSlider.isSliderDown():
             self._display.setBeat(measnum, beat, num, den)
-    
+
     def updateDisplayTime(self, time):
         if not self._timeSlider.isSliderDown():
             self._display.setTime(time)
-    
+
     def slotDocumentLoaded(self, document):
         """Called when a new document is loaded.
-        
+
         Only calls slotUpdatedFiles when this is the first document, as that
         slot will be called anyway when the current document is switched. When
         the first document is loaded, it is loaded into the existing empty
         document, so mainwindow.currentDocumentChanged() will never be emitted.
-        
+
         """
         if len(app.documents) == 1:
             self.slotUpdatedFiles(document)
-    
+
     def slotUpdatedFiles(self, document, job=None):
         """Called when there are new MIDI files."""
         mainwindow = self.parentWidget().mainwindow()
@@ -232,7 +232,7 @@ class Widget(QWidget):
         if job and jobattributes.get(job).mainwindow != mainwindow:
             return
         self.loadResults(document)
-    
+
     def loadResults(self, document):
         files = midifiles.MidiFiles.instance(document)
         if files.update():
@@ -241,7 +241,7 @@ class Widget(QWidget):
             self._fileSelector.setCurrentIndex(files.current)
             if not self._player.is_playing():
                 self.loadSong(files.current)
-    
+
     def loadSong(self, index):
         files = midifiles.MidiFiles.instance(self._document)
         self._player.set_song(files.song(index))
@@ -252,7 +252,7 @@ class Widget(QWidget):
         self._display.statusMessage(
             _("midi lcd screen", "LOADED"), name,
             _("midi lcd screen", "TOTAL"), "{0}:{1:02}".format(m, s))
-    
+
     def slotFileSelected(self, index):
         if self._document:
             self._player.stop()
@@ -260,7 +260,7 @@ class Widget(QWidget):
             if files:
                 files.current = index
                 self.restart()
-    
+
     def slotDocumentClosed(self, document):
         if document == self._document:
             self._document = None
@@ -285,40 +285,40 @@ class Display(QLabel):
         self._status = None
         self.reset()
         app.translateUI(self)
-    
+
     def reset(self):
         """Sets everything to 0."""
         self._time = 0
         self._beat = 0, 0, 0, 0
         self.updateDisplay()
-        
+
     def translateUI(self):
         self.updateDisplay()
-    
+
     def setTime(self, time):
         self._time = time
         self.updateDisplay()
-    
+
     def setBeat(self, measnum, beat, num, den):
         self._beat = measnum, beat, num, den
         self.updateDisplay()
-    
+
     def setTempo(self, text=None):
         self._tempo = text
         if text:
             self._tempoTimer.start()
         self.updateDisplay()
-    
+
     def statusMessage(self, *msg):
         """Status message can be multiple arguments (1 to 4)."""
         self._status = msg
         if msg:
             self._statusTimer.start()
         self.updateDisplay()
-        
+
     def updateDisplay(self):
         minutes, seconds = divmod(self._time // 1000, 60)
-        
+
         time_spec = "{0}:{1:02}".format(minutes, seconds)
         if self._status:
             items = self._status

--- a/frescobaldi_app/musicpos.py
+++ b/frescobaldi_app/musicpos.py
@@ -43,7 +43,7 @@ class MusicPosition(plugin.ViewSpacePlugin):
         view = space.activeView()
         if view:
             self.slotViewChanged(view)
-    
+
     def slotViewChanged(self, view):
         old = self._view()
         if old:
@@ -51,25 +51,25 @@ class MusicPosition(plugin.ViewSpacePlugin):
         self._view = weakref.ref(view)
         self.connectView(view)
         self.startTimer()
-    
+
     def connectView(self, view):
         view.cursorPositionChanged.connect(self.startTimer)
         view.document().contentsChanged.connect(self.startWaitTimer)
-        
+
     def disconnectView(self, view):
         view.cursorPositionChanged.disconnect(self.startTimer)
         view.document().contentsChanged.disconnect(self.startWaitTimer)
-    
+
     def startWaitTimer(self):
         """Called when the document changes, waits longer to prevent stutter."""
         self._waittimer.start(900)
         self._timer.stop()
-        
+
     def startTimer(self):
         """Called when the cursor moves."""
         if not self._waittimer.isActive():
             self._timer.start(100)
-    
+
     def slotTimeout(self):
         """Called when one of the timers fires."""
         view = self._view()

--- a/frescobaldi_app/musicpreview.py
+++ b/frescobaldi_app/musicpreview.py
@@ -56,21 +56,21 @@ class MusicPreviewJob(job.Job):
         self.document = os.path.join(self.directory, 'document.ly')
         with open(self.document, 'wb') as f:
             f.write(text.encode('utf-8'))
-            
+
         info = lilypondinfo.preferred()
         if QSettings().value("lilypond_settings/autoversion", True, bool):
             version = ly.docinfo.DocInfo(ly.document.Document(text, 'lilypond')).version()
             if version:
                 info = lilypondinfo.suitable(version)
-        
+
         lilypond = info.abscommand() or info.command
         self.command = [lilypond, '-dno-point-and-click', '--pdf', self.document]
         if title:
             self.set_title(title)
-    
+
     def resultfiles(self):
         return glob.glob(os.path.join(self.directory, '*.pdf'))
-        
+
     def cleanup(self):
         shutil.rmtree(self.directory, ignore_errors=True)
 
@@ -81,23 +81,23 @@ class MusicPreviewWidget(QWidget):
         self._lastbuildtime = 10.0
         self._running = None
         self._current = None
-        
+
         self._chooserLabel = QLabel()
         self._chooser = QComboBox(self, activated=self.selectDocument)
         self._log = log.Log()
         self._view = popplerview.View()
         self._progress = widgets.progressbar.TimedProgressBar()
-        
+
         self._stack = QStackedLayout()
         self._top = QWidget()
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         layout.addWidget(self._top)
         layout.addLayout(self._stack)
         layout.addWidget(self._progress)
-        
+
         top = QHBoxLayout()
         top.setContentsMargins(0, 0, 0, 0)
         top.setSpacing(2)
@@ -105,17 +105,17 @@ class MusicPreviewWidget(QWidget):
         top.addWidget(self._chooserLabel)
         top.addWidget(self._chooser)
         top.addStretch(1)
-        
+
         self._stack.addWidget(self._log)
         self._stack.addWidget(self._view)
-        
+
         self._top.hide()
         app.aboutToQuit.connect(self.cleanup)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self._chooserLabel.setText(_("Document:"))
-        
+
     def preview(self, text, title=None):
         """Runs LilyPond on the given text and shows the resulting PDF."""
         j = self._running = MusicPreviewJob(text, title)
@@ -124,7 +124,7 @@ class MusicPreviewWidget(QWidget):
         self._log.connectJob(j)
         j.start()
         self._progress.start(self._lastbuildtime)
-    
+
     def _done(self, success):
         self._progress.stop(False)
         pdfs = self._running.resultfiles()
@@ -138,7 +138,7 @@ class MusicPreviewWidget(QWidget):
             self._current.cleanup()
         self._current = self._running # keep the tempdir
         self._running = None
-        
+
     def setDocuments(self, pdfs):
         """Loads the given PDF path names in the UI."""
         self._documents = [popplertools.Document(name) for name in pdfs]
@@ -167,7 +167,7 @@ class MusicPreviewWidget(QWidget):
         self._stack.setCurrentWidget(self._log)
         self._top.hide()
         self._view.clear()
-    
+
     def print_(self):
         """Prints the currently displayed document."""
         if self._documents:
@@ -194,11 +194,11 @@ class MusicPreviewDialog(QDialog):
         self._printButton.hide()
         qutil.saveDialogSize(self, "musicpreview/dialog/size", QSize(500, 350))
         app.translateUI(self)
-    
+
     def translateUI(self):
         self._printButton.setText(_("&Print"))
         self.setWindowTitle(app.caption(_("Music Preview")))
-        
+
     def preview(self, text, title=None):
         self._widget.preview(text, title)
 

--- a/frescobaldi_app/musicview/__init__.py
+++ b/frescobaldi_app/musicview/__init__.py
@@ -65,11 +65,11 @@ from qpopplerview import FixedScale, FitWidth, FitHeight, FitBoth
 
 def activate(func):
     """Decorator for MusicViewPanel methods/slots.
-    
+
     The purpose is to first activate the widget and only perform an action
     when the event loop starts. This gives the PDF widget the chance to resize
     and position itself correctly.
-    
+
     """
     @functools.wraps(func)
     def wrapper(self):
@@ -87,7 +87,7 @@ class MusicViewPanel(panel.Panel):
         super(MusicViewPanel, self).__init__(mainwindow)
         self.toggleViewAction().setShortcut(QKeySequence("Meta+Alt+M"))
         mainwindow.addDockWidget(Qt.RightDockWidgetArea, self)
-        
+
         ac = self.actionCollection = Actions(self)
         actioncollectionmanager.manager(mainwindow).addActionCollection(ac)
         ac.music_print.triggered.connect(self.printMusic)
@@ -117,7 +117,7 @@ class MusicViewPanel(panel.Panel):
         ac.music_reload.triggered.connect(self.reloadView)
         self.actionCollection.music_sync_cursor.setChecked(
             QSettings().value("musicview/sync_cursor", False, bool))
-        
+
         mode = QSettings().value("muziekview/layoutmode", "single", str)
         if mode == "double_left":
             ac.music_two_pages_first_left.setChecked(True)
@@ -125,18 +125,18 @@ class MusicViewPanel(panel.Panel):
             ac.music_two_pages_first_right.setChecked(True)
         else: # mode == "single":
             ac.music_single_pages.setChecked(True)
-        
+
     def translateUI(self):
         self.setWindowTitle(_("window title", "Music View"))
         self.toggleViewAction().setText(_("&Music View"))
-    
+
     def createWidget(self):
         from . import widget
         w = widget.MusicView(self)
         w.zoomChanged.connect(self.slotMusicZoomChanged)
         w.updateZoomInfo()
         w.view.surface().selectionChanged.connect(self.updateSelection)
-        
+
         # read layout mode setting before using the widget
         layout = w.view.surface().pageLayout()
         if self.actionCollection.music_two_pages_first_right.isChecked():
@@ -148,17 +148,17 @@ class MusicViewPanel(panel.Panel):
         else: # "single"
             layout.setPagesPerRow(1)   # default to single
             layout.setPagesFirstRow(0) # pages
-        
+
         import qpopplerview.pager
         self._pager = p = qpopplerview.pager.Pager(w.view)
         p.pageCountChanged.connect(self.slotPageCountChanged)
         p.currentPageChanged.connect(self.slotCurrentPageChanged)
         app.languageChanged.connect(self.updatePagerLanguage)
-        
+
         selector = self.actionCollection.music_document_select
         selector.currentDocumentChanged.connect(w.openDocument)
         selector.documentClosed.connect(w.clear)
-        
+
         if selector.currentDocument():
             # open a document only after the widget has been created;
             # this prevents many superfluous resizes
@@ -167,16 +167,16 @@ class MusicViewPanel(panel.Panel):
                     w.openDocument(selector.currentDocument())
             QTimer.singleShot(0, open)
         return w
-    
+
     def setPageLayoutMode(self, mode):
         """Change the page layout and store the setting as well.
-        
+
         The mode is "single", "double_left" or "double_right".
-        
+
         "single": a vertical row of single pages
         "double_left": two pages besides each other, first page is a left page
         "double_right": two pages, first page is a right page.
-        
+
         """
         layout = self.widget().view.surface().pageLayout()
         if mode == "double_right":
@@ -192,38 +192,38 @@ class MusicViewPanel(panel.Panel):
             raise ValueError("wrong mode value")
         QSettings().setValue("muziekview/layoutmode", mode)
         layout.update()
-    
+
     def updateSelection(self, rect):
         self.actionCollection.music_copy_image.setEnabled(bool(rect))
         self.actionCollection.music_copy_text.setEnabled(bool(rect))
-    
+
     def updatePagerLanguage(self):
         self.actionCollection.music_pager.setPageCount(self._pager.pageCount())
-    
+
     def slotPageCountChanged(self, total):
         self.actionCollection.music_pager.setPageCount(total)
-        
+
     def slotCurrentPageChanged(self, num):
         self.actionCollection.music_pager.setCurrentPage(num)
         self.actionCollection.music_next_page.setEnabled(num < self._pager.pageCount())
         self.actionCollection.music_prev_page.setEnabled(num > 1)
-        
+
     @activate
     def slotNextPage(self):
         self._pager.setCurrentPage(self._pager.currentPage() + 1)
-    
+
     @activate
     def slotPreviousPage(self):
         self._pager.setCurrentPage(self._pager.currentPage() - 1)
-    
+
     def setCurrentPage(self, num):
         self.activate()
         self._pager.setCurrentPage(num)
-        
+
     def updateActions(self):
         ac = self.actionCollection
         ac.music_print.setEnabled(bool(ac.music_document_select.documents()))
-        
+
     def printMusic(self):
         doc = self.actionCollection.music_document_select.currentDocument()
         if doc and doc.document():
@@ -250,23 +250,23 @@ class MusicViewPanel(panel.Panel):
             ### end temporarily disable printing on Mac OS X
             import popplerprint
             popplerprint.printDocument(doc, self)
-    
+
     @activate
     def zoomIn(self):
         self.widget().view.zoomIn()
-    
+
     @activate
     def zoomOut(self):
         self.widget().view.zoomOut()
-    
+
     @activate
     def zoomOriginal(self):
         self.widget().view.zoom(1.0)
-    
+
     @activate
     def fitWidth(self):
         self.widget().view.setViewMode(FitWidth)
-    
+
     @activate
     def fitHeight(self):
         self.widget().view.setViewMode(FitHeight)
@@ -274,23 +274,23 @@ class MusicViewPanel(panel.Panel):
     @activate
     def fitBoth(self):
         self.widget().view.setViewMode(FitBoth)
-    
+
     @activate
     def viewSinglePages(self):
         self.setPageLayoutMode("single")
-    
+
     @activate
     def viewTwoPagesFirstRight(self):
         self.setPageLayoutMode("double_right")
-    
+
     @activate
     def viewTwoPagesFirstLeft(self):
         self.setPageLayoutMode("double_left")
-    
+
     @activate
     def jumpToCursor(self):
         self.widget().showCurrentLinks()
-    
+
     @activate
     def reloadView(self):
         d = self.mainwindow().currentDocument()
@@ -298,11 +298,11 @@ class MusicViewPanel(panel.Panel):
         if group.update() or group.update(False):
             ac = self.actionCollection
             ac.music_document_select.setCurrentDocument(d)
-    
+
     def toggleSyncCursor(self):
         QSettings().setValue("musicview/sync_cursor",
             self.actionCollection.music_sync_cursor.isChecked())
-     
+
     def copyImage(self):
         page = self.widget().view.surface().selectedPage()
         if not page:
@@ -310,12 +310,12 @@ class MusicViewPanel(panel.Panel):
         rect = self.widget().view.surface().selectedPageRect(page)
         import copy2image
         copy2image.copy_image(self, page, rect, documents.filename(page.document()))
-        
+
     def copyText(self):
         text = self.widget().view.surface().selectedText()
         if text:
             QApplication.clipboard().setText(text)
-    
+
     def slotZoomChanged(self, mode, scale):
         """Called when the combobox is changed, changes view zoom."""
         self.activate()
@@ -323,7 +323,7 @@ class MusicViewPanel(panel.Panel):
             self.widget().view.zoom(scale)
         else:
             self.widget().view.setViewMode(mode)
-    
+
     def slotMusicZoomChanged(self, mode, scale):
         """Called when the music view is changed, updates the toolbar actions."""
         ac = self.actionCollection
@@ -331,7 +331,7 @@ class MusicViewPanel(panel.Panel):
         ac.music_fit_height.setChecked(mode == FitHeight)
         ac.music_fit_both.setChecked(mode == FitBoth)
         ac.music_zoom_combo.updateZoomInfo(mode, scale)
-        
+
 
 class Actions(actioncollection.ActionCollection):
     name = "musicview"
@@ -372,7 +372,7 @@ class Actions(actioncollection.ActionCollection):
         self.music_copy_text.setIcon(icons.get('edit-copy'))
         self.music_next_page.setIcon(icons.get('go-next'))
         self.music_prev_page.setIcon(icons.get('go-previous'))
-        
+
         self.music_document_select.setShortcut(QKeySequence(Qt.SHIFT | Qt.CTRL | Qt.Key_O))
         self.music_print.setShortcuts(QKeySequence.Print)
         self.music_zoom_in.setShortcuts(QKeySequence.ZoomIn)
@@ -380,7 +380,7 @@ class Actions(actioncollection.ActionCollection):
         self.music_jump_to_cursor.setShortcut(QKeySequence(Qt.CTRL | Qt.Key_J))
         self.music_copy_image.setShortcut(QKeySequence(Qt.SHIFT | Qt.CTRL | Qt.Key_C))
         self.music_reload.setShortcut(QKeySequence(Qt.Key_F5))
-        
+
     def translateUI(self):
         self.music_document_select.setText(_("Select Music View Document"))
         self.music_print.setText(_("&Print Music..."))
@@ -411,7 +411,7 @@ class ComboBoxAction(QWidgetAction):
     def __init__(self, panel):
         super(ComboBoxAction, self).__init__(panel)
         self.triggered.connect(self.showPopup)
-        
+
     def showPopup(self):
         """Called when our action is triggered by a keyboard shortcut."""
         # find the widget in our floating panel, if available there
@@ -424,24 +424,24 @@ class ComboBoxAction(QWidgetAction):
             if w.window() == self.parent().mainwindow():
                 w.showPopup()
                 return
-    
+
 
 class DocumentChooserAction(ComboBoxAction):
     """A ComboBoxAction that keeps track of the current text document.
-    
+
     It manages the list of generated PDF documents for every text document.
     If the mainwindow changes its current document and there are PDFs to display,
     it switches the current document.
-    
+
     It also switches to a text document if a job finished for that document,
     and it generated new PDF documents.
-    
+
     """
-    
+
     documentClosed = pyqtSignal()
     documentsChanged = pyqtSignal()
     currentDocumentChanged = pyqtSignal(documents.Document)
-    
+
     def __init__(self, panel):
         super(DocumentChooserAction, self).__init__(panel)
         self._model = None
@@ -451,20 +451,20 @@ class DocumentChooserAction(ComboBoxAction):
         self._indices = weakref.WeakKeyDictionary()
         panel.mainwindow().currentDocumentChanged.connect(self.slotDocumentChanged)
         documents.documentUpdated.connect(self.slotDocumentUpdated)
-        
+
     def createWidget(self, parent):
         w = DocumentChooser(parent)
         w.activated[int].connect(self.setCurrentIndex)
         if self._model:
             w.setModel(self._model)
         return w
-    
+
     def slotDocumentChanged(self, doc):
         """Called when the mainwindow changes its current document."""
         # only switch our document if there are PDF documents to display
         if self._document is None or documents.group(doc).documents():
             self.setCurrentDocument(doc)
-    
+
     def slotDocumentUpdated(self, doc, job):
         """Called when a Job, finished on the document, has created new PDFs."""
         # if result files of this document were already displayed, the display
@@ -477,7 +477,7 @@ class DocumentChooserAction(ComboBoxAction):
             (jobattributes.get(job).mainwindow == mainwindow and
              doc == engrave.engraver(mainwindow).document())):
             self.setCurrentDocument(doc)
-    
+
     def setCurrentDocument(self, document):
         """Displays the DocumentGroup of the given text Document in our chooser."""
         prev = self._document
@@ -489,26 +489,26 @@ class DocumentChooserAction(ComboBoxAction):
         document.loaded.connect(self.updateDocument)
         document.closed.connect(self.closeDocument)
         self.updateDocument()
-        
+
     def updateDocument(self):
         """(Re)read the output documents of the current document and show them."""
         docs = self._documents = documents.group(self._document).documents()
         self.setVisible(bool(docs))
         self.setEnabled(bool(docs))
-        
+
         # make model for the docs
         m = self._model = listmodel.ListModel([d.filename() for d in docs],
             display = os.path.basename, icon = icons.file_type)
         m.setRoleFunction(Qt.UserRole, lambda f: f)
         for w in self.createdWidgets():
             w.setModel(m)
-        
+
         index = self._indices.get(self._document, 0)
         if index < 0 or index >= len(docs):
             index = 0
         self.documentsChanged.emit()
         self.setCurrentIndex(index)
-    
+
     def closeDocument(self):
         """Called when the current document is closed by the user."""
         self._document = None
@@ -518,10 +518,10 @@ class DocumentChooserAction(ComboBoxAction):
         self.setEnabled(False)
         self.documentClosed.emit()
         self.documentsChanged.emit()
-        
+
     def documents(self):
         return self._documents
-        
+
     def setCurrentIndex(self, index):
         if self._documents:
             self._currentIndex = index
@@ -533,10 +533,10 @@ class DocumentChooserAction(ComboBoxAction):
                 w.setCurrentIndex(index)
                 w.setPalette(p)
             self.currentDocumentChanged.emit(self._documents[index])
-    
+
     def currentIndex(self):
         return self._currentIndex
-    
+
     def currentDocument(self):
         """Returns the currently selected Music document (Note: NOT the text document!)"""
         if self._documents:
@@ -552,7 +552,7 @@ class DocumentChooser(QComboBox):
         self.setFocusPolicy(Qt.NoFocus)
         app.translateUI(self)
         gadgets.drag.ComboDrag(self).role = Qt.UserRole
-        
+
     def translateUI(self):
         self.setToolTip(_("Choose the PDF document to display."))
         self.setWhatsThis(_(
@@ -562,15 +562,15 @@ class DocumentChooser(QComboBox):
 
 class ZoomerAction(ComboBoxAction):
     zoomChanged = pyqtSignal(int, float)
-    
+
     def createWidget(self, parent):
         return Zoomer(self, parent)
-    
+
     def setCurrentIndex(self, index):
         """Called when a user manipulates a Zoomer combobox.
-        
+
         Updates the other widgets and calls the corresponding method of the panel.
-        
+
         """
         for w in self.createdWidgets():
             w.setCurrentIndex(index)
@@ -582,7 +582,7 @@ class ZoomerAction(ComboBoxAction):
             self.zoomChanged.emit(FitBoth, 0)
         else:
             self.zoomChanged.emit(FixedScale, _zoomvalues[index-3] / 100.0)
-    
+
     def updateZoomInfo(self, mode, scale):
         """Connect view.viewModeChanged and layout.scaleChanged to this."""
         if mode == FixedScale:
@@ -612,23 +612,23 @@ class Zoomer(QComboBox):
         self.addItems(list(map("{0}%".format, _zoomvalues)))
         self.setMaxVisibleItems(20)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setItemText(0, _("Fit Width"))
         self.setItemText(1, _("Fit Height"))
         self.setItemText(2, _("Fit Page"))
-        
+
 
 class PagerAction(QWidgetAction):
     def __init__(self, panel):
         super(PagerAction, self).__init__(panel)
-    
+
     def createWidget(self, parent):
         w = QSpinBox(parent, buttonSymbols=QSpinBox.NoButtons)
         w.setFocusPolicy(Qt.ClickFocus)
         w.valueChanged[int].connect(self.slotValueChanged)
         return w
-    
+
     def setPageCount(self, total):
         if total:
             self.setVisible(True)
@@ -646,14 +646,14 @@ class PagerAction(QWidgetAction):
         for w in self.createdWidgets():
             with qutil.signalsBlocked(w):
                 adjust(w)
-    
+
     def setCurrentPage(self, num):
         if num:
             for w in self.createdWidgets():
                 with qutil.signalsBlocked(w):
                     w.setValue(num)
                     w.lineEdit().deselect()
-    
+
     def slotValueChanged(self, num):
         self.parent().setCurrentPage(num)
 

--- a/frescobaldi_app/musicview/contextmenu.py
+++ b/frescobaldi_app/musicview/contextmenu.py
@@ -31,21 +31,21 @@ import icons
 
 def show(position, panel, link, cursor):
     """Shows a context menu.
-    
+
     position: The global position to pop up
     panel: The music view panel, giving access to mainwindow and view widget
     link: a popplerqt5 LinkBrowse instance or None
     cursor: a QTextCursor instance or None
-    
+
     """
     m = QMenu(panel)
-    
+
     # selection? -> Copy
     if panel.widget().view.surface().hasSelection():
         if panel.widget().view.surface().selectedText():
             m.addAction(panel.actionCollection.music_copy_text)
         m.addAction(panel.actionCollection.music_copy_image)
-    
+
     if cursor:
         a = m.addAction(icons.get("document-edit"), _("Edit in Place"))
         @a.triggered.connect
@@ -58,7 +58,7 @@ def show(position, panel, link, cursor):
         def open_in_browser():
             import helpers
             helpers.openUrl(QUrl(link.url()))
-        
+
         a = m.addAction(icons.get("edit-copy"), _("Copy &Link"))
         @a.triggered.connect
         def copy_link():
@@ -71,7 +71,7 @@ def show(position, panel, link, cursor):
         m.addAction(panel.actionCollection.music_zoom_original)
         m.addSeparator()
         m.addAction(panel.actionCollection.music_sync_cursor)
-    
+
     # help
     m.addSeparator()
     a = m.addAction(icons.get("help-contents"), _("Help"))
@@ -79,7 +79,7 @@ def show(position, panel, link, cursor):
     def help():
         import userguide
         userguide.show("musicview")
-    
+
     # show it!
     if m.actions():
         m.exec_(position)

--- a/frescobaldi_app/musicview/documents.py
+++ b/frescobaldi_app/musicview/documents.py
@@ -60,13 +60,13 @@ def group(document):
 
 def load(filename):
     """Returns a Poppler.Document for the given filename, caching it (weakly).
-    
+
     Returns None if the document failed to load.
-    
+
     """
     mtime = os.path.getmtime(filename)
     key = (mtime, filename)
-    
+
     try:
         return _cache[key]
     except KeyError:
@@ -88,10 +88,10 @@ def filename(poppler_document):
 class Document(popplertools.Document):
     """Represents a (lazily) loaded PDF document."""
     updated = True
-    
+
     def load(self):
         return load(self.filename())
-        
+
     if popplerqt5 is None:
         def document(self):
             """Returns None because popplerqt5 is not available."""
@@ -100,19 +100,19 @@ class Document(popplertools.Document):
 
 class DocumentGroup(plugin.DocumentPlugin):
     """Represents a group of PDF documents, created by the text document it belongs to.
-    
+
     Multiple MusicView instances can use this group, they can store the positions
     of the Documents in the viewer themselves via a weak-key dictionary on the Document
     instances returned by documents(). On update() these Document instances will be reused.
-    
+
     The global documentUpdated(Document) signal will be emitted when the global
     app.jobFinished() signal causes a reload of documents in a group.
-    
+
     """
     def __init__(self, document):
         self._documents = None
         document.loaded.connect(self.update, -100)
-        
+
     def documents(self):
         """Returns the list of PDF Document objects created by our text document."""
         # If the list is asked for the very first time, update
@@ -120,19 +120,19 @@ class DocumentGroup(plugin.DocumentPlugin):
             self._documents = []
             self.update()
         return self._documents[:]
-    
+
     def update(self, newer=None):
         """Queries the resultfiles of this text document for PDF files and loads them.
-        
+
         Returns True if new documents were loaded.
         If newer is True, only PDF files newer than the source document are returned.
         If newer is False, all PDF files are returned.
         If newer is None (default), the setting from the configuration is used.
-        
+
         """
         if newer is None:
             newer = QSettings().value("musicview/newer_files_only", True, bool)
-        
+
         results = resultfiles.results(self.document())
         files = results.files(".pdf", newer)
         if files:

--- a/frescobaldi_app/musicview/pointandclick.py
+++ b/frescobaldi_app/musicview/pointandclick.py
@@ -60,16 +60,16 @@ def links(document):
 
 class Links(pointandclick.Links):
     """Stores all the links of a Poppler document sorted by URL and text position.
-    
+
     Only textedit:// urls are stored.
-    
+
     """
     def cursor(self, link, load=False):
         """Returns the destination of a link as a QTextCursor of the destination document.
-        
+
         If load (defaulting to False) is True, the document is loaded if it is not yet loaded.
         Returns None if the url was not valid or the document could not be loaded.
-        
+
         """
         import popplerqt5
         if not isinstance(link, popplerqt5.Poppler.LinkBrowse) or not link.url():

--- a/frescobaldi_app/musicview/widget.py
+++ b/frescobaldi_app/musicview/widget.py
@@ -53,28 +53,28 @@ from . import pointandclick
 
 class MusicView(QWidget):
     """Widget containing the qpopplerview.View."""
-    
+
     zoomChanged = pyqtSignal(int, float) # mode, scale
-    
+
     def __init__(self, dockwidget):
         """Creates the Music View for the dockwidget."""
         super(MusicView, self).__init__(dockwidget)
-        
+
         self._positions = weakref.WeakKeyDictionary()
         self._currentDocument = None
         self._links = None
         self._clicking_link = False
-        
+
         self._highlightFormat = QTextCharFormat()
         self._highlightMusicFormat = Highlighter()
         self._highlightRange = None
         self._highlightTimer = QTimer(singleShot=True, interval= 250, timeout=self.updateHighlighting)
         self._highlightRemoveTimer = QTimer(singleShot=True, timeout=self.clearHighlighting)
-        
+
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-        
+
         self.view = popplerview.View(self)
         self.view.MAX_ZOOM = 8.0
         layout.addWidget(self.view)
@@ -87,26 +87,26 @@ class MusicView(QWidget):
         self.view.surface().linkLeft.connect(self.slotLinkLeft)
         self.view.surface().setShowUrlTips(False)
         self.view.surface().linkHelpRequested.connect(self.slotLinkHelpRequested)
-        
+
         self.view.viewModeChanged.connect(self.updateZoomInfo)
         self.view.surface().pageLayout().scaleChanged.connect(self.updateZoomInfo)
         self.view.setContextMenuPolicy(Qt.CustomContextMenu)
         self.view.customContextMenuRequested.connect(self.showContextMenu)
-        
+
         # react if cursor of current text document moves
         dockwidget.mainwindow().currentViewChanged.connect(self.slotCurrentViewChanged)
         view = dockwidget.mainwindow().currentView()
         if view:
             self.slotCurrentViewChanged(view)
-    
+
     def sizeHint(self):
         """Returns the initial size the PDF (Music) View prefers."""
         return self.parent().mainwindow().size() / 2
-    
+
     def updateZoomInfo(self):
         """Called when zoom and viewmode of the qpopplerview change, emit zoomChanged."""
         self.zoomChanged.emit(self.view.viewMode(), self.view.surface().pageLayout().scale())
-    
+
     def openDocument(self, doc):
         """Opens a documents.Document instance."""
         self.clear()
@@ -128,7 +128,7 @@ class MusicView(QWidget):
         self._highlightRange = None
         self._highlightTimer.stop()
         self.view.clear()
-        
+
     def readSettings(self):
         """Reads the settings from the user's preferences."""
         # background and highlight colors of music view
@@ -140,10 +140,10 @@ class MusicView(QWidget):
 
     def slotLinkClicked(self, ev, page, link):
         """Called when the use clicks a link.
-        
+
         If the links is a textedit link, opens the document and puts the cursor there.
         Otherwise, call the helpers module to open the destination.
-        
+
         """
         if ev.button() == Qt.RightButton:
             return
@@ -171,13 +171,13 @@ class MusicView(QWidget):
 
     def slotLinkHovered(self, page, link):
         """Called when the mouse hovers a link.
-        
+
         If the links points to the current editor document, the token(s) it points
         at are highlighted using a transparent selection color.
-        
+
         The highlight shows for a few seconds but disappears when the mouse moves
         off the link or when the link is clicked.
-        
+
         """
         self.view.surface().highlight(self._highlightMusicFormat,
             [(page, link.linkArea().normalized())], 2000)
@@ -185,13 +185,13 @@ class MusicView(QWidget):
         cursor = self._links.cursor(link)
         if not cursor or cursor.document() != self.parent().mainwindow().currentDocument():
             return
-        
+
         # highlight token(s) at this cursor
         cursors = pointandclick.positions(cursor)
         if cursors:
             view = self.parent().mainwindow().currentView()
             viewhighlighter.highlighter(view).highlight(self._highlightFormat, cursors, 2, 5000)
-    
+
     def slotLinkLeft(self):
         """Called when the mouse moves off a previously highlighted link."""
         self.clearHighlighting()
@@ -224,17 +224,17 @@ class MusicView(QWidget):
         if old:
             old.cursorPositionChanged.disconnect(self.slotCursorPositionChanged)
         view.cursorPositionChanged.connect(self.slotCursorPositionChanged)
-    
+
     def slotCursorPositionChanged(self):
         """Called when the user moves the text cursor."""
         if not self.isVisible() or not self._links:
             return # not visible of no PDF in the viewer
-        
+
         view = self.parent().mainwindow().currentView()
         links = self._links.boundLinks(view.document())
         if not links:
             return # the PDF contains no references to the current text document
-        
+
         s = links.indices(view.textCursor())
         if s is False:
             self.clearHighlighting()
@@ -248,7 +248,7 @@ class MusicView(QWidget):
                 self.view.ensureVisible(center.x(), center.y(),
                                         50 + rect.width() // 2,
                                         50 + rect.height() // 2)
-            
+
             # perform highlighting after move has been started. This is to ensure that if kinetic scrolling is
             # is enabled its speed is already set so that we can adjust the highlight timer.
             self.highlight(links.destinations(), s)
@@ -261,7 +261,7 @@ class MusicView(QWidget):
             # RC: increased timer to give some time to the kinetic scrolling to complete.
             kineticTimeLeft = 0
             if self.view.kineticScrollingEnabled():
-                kineticTimeLeft = 20*self.view.kineticTicksLeft() 
+                kineticTimeLeft = 20*self.view.kineticTicksLeft()
             msec = 5000 if count > 1 else 2000 # show selections longer
             msec += kineticTimeLeft
         self._highlightRemoveTimer.start(msec)
@@ -274,7 +274,7 @@ class MusicView(QWidget):
         else:
             self._highlightTimer.stop()
             self.updateHighlighting()
-    
+
     def updateHighlighting(self):
         """Really orders the view's surface to draw the highlighting."""
         layout = self.view.surface().pageLayout()
@@ -282,7 +282,7 @@ class MusicView(QWidget):
                     for dest in self._destinations
                     for pageNum, rect in dest]
         self.view.surface().highlight(self._highlightMusicFormat, areas)
-    
+
     def clearHighlighting(self):
         """Called on timeout of the _highlightRemoveTimer."""
         self._highlightRange = None
@@ -292,18 +292,18 @@ class MusicView(QWidget):
         """Scrolls the view if necessary to show objects at current text cursor."""
         if not self._links:
             return # no PDF in viewer
-            
+
         view = self.parent().mainwindow().currentView()
         links = self._links.boundLinks(view.document())
         if not links:
             return # the PDF contains no references to the current text document
-        
+
         s = links.indices(view.textCursor())
         if not s:
             return
         self.view.center(self.destinationsRect(links.destinations()[s]).center())
         self.highlight(links.destinations(), s, 10000)
-    
+
     def destinationsRect(self, destinations):
         """Return the rectangle containing all destinations."""
         layout = self.view.surface().pageLayout()
@@ -314,7 +314,7 @@ class MusicView(QWidget):
         # not larger than viewport
         rect.setSize(rect.size().boundedTo(self.view.viewport().size()))
         return rect
-    
+
     def showContextMenu(self):
         """Called when the user right-clicks or presses the context menu key."""
         pos = self.view.mapToGlobal(QPoint(0, 0))
@@ -332,14 +332,14 @@ class MusicView(QWidget):
 
 class Highlighter(qpopplerview.Highlighter):
     """Simple version of qpopplerview.Highlighter that has the color settable.
-    
+
     You must set a color before using the Highlighter.
-    
+
     """
     def setColor(self, color):
         """Sets the color to use to draw highlighting rectangles."""
         self._color = color
-    
+
     def color(self):
         """Returns the color set using the setColor method."""
         return self._color

--- a/frescobaldi_app/objecteditor/__init__.py
+++ b/frescobaldi_app/objecteditor/__init__.py
@@ -41,7 +41,7 @@ class ObjectEditor(panel.Panel):
     def translateUI(self):
         self.setWindowTitle(_("Object Editor"))
         self.toggleViewAction().setText(_("O&bject Editor"))
-        
+
     def createWidget(self):
         from . import widget
         w = widget.Widget(self)

--- a/frescobaldi_app/objecteditor/defineoffset.py
+++ b/frescobaldi_app/objecteditor/defineoffset.py
@@ -39,11 +39,11 @@ class DefineOffset():
         self.lilyObject = None
         self.lilyContext = ""
         self.pos = 0
-        
+
     def getCurrentLilyObject(self, cursor):
-        """ Use cursor from textedit link to get type of object being edited."""        
+        """ Use cursor from textedit link to get type of object being edited."""
         lycursor = lydocument.cursor(cursor)
-        self.pos = lycursor.start        
+        self.pos = lycursor.start
         node = self.docinfo.node(self.pos)
         self.node = node
         child = self.docinfo.iter_music(node)
@@ -52,16 +52,16 @@ class DefineOffset():
             return self.item2object(name)
         name = node.__class__.__name__
         return self.item2object(name)
-        
+
     def item2object(self, item):
-        """ Translate item type into name of 
+        """ Translate item type into name of
         LilyPond object.
         """
         item2objectDict = {
-            "String": { "GrobType": "TextScript" }, 
+            "String": { "GrobType": "TextScript" },
             "Markup": { "GrobType": "TextScript" },
             "Tempo": { "GrobType": "MetronomeMark",
-                       "Context" : "Score" }, 
+                       "Context" : "Score" },
             "Articulation": { "GrobType": "Script" }
             }
         try:
@@ -72,7 +72,7 @@ class DefineOffset():
         if "Context" in obj:
             self.lilyContext = obj["Context"]
         return obj["GrobType"]
-        
+
     def insertOverride(self, x, y):
         """ Insert the override command. """
         doc = lydocument.Document(self.doc)
@@ -85,7 +85,7 @@ class DefineOffset():
         cursor.insertBlock()
         cursor.endEditBlock()
         reformat.reformat(cursor)
-        
+
     def createOffsetOverride(self, x, y):
         """ Create the override command.
         Can this be created as a node?

--- a/frescobaldi_app/objecteditor/widget.py
+++ b/frescobaldi_app/objecteditor/widget.py
@@ -38,7 +38,7 @@ from . import defineoffset
 
 
 class Widget(QWidget):
-    
+
 # I think we will work with individual editor objects for different types of objects.
 # Each one will be shown/hidden on demand, i.e. when an element is activated
 # through the SVG view, the music view or the cursor in the source.
@@ -50,48 +50,48 @@ class Widget(QWidget):
         super(Widget, self).__init__(tool)
         self.mainwindow = tool.mainwindow()
         self.define = None
-        
+
         import panelmanager
         self.svgview = panelmanager.manager(tool.mainwindow()).svgview.widget().view
-        
+
         layout = QVBoxLayout(spacing=1)
         self.setLayout(layout)
-        
+
         self.elemLabel = QLabel()
-        
+
         self.XOffsetBox = QDoubleSpinBox()
         self.XOffsetBox.setRange(-99,99)
         self.XOffsetBox.setSingleStep(0.1)
         self.XOffsetLabel = l = QLabel()
         l.setBuddy(self.XOffsetBox)
- 
+
         self.YOffsetBox = QDoubleSpinBox()
         self.YOffsetBox.setRange(-99,99)
         self.YOffsetBox.setSingleStep(0.1)
         self.YOffsetLabel = l = QLabel()
         l.setBuddy(self.YOffsetBox)
-        
+
         self.insertButton = QPushButton("insert offset in source", self)
         self.insertButton.clicked.connect(self.callInsert)
-        
+
         layout.addWidget(self.elemLabel)
         layout.addWidget(self.XOffsetLabel)
         layout.addWidget(self.XOffsetBox)
         layout.addWidget(self.YOffsetLabel)
         layout.addWidget(self.YOffsetBox)
         layout.addWidget(self.insertButton)
-        
+
         layout.addStretch(1)
 
         app.translateUI(self)
         self.loadSettings()
-        
+
         self.connectSlots()
-    
+
     def connectSlots(self):
         # On creation we connect to all available signals
         self.connectToSvgView()
-    
+
     def connectToSvgView(self):
         """Register with signals emitted by the
            SVG viewer for processing graphical editing.
@@ -100,7 +100,7 @@ class Widget(QWidget):
         self.svgview.objectDragging.connect(self.Dragging)
         self.svgview.objectDragged.connect(self.Dragged)
         self.svgview.cursor.connect(self.setObjectFromCursor)
-        
+
     def disconnectFromSvgView(self):
         """Do not process graphical edits when the
            Object Editor isn't visible."""
@@ -108,7 +108,7 @@ class Widget(QWidget):
         self.svgview.objectDragging.disconnect()
         self.svgview.objectDragged.disconnect()
         self.svgview.cursor.disconnect()
-        
+
     def translateUI(self):
         self.XOffsetLabel.setText(_("X Offset"))
         self.XOffsetBox.setToolTip(_("Display the X Offset"))
@@ -122,46 +122,46 @@ class Widget(QWidget):
         """
         self.disconnectFromSvgView()
         event.accept()
-    
+
     def showEvent(self, event):
         """Connect to the graphical editing signals
            when the panel becomes visible
         """
         self.connectToSvgView()
         event.accept()
-        
+
     def callInsert(self):
         """ Insert the override command in the source."""
         if self.define:
-            self.define.insertOverride(self.XOffsetBox.value(), self.YOffsetBox.value())		
-    
+            self.define.insertOverride(self.XOffsetBox.value(), self.YOffsetBox.value())
+
     @QtCore.pyqtSlot(float, float)
     def setOffset(self, x, y):
         """Display the updated offset."""
         self.XOffsetBox.setValue(x)
         self.YOffsetBox.setValue(y)
-    
+
     @QtCore.pyqtSlot(float, float)
     def startDragging(self, x, y):
         """Set the value of the offset externally."""
         # temporary debug output
         #print("Start dragging with offset", x, y)
         self.setOffset(x, y)
-        
+
     @QtCore.pyqtSlot(float, float)
     def Dragging(self, x, y):
         """Set the value of the offset externally."""
         # temporary debug output
         # print("Dragging with offset", x, y)
         self.setOffset(x, y)
-        
+
     @QtCore.pyqtSlot(float, float)
     def Dragged(self, x, y):
         """Set the value of the offset externally."""
         # temporary debug output
         #print("Dragged to", x, y)
         self.setOffset(x, y)
-        
+
     @QtCore.pyqtSlot(QTextCursor)
     def setObjectFromCursor(self, cursor):
         """Set selected element."""
@@ -173,7 +173,7 @@ class Widget(QWidget):
         """Called on construction. Load settings and set checkboxes state."""
         s = QSettings()
         s.beginGroup('object_editor')
-        
+
     def saveSettings(self):
         """Called on close. Save settings and checkboxes state."""
         s = QSettings()

--- a/frescobaldi_app/open_file_at_cursor.py
+++ b/frescobaldi_app/open_file_at_cursor.py
@@ -32,9 +32,9 @@ import browseriface
 
 def filenames_at_cursor(cursor, existing=True):
     """Return a list of filenames at the cursor.
-    
+
     If existing is False, also names are returned that do not exist on disk.
-    
+
     """
     # take either the selection or the include-args found by lydocinfo
     start = cursor.document().findBlock(cursor.selectionStart()).position()
@@ -48,7 +48,7 @@ def filenames_at_cursor(cursor, existing=True):
         text = cursor.selection().toPlainText()
         if '\n' not in text.strip():
             fnames = [text]
-    
+
     # determine search path: doc dir and other include path names
     filename = cursor.document().url().toLocalFile()
     directory = os.path.dirname(filename)
@@ -57,7 +57,7 @@ def filenames_at_cursor(cursor, existing=True):
     else:
         path = []
     path.extend(dinfo.includepath())
-    
+
     # find all docs, trying all include paths
     filenames = []
     for f in fnames:
@@ -74,9 +74,9 @@ def filenames_at_cursor(cursor, existing=True):
 
 def open_file_at_cursor(mainwindow, cursor=None):
     """Open the filename(s) mentioned at the mainwindow's text cursor.
-    
+
     Return True if there were one or more filenames that were opened.
-    
+
     """
     if cursor is None:
         cursor = mainwindow.textCursor()

--- a/frescobaldi_app/outline/__init__.py
+++ b/frescobaldi_app/outline/__init__.py
@@ -38,7 +38,7 @@ class OutlinePanel(panel.Panel):
     def translateUI(self):
         self.setWindowTitle(_("Outline"))
         self.toggleViewAction().setText(_("&Outline"))
-        
+
     def createWidget(self):
         from . import widget
         w = widget.Widget(self)

--- a/frescobaldi_app/outline/widget.py
+++ b/frescobaldi_app/outline/widget.py
@@ -47,7 +47,7 @@ class Widget(QTreeWidget):
         doc = tool.mainwindow().currentDocument()
         if doc:
             self.slotCurrentDocumentChanged(doc)
-    
+
     def slotCurrentDocumentChanged(self, doc, old=None):
         """Called whenever the mainwindow changes the current document."""
         if old:
@@ -55,14 +55,14 @@ class Widget(QTreeWidget):
         if doc:
             doc.contentsChange.connect(self.slotContentsChange)
             self._timer.start(100)
-            
+
     def slotContentsChange(self, position, added, removed):
         """Updates the view on contents change."""
         if added + removed > 1000:
             self._timer.start(100)
         else:
             self._timer.start(2000)
-        
+
     def updateView(self):
         """Recreate the items in the view."""
         with qutil.signalsBlocked(self):
@@ -106,9 +106,9 @@ class Widget(QTreeWidget):
                             b = b.next()
                         else:
                             parent = last_item
-                
+
                 item = last_item = QTreeWidgetItem(parent)
-                
+
                 # set item text and display style bold if 'title' was used
                 for name, text in i.groupdict().items():
                     if text:
@@ -129,7 +129,7 @@ class Widget(QTreeWidget):
                 else:
                     text = i.group()
                 item.setText(0, text)
-                
+
                 # remember whether is was collapsed by the user
                 try:
                     collapsed = block.userData().collapsed
@@ -144,19 +144,19 @@ class Widget(QTreeWidget):
                     current_item = item
             if current_item:
                 self.scrollToItem(current_item)
-    
+
     def cursorForItem(self, item):
         """Returns a cursor for the specified item.
-        
+
         This method (as all others) assume that the item refers to the current
         Document.
-        
+
         """
         doc = self.parent().mainwindow().currentDocument()
         cursor = QTextCursor(doc)
         cursor.setPosition(item.position)
         return cursor
-        
+
     def slotItemClicked(self, item):
         """Called when the user clicks an item."""
         cursor = self.cursorForItem(item)
@@ -171,7 +171,7 @@ class Widget(QTreeWidget):
         """Called when the user collapses an item."""
         block = self.cursorForItem(item).block()
         cursortools.data(block).collapsed = True
-    
+
     def slotItemExpanded(self, item):
         """Called when the user expands an item."""
         block = self.cursorForItem(item).block()

--- a/frescobaldi_app/panel.py
+++ b/frescobaldi_app/panel.py
@@ -35,35 +35,35 @@ import app
 
 class Panel(QDockWidget):
     """Base class for Panels.
-    
+
     You should implement __init__(), createWidget() and translateUI().
-    
+
     This QDockWidget subclass implements lazy loading of the panel's widget.
     When one of sizeHint() or showEvent() is called for the first time, the
     widget is created by calling createWidget().
-    
+
     """
     def __init__(self, mainwindow):
         """Implement this method to add yourself to the mainwindow.
-        
+
         First call this super method as it calls the Qt constructor.
-        
+
         """
         super(Panel, self).__init__(mainwindow)
         self.setObjectName(self.__class__.__name__.lower())
         app.translateUI(self)
         app.languageChanged.connect(self._setToolTips)
         self._setToolTips()
-    
+
     def mainwindow(self):
         """Returns the MainWindow."""
         return self.parentWidget()
-        
+
     def sizeHint(self):
         """Re-implemented to force creation of our widget."""
         self.widget()
         return super(Panel, self).sizeHint()
-    
+
     def widget(self):
         """Ensures that our widget() is created and returns it."""
         w = super(Panel, self).widget()
@@ -71,36 +71,36 @@ class Panel(QDockWidget):
             w = self.createWidget()
             self.setWidget(w)
         return w
-    
+
     def instantiated(self):
         """Return True if the tool already has been loaded."""
         return bool(super(Panel, self).widget())
-        
+
     def showEvent(self, ev):
         """Re-implemented to force creation of widget."""
         self.widget()
-        
+
     def createWidget(self):
         """Implement this to return the widget for this tool."""
         return QLabel("<test>", self)
-        
+
     def activate(self):
         """Really shows the dock widget, even if tabified or floating."""
         self.show()
         if self.mainwindow().tabifiedDockWidgets(self) or self.isFloating():
             self.raise_()
-    
+
     def maximize(self):
         """Show the dockwidget floating and maximized."""
         self.setFloating(True)
         self.showMaximized()
-    
+
     def translateUI(self):
         """Implement to set a title for the widget and its toggleViewAction."""
         raise NotImplementedError(
             "Please implement this method to at least set a title "
             "for the dockwidget and its toggleViewAction().")
-    
+
     def _setToolTips(self):
         """Generic tool tips are set here."""
         self.setToolTip(_("Drag to dock/undock"))

--- a/frescobaldi_app/panelmanager.py
+++ b/frescobaldi_app/panelmanager.py
@@ -34,18 +34,18 @@ import vcs
 
 def manager(mainwindow):
     return PanelManager.instance(mainwindow)
-    
+
 
 class PanelManager(plugin.MainWindowPlugin):
     def __init__(self, mainwindow):
         """Instantiate the Panel Manager.
-        
+
         In this method you should also load the modules that implement
         panel tools.
-        
+
         """
         self._panels = []
-        
+
         # add the the panel stubs here
         self.loadPanel("quickinsert.QuickInsertPanel")
         self.loadPanel("musicview.MusicViewPanel")
@@ -60,27 +60,27 @@ class PanelManager(plugin.MainWindowPlugin):
         self.loadPanel("doclist.DocumentList")
         self.loadPanel("outline.OutlinePanel")
         self.loadPanel("layoutcontrol.LayoutControlOptions")
-        
+
         # The Object editor is highly experimental and should be
         # commented out for stable releases.
         if vcs.app_is_git_controlled() or QSettings().value("experimental-features", False, bool):
             self.loadPanel("objecteditor.ObjectEditor")
         self.createActions()
-        
+
         # make some default arrangements
         mainwindow.tabifyDockWidget(self.musicview, self.docbrowser)
         mainwindow.tabifyDockWidget(self.musicview, self.svgview)
-    
+
     def loadPanel(self, name):
         """Loads the named Panel.
-        
+
         The name consists of a module name and the class name of the Panel
         subclass to instantiate.
-        
+
         The instance is saved in an attribute 'name', with dots and the class
         name removed. So if you call self.loadTool("foo.bar.FooBar"), you can
         find the instantiated FooBar panel in the 'foobar' attribute.
-        
+
         """
         module_name, class_name = name.rsplit('.', 1)
         __import__(module_name)
@@ -102,10 +102,10 @@ class PanelManager(plugin.MainWindowPlugin):
 
     def panels_at(self, area):
         """Return the list of panels at the specified Qt.DockWidgetArea.
-        
+
         Each entry is the (name, panel) tuple. Floating or hidden panels are
         not returned, but tabbed panels are.
-        
+
         """
         result = []
         for name, panel in self._panels:
@@ -119,7 +119,7 @@ class PanelManager(plugin.MainWindowPlugin):
 class Actions(actioncollection.ActionCollection):
     """Manages the keyboard shortcuts to hide/show the plugins."""
     name = "panels"
-    
+
     def createActions(self, manager):
         # add the actions for the plugins
         for name, panel in manager._panels:

--- a/frescobaldi_app/pitch/__init__.py
+++ b/frescobaldi_app/pitch/__init__.py
@@ -57,55 +57,55 @@ class Pitch(plugin.MainWindowPlugin):
         ac.pitch_simplify.triggered.connect(self.simplifyAccidentals)
         self.readSettings()
         app.aboutToQuit.connect(self.writeSettings)
-    
+
     def get_absolute(self, document):
         """Return True when the first pitch in a \\relative expression without
         startpitch may be considered absolute.
-        
+
         """
         import documentinfo
         return (self.actionCollection.pitch_relative_assume_first_pitch_absolute.isChecked()
             or documentinfo.docinfo(document).version() >= (2, 18))
-    
+
     def rel2abs(self):
         from . import pitch
         cursor = self.mainwindow().textCursor()
         pitch.rel2abs(cursor, self.get_absolute(cursor.document()))
-    
+
     def abs2rel(self):
         startpitch = self.actionCollection.pitch_relative_write_startpitch.isChecked()
         from . import pitch
         cursor = self.mainwindow().textCursor()
         pitch.abs2rel(cursor, startpitch, self.get_absolute(cursor.document()))
-    
+
     def transpose(self):
         from . import pitch
         cursor = self.mainwindow().textCursor()
         transposer = pitch.getTransposer(cursor.document(), self.mainwindow())
         if transposer:
             pitch.transpose(cursor, transposer, self.mainwindow(), self.get_absolute(cursor.document()))
-    
+
     def modalTranspose(self):
         from . import pitch
         cursor = self.mainwindow().textCursor()
         transposer = pitch.getModalTransposer(cursor.document(), self.mainwindow())
         if transposer:
             pitch.transpose(cursor, transposer, self.mainwindow())
-            
+
     def modeShift(self):
         from . import pitch
         cursor = self.mainwindow().textCursor()
         transposer = pitch.getModeShifter(cursor.document(), self.mainwindow())
         if transposer:
             pitch.transpose(cursor, transposer, self.mainwindow())
-    
+
     def simplifyAccidentals(self):
         from . import pitch
         import ly.pitch.transpose
         cursor = self.mainwindow().textCursor()
         transposer = ly.pitch.transpose.Simplifier()
         pitch.transpose(cursor, transposer, self.mainwindow(), self.get_absolute(cursor.document()))
-    
+
     def setLanguageMenu(self):
         """Called when the menu is shown; selects the correct language."""
         import documentinfo
@@ -115,12 +115,12 @@ class Pitch(plugin.MainWindowPlugin):
             if a.objectName() == lang:
                 a.setChecked(True)
                 break
-    
+
     def changeLanguage(self, action):
         from . import pitch
         cursor = self.mainwindow().textCursor()
         pitch.changeLanguage(cursor, action.objectName())
-    
+
     def readSettings(self):
         s = QSettings()
         s.beginGroup("pitch-menu")
@@ -128,7 +128,7 @@ class Pitch(plugin.MainWindowPlugin):
             s.value("relative-first-pitch-absolute", False, bool))
         self.actionCollection.pitch_relative_write_startpitch.setChecked(
             s.value("relative-write-startpitch", True, bool))
-    
+
     def writeSettings(self):
         s = QSettings()
         s.beginGroup("pitch-menu")
@@ -156,7 +156,7 @@ class Actions(actioncollection.ActionCollection):
         self.pitch_modal_transpose.setIcon(icons.get('tools-transpose'))
         self.pitch_mode_shift.setIcon(icons.get('tools-transpose'))
         self.pitch_simplify.setIcon(icons.get('tools-transpose'))
-        
+
     def translateUI(self):
         self.pitch_language.setText(_("Pitch Name &Language"))
         self.pitch_language.setToolTip(_(

--- a/frescobaldi_app/pitch/dialog.py
+++ b/frescobaldi_app/pitch/dialog.py
@@ -18,7 +18,7 @@
 # See http://www.gnu.org/licenses/ for more information.
 
 """
-Dialog for the Mode shift functionality. 
+Dialog for the Mode shift functionality.
 """
 
 
@@ -35,54 +35,54 @@ import qutil
 
 # Mode definitions
 modes = {
-'Major': ((0,0), (1,1), (2,2), (3, Fraction(5, 2)), (4, Fraction(7, 2)), 
+'Major': ((0,0), (1,1), (2,2), (3, Fraction(5, 2)), (4, Fraction(7, 2)),
           (5, Fraction(9, 2)), (6, Fraction(11, 2))),
-'Minor (harmonic)': ((0,0), (1,1), (2, Fraction(3, 2)), (3, Fraction(5, 2)), 
+'Minor (harmonic)': ((0,0), (1,1), (2, Fraction(3, 2)), (3, Fraction(5, 2)),
           (4, Fraction(7, 2)), (5, 4), (6, Fraction(11, 2))),
-'Minor (natural)': ((0,0), (1,1), (2, Fraction(3, 2)), (3, Fraction(5, 2)), 
+'Minor (natural)': ((0,0), (1,1), (2, Fraction(3, 2)), (3, Fraction(5, 2)),
              (4, Fraction(7, 2)), (5, 4), (6,5)),
-'Dorian': ((0,0), (1,1), (2, Fraction(3, 2)), (3, Fraction(5, 2)), 
+'Dorian': ((0,0), (1,1), (2, Fraction(3, 2)), (3, Fraction(5, 2)),
            (4, Fraction(7, 2)), (5, Fraction(9, 2)), (6,5)),
-'Phrygian': ((0,0), (1, Fraction(1, 2)), (2, Fraction(3, 2)), 
+'Phrygian': ((0,0), (1, Fraction(1, 2)), (2, Fraction(3, 2)),
              (3, Fraction(5, 2)), (4, Fraction(7, 2)), (5,4), (6,5)),
-'Lydian': ((0,0), (1,1), (2,2), (3,3), (4, Fraction(7, 2)), 
+'Lydian': ((0,0), (1,1), (2,2), (3,3), (4, Fraction(7, 2)),
            (5, Fraction(9, 2)), (6, Fraction(11, 2))),
-'Mixolydian': ((0,0), (1,1), (2,2), (3, Fraction(5, 2)), (4, Fraction(7, 2)), 
+'Mixolydian': ((0,0), (1,1), (2,2), (3, Fraction(5, 2)), (4, Fraction(7, 2)),
                (5, Fraction(9, 2)), (6,5)),
-'Locrian': ((0,0), (1, Fraction(1, 2)), (2, Fraction(3, 2)), 
+'Locrian': ((0,0), (1, Fraction(1, 2)), (2, Fraction(3, 2)),
              (3, Fraction(5, 2)), (4, 3), (5,4), (6,5)),
-'Phrygian dominant': ((0,0), (1, Fraction(1, 2)), (2, 2), 
+'Phrygian dominant': ((0,0), (1, Fraction(1, 2)), (2, 2),
              (3, Fraction(5, 2)), (4, Fraction(7, 2)), (5,4), (6,5)),
-'Hungarian minor': ((0,0), (1,1), (2, Fraction(3, 2)), (3,3), 
+'Hungarian minor': ((0,0), (1,1), (2, Fraction(3, 2)), (3,3),
           (4, Fraction(7, 2)), (5, 4), (6, Fraction(11, 2))),
-'Double harmonic major': ((0,0), (1, Fraction(1, 2)), (2, 2), (3, Fraction(5, 2)), 
+'Double harmonic major': ((0,0), (1, Fraction(1, 2)), (2, 2), (3, Fraction(5, 2)),
                           (4, Fraction(7, 2)), (5,4), (6, Fraction(11, 2))),
-'Persian': ((0,0), (1, Fraction(1, 2)), (2, 2), (3, Fraction(5, 2)), 
+'Persian': ((0,0), (1, Fraction(1, 2)), (2, 2), (3, Fraction(5, 2)),
             (4, 3), (5,4), (6, Fraction(11, 2))),
-'Diminished (octatonic)': ((0,0), (1,1), (2, Fraction(3, 2)), (3, Fraction(5, 2)), (4, 3), 
+'Diminished (octatonic)': ((0,0), (1,1), (2, Fraction(3, 2)), (3, Fraction(5, 2)), (4, 3),
         (5,4), (5, Fraction(9, 2)), (6, Fraction(11, 2))),
 'Whole tone (hexatonic)': ((0,0), (1,1), (2,2), (3,3), (4,4), (6,5)),
-'Yo (pentatonic)': ((0,0), (1,1), (3, Fraction(5, 2)), (4, Fraction(7, 2)), (6,5)) 
+'Yo (pentatonic)': ((0,0), (1,1), (3, Fraction(5, 2)), (4, Fraction(7, 2)), (6,5))
 }
-           
-                
+
+
 class ModeShiftDialog(QDialog):
-	
+
     def __init__(self, parent=None):
         super(ModeShiftDialog, self).__init__(parent)
-        
+
         mainLayout = QGridLayout()
         self.setLayout(mainLayout)
-        
+
         self.keyLabel = QLabel()
         self.keyInput = QLineEdit()
         self.modeCombo = QComboBox()
         self.modeLabel = QLabel()
-        
+
         self.buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         userguide.addButton(self.buttons, "mode_shift")
-        
+
         for m in sorted(modes.keys()):
             self.modeCombo.addItem(m)
 
@@ -91,35 +91,35 @@ class ModeShiftDialog(QDialog):
         mainLayout.addWidget(self.modeLabel, 1, 0, 1, 1)
         mainLayout.addWidget(self.modeCombo, 1, 1, 1, 1)
         mainLayout.addWidget(self.buttons, 9, 0, 2, 2)
-        
+
         app.translateUI(self)
         qutil.saveDialogSize(self, "mode_shift/dialog/size", QSize(80, 60))
         self.buttons.accepted.connect(self.accept)
         self.buttons.rejected.connect(self.reject)
-        
+
         self.keyInput.textEdited.connect(self.readKeyInput)
         self.modeCombo.currentIndexChanged.connect(self.readSettings)
-        
+
         self.loadSettings()
-    
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Mode Shift")))
         self.keyLabel.setText(_("Key:"))
         self.modeLabel.setText(_("Mode:"))
         self.buttons.button(QDialogButtonBox.Ok).setText(_("shift pitches"))
         self.buttons.button(QDialogButtonBox.Ok).setEnabled(False)
-        
+
     def setKeyValidator(self, validate):
         """Set function that validates the key input."""
         keyValidator = KeyValidator()
         keyValidator.setValidateFunc(validate)
         self.keyInput.setValidator(keyValidator)
-    
+
     def readSettings(self):
         """Reads the current settings."""
         self._currentKey = self.keyInput.text()
         self._currentMode = self.modeCombo.currentText()
-        
+
     def readKeyInput(self):
         """Read the key input and check if it's acceptable."""
         if self.keyInput.hasAcceptableInput():
@@ -127,11 +127,11 @@ class ModeShiftDialog(QDialog):
             self.buttons.button(QDialogButtonBox.Ok).setEnabled(True)
         else:
             self.buttons.button(QDialogButtonBox.Ok).setEnabled(False)
-    
+
     def getMode(self):
         """Returns the chosen mode."""
         return self._currentKey, modes[self._currentMode]
-        
+
     def loadSettings(self):
         """ get users previous settings """
         s = QSettings()
@@ -141,7 +141,7 @@ class ModeShiftDialog(QDialog):
         index = s.value('mode', 0, int)
         self.modeCombo.setCurrentIndex(index)
         self.readKeyInput()
-        
+
     def saveSettings(self):
         """ save users last settings """
         s = QSettings()
@@ -151,13 +151,13 @@ class ModeShiftDialog(QDialog):
 
 
 class KeyValidator(QValidator):
-    
+
     def __init__(self, parent=None):
         super(KeyValidator, self).__init__(parent)
-        
+
     def setValidateFunc(self, func):
         self._func = func
-        
+
     def validate(self, text, pos):
         if text:
             if self._func(text):
@@ -165,4 +165,4 @@ class KeyValidator(QValidator):
             elif len(text) > 3:
                 return (QValidator.Invalid, text, pos)
         return (QValidator.Intermediate, text, pos)
-    
+

--- a/frescobaldi_app/pitch/pitch.py
+++ b/frescobaldi_app/pitch/pitch.py
@@ -93,12 +93,12 @@ def abs2rel(cursor, startpitch, first_pitch_absolute):
 
 def getTransposer(document, mainwindow):
     """Show a dialog and return the desired transposer.
-    
+
     Returns None if the dialog was cancelled.
-    
+
     """
     language = documentinfo.docinfo(document).language() or 'nederlands'
-    
+
     def readpitches(text):
         """Reads pitches from text."""
         result = []
@@ -107,29 +107,29 @@ def getTransposer(document, mainwindow):
             if r:
                 result.append(ly.pitch.Pitch(*r, octave=ly.pitch.octaveToNum(octave)))
         return result
-    
+
     def validate(text):
         """Returns whether the text contains exactly two pitches."""
         return len(readpitches(text)) == 2
-    
+
     text = inputdialog.getText(mainwindow, _("Transpose"), _(
         "Please enter two absolute pitches, separated by a space, "
         "using the pitch name language \"{language}\"."
         ).format(language=language), icon = icons.get('tools-transpose'),
         help = "transpose", validate = validate)
-    
+
     if text:
         return ly.pitch.transpose.Transposer(*readpitches(text))
 
 
 def getModalTransposer(document, mainwindow):
     """Show a dialog and return the desired modal transposer.
-    
+
     Returns None if the dialog was cancelled.
-    
+
     """
     language = documentinfo.docinfo(document).language() or 'nederlands'
-    
+
     def readpitches(text):
         """Reads pitches from text."""
         result = []
@@ -138,7 +138,7 @@ def getModalTransposer(document, mainwindow):
             if r:
                 result.append(ly.pitch.Pitch(*r, octave=ly.pitch.octaveToNum(octave)))
         return result
-    
+
     def validate(text):
         """Returns whether the text is an integer followed by the name of a key."""
         words = text.split()
@@ -150,7 +150,7 @@ def getModalTransposer(document, mainwindow):
             return True
         except ValueError:
             return False
-    
+
     text = inputdialog.getText(mainwindow, _("Transpose"), _(
         "Please enter the number of steps to alter by, followed by a key signature. (i.e. \"5 F\")"
         ), icon = icons.get('tools-transpose'),
@@ -158,16 +158,16 @@ def getModalTransposer(document, mainwindow):
     if text:
         words = text.split()
         return ly.pitch.transpose.ModalTransposer(int(words[0]), ly.pitch.transpose.ModalTransposer.getKeyIndex(words[1]))
-        
+
 
 def getModeShifter(document, mainwindow):
     """Show a dialog and return the desired mode shifter.
-    
+
     Returns None if the dialog was cancelled.
-    
+
     """
     language = documentinfo.docinfo(document).language() or 'nederlands'
-    
+
     def readpitches(text):
         """Reads pitches from text."""
         result = []
@@ -176,11 +176,11 @@ def getModeShifter(document, mainwindow):
             if r:
                 result.append(ly.pitch.Pitch(*r, octave=ly.pitch.octaveToNum(octave)))
         return result
-        
+
     def validate(text):
         """Validates text by checking if it contains a defined mode."""
         return len(readpitches(text)) == 1
-    
+
     from . import dialog
     dlg = dialog.ModeShiftDialog(mainwindow)
     dlg.addAction(mainwindow.actionCollection.help_whatsthis)
@@ -192,7 +192,7 @@ def getModeShifter(document, mainwindow):
         dlg.saveSettings()
         return ly.pitch.transpose.ModeShifter(key, scale)
 
-    
+
 def transpose(cursor, transposer, mainwindow=None, relative_first_pitch_absolute=False):
     """Transpose pitches using the specified transposer."""
     c = lydocument.cursor(cursor, select_all=True)

--- a/frescobaldi_app/plugin.py
+++ b/frescobaldi_app/plugin.py
@@ -53,27 +53,27 @@ _instances = weakref.WeakKeyDictionary()
 
 class Plugin(object):
     """Base class for plugins.
-    
+
     A Plugin is coupled to another object and is automatically garbage collected
     as soon as the other object disappears.
-    
+
     Use the instance() class method to get/create the Plugin instance for an object.
-    
+
     Implement the __init__() method if you want to do some setup.
-    
+
     The instances() class method returns all living instances of this plugin type.
-    
+
     """
     def __init__(self, obj):
         """Implement this method to setup the plugin instance."""
         pass
-    
+
     @classmethod
     def instance(cls, obj):
         """Returns the instance of this plugin type for this object.
-        
+
         The plugin instance is created if it did not exist.
-        
+
         """
         try:
             return _instances[cls][obj]
@@ -83,7 +83,7 @@ class Plugin(object):
             result._parent = weakref.ref(obj)
             result.__init__(obj)
         return result
-    
+
     @classmethod
     def instances(cls):
         """Iterates over all living instances of this plugin."""
@@ -95,25 +95,25 @@ class Plugin(object):
 
 class Attributes(object):
     """Manages attributes.
-    
+
     The attributes can be set simply as instance attributes.
-    
+
     If an attribute is set, it is stored as a weak reference when possible
     If an attribute is requested but not set or its value does not exist anymore,
     None is returned.
     Deleting an attribute does not fail if it doesn't exist.
-    
+
     """
     def __init__(self):
         self._attrs = {}
-        
+
     def __getattr__(self, name):
         val = self._attrs.get(name)
         if isinstance(val, weakref.ref):
             return val()
         else:
             return val
-    
+
     def __setattr__(self, name, value):
         if name.startswith('_'):
             object.__setattr__(self, name, value)
@@ -135,12 +135,12 @@ class AttributePlugin(Plugin, Attributes):
     """Base class for a Plugin managing attributes for any object."""
     def __init__(self, obj):
         """Implement this method to setup the plugin instance.
-        
+
         For this class (AttributePlugin) you must also call this constructor if you reimplement it.
-        
+
         """
         Attributes.__init__(self)
-    
+
 
 class DocumentPlugin(Plugin):
     """Base class for plugins that live besides a Document."""

--- a/frescobaldi_app/po/__init__.py
+++ b/frescobaldi_app/po/__init__.py
@@ -34,41 +34,41 @@ def available():
 
 def find(language):
     """Returns a .mo file for the given language.
-    
+
     Returns None if no suitable MO file can be found.
-    
+
     """
     filename = os.path.join(podir, language + ".mo")
     if os.path.exists(filename):
         return filename
     elif '_' in language:
         return find(language.split('_')[0])
-    
+
 def translator(mo):
     """Returns a function that can translate messages using the specified MoFile object.
-    
+
     The returned function can be called with one to four arguments:
-    
+
     - message
     - context, message
     - message, plural_message, count
     - context, message, plural_message, count
 
     In all cases a single string (the translation) is returned.
-    
+
     If mo is None, returns a dummy translator that returns strings untranslated.
-    
+
     """
     if not mo:
         mo = mofile.NullMoFile()
     funcs = (None, mo.gettext, mo.pgettext, mo.ngettext, mo.npgettext)
     return lambda *args: funcs[len(args)](*args)
-    
+
 def install(filename):
     """Installs the translations from the given .mo file.
-    
+
     If filename is None, installs a dummy translator.
-    
+
     """
     builtins._ = translator(mofile.MoFile(filename) if filename else None)
 

--- a/frescobaldi_app/po/md2pot.py
+++ b/frescobaldi_app/po/md2pot.py
@@ -29,7 +29,7 @@ import sys
 import textwrap
 
 import simplemarkdown
-import userguide.read 
+import userguide.read
 
 
 class Parser(userguide.read.Parser):
@@ -42,7 +42,7 @@ class Parser(userguide.read.Parser):
         w.subsequent_indent = ''
         self._output_lines = []
         self.f = output_file
-    
+
     def make_translation_strings(self, filename):
         self._curfilename = filename
         self.parse(userguide.read.document(filename)[0], lineno=1)

--- a/frescobaldi_app/po/mofile.py
+++ b/frescobaldi_app/po/mofile.py
@@ -62,13 +62,13 @@ class NullMoFile(object):
     """Empty "mo file", returning messages untranslated."""
     def gettext(self, message):
         return message
-    
+
     def ngettext(self, message, message_plural, n):
         return message if n == 1 else message_plural
-    
+
     def pgettext(self, context, message):
         return message
-    
+
     def npgettext(self, context, message, message_plural, n):
         return message if n == 1 else message_plural
 
@@ -84,7 +84,7 @@ class MoFile(NullMoFile):
         obj = cls.__new__(cls)
         obj._load(buf)
         return obj
-        
+
     @classmethod
     def fromStream(cls, stream):
         """Constructs the MoFile object, reading the messages from an open stream."""
@@ -94,7 +94,7 @@ class MoFile(NullMoFile):
         """The default constructor reads the messages from the given filename."""
         with open(filename, 'rb') as f:
             self._load(f.read())
-    
+
     def _load(self, buf):
         catalog = {}
         context_catalog = {}
@@ -133,69 +133,69 @@ class MoFile(NullMoFile):
         self._catalog = catalog
         self._context_catalog = context_catalog
         self._fallback = NullMoFile()
-        
+
     def set_fallback(self, fallback):
         """Sets a fallback class to return translations for messages not in this MO file.
-        
+
         If fallback is None, AttributeError is raised when translations are not found.
         By default, fallback is set to a NullMoFile instance that returns the message
         untranslated.
-        
+
         """
         self._fallback = fallback
-    
+
     def fallback(self):
         """Returns the fallback MoFile or NullMoFile object or None.
-        
+
         The fallback is called when a message is not found in our own catalog.
         By default, fallback is set to a NullMoFile instance that returns the message
         untranslated.
-        
+
         """
         return self._fallback
-    
+
     def info(self):
         """Returns the header (catalog description) from the MO-file as a dictionary.
-        
+
         The keys are the header names in lower case, the values unicode strings.
-        
+
         """
         return self._info
-    
+
     def gettext(self, message):
         """Returns the translation of the message."""
         try:
             return self._catalog[message]
         except KeyError:
             return self._fallback.gettext(message)
-    
+
     def ngettext(self, message, message_plural, n):
         """Returns the correct translation (singular or plural) depending on n."""
         try:
             return self._catalog[(message, self._plural(n))]
         except KeyError:
             return self._fallback.ngettext(message, message_plural, n)
-    
+
     def pgettext(self, context, message):
         """Returns the translation of the message in the given context."""
         try:
             return self._context_catalog[context][message]
         except KeyError:
             return self._fallback.pgettext(context, message)
-    
+
     def npgettext(self, context, message, message_plural, n):
         """Returns the correct translation (singular or plural) depending on n, in the given context."""
         try:
             return self._context_catalog[context][(message, self._plural(n))]
         except KeyError:
             return self._fallback.npgettext(context, message, message_plural, n)
-    
+
 
 def parse_mo(buf):
     """Parses the given buffer (a bytes instance) as a MO file.
-    
+
     Yields raw message/translation pairs, not decoded or handled in any other way.
-    
+
     """
     # are we LE or BE?
     magic = unpack('<I', buf[:4])[0]
@@ -207,9 +207,9 @@ def parse_mo(buf):
         ii = '>II'
     else:
         raise IOError(0, 'Invalid MO data')
-    
+
     buflen = len(buf)
-    
+
     # read the MO buffer and store all data
     for i in range(msgcount):
         mlen, moff = unpack(ii, buf[masteridx:masteridx+8])
@@ -221,18 +221,18 @@ def parse_mo(buf):
             tmsg = buf[toff:tend]
         else:
             raise IOError(0, 'Corrupt MO data')
-        
+
         yield msg, tmsg
-        
+
         masteridx += 8
         transidx += 8
 
 
 def parse_header(data):
     """Parses the "header" (the msgstr of the first, empty, msgid) and returns it as a dict.
-    
+
     The names are made lower-case.
-    
+
     """
     info = {}
     lastkey = key = None
@@ -252,12 +252,12 @@ def parse_header(data):
 
 def parse_mo_split(buf):
     """Parses the mo file and splits up all messages/translation pairs.
-    
+
     Yields three-element tuples: (context, messages, translations)
-    
+
     where context is None or bytes, and messages and translations are both lists
     of undecoded bytes objects.
-    
+
     """
     for msg, tmsg in parse_mo(buf):
         try:
@@ -288,13 +288,13 @@ expr_re = re.compile(r"\d+|>>|<<|[<>!=]=|&&|\|\||[-+*/%^&<>?:|!()n]")
 
 def parse_plural_expr(text):
     """Parses an expression such as the 'plural=<expression>' found in PO/MO files.
-    
+
     Returns a lambda function taking the 'n' argument and returning the plural number.
     Returns None if the expression could not be parsed.
-    
+
     """
     source = iter(expr_re.findall(text))
-    
+
     def _expr():
         result = []
         for token in source:
@@ -318,7 +318,7 @@ def parse_plural_expr(text):
                 elif token == ')':
                     return result
         return result
-    
+
     py_expression = ' '.join(_expr())
     if py_expression:
         code = "lambda n: int({0})".format(py_expression)

--- a/frescobaldi_app/po/molint.py
+++ b/frescobaldi_app/po/molint.py
@@ -18,19 +18,19 @@ _parse = string.Formatter().parse
 
 def fields(text):
     """Returns the format field names in text as a set().
-    
+
     If the text contains erroneous formatting delimiters, ValueError is raised.
-    
+
     """
     return set(i[1] for i in _parse(text) if i[1] and i[1][0].isalpha())
 
 
 def molint(filename):
     """Checks filename for superfluous fields in the translated messages.
-    
+
     Returns True if there are no errors, otherwise prints messages to stderr
     and returns False.
-    
+
     """
     correct = True
     with open(filename, 'rb') as f:
@@ -44,10 +44,10 @@ def molint(filename):
                 s |= fields(m)
             except ValueError:
                 pass
-        
+
         if not s:
             continue
-        
+
         # collect superfluous fields in translations
         errors = []
         for t in translations:
@@ -60,7 +60,7 @@ def molint(filename):
                     errors.append((t, "Field{0} {1} not in message".format(
                         's' if len(superfluous) > 1 else '',
                         ', '.join('{{{0}}}'.format(name) for name in superfluous))))
-        
+
         # write out errors if any
         if errors:
             correct = False
@@ -69,12 +69,12 @@ def molint(filename):
                 "  Message{1}:\n".format(filename, '' if len(messages) == 1 else "s"))
             for m in messages:
                 sys.stderr.write("    {0}\n".format(m))
-            
+
             sys.stderr.write("  Offending translation{0}:\n".format('' if len(errors) == 1 else "s"))
-            
+
             for t, errmsg in errors:
                 sys.stderr.write("    {0}:\n      {1}\n".format(errmsg, t))
-    
+
     return correct
 
 

--- a/frescobaldi_app/po/setup.py
+++ b/frescobaldi_app/po/setup.py
@@ -41,9 +41,9 @@ _currentlanguage = None
 
 def preferred():
     """Return a list of language codes from the operating system preferences.
-    
+
     Language- and country codes will always be separated with an underscore '_'.
-    
+
     """
     try:
         langs = QLocale().uiLanguages()
@@ -54,7 +54,7 @@ def preferred():
         # in some systems, language/country codes have '-' and not '_'
         langs = [l.replace('-', '_') for l in langs]
     if not langs:
-        try: 
+        try:
             langs.append(locale.getdefaultlocale()[0])
         except ValueError:
             pass
@@ -62,10 +62,10 @@ def preferred():
 
 def default():
     """Return the first preferred system default UI language that is available in Frescobaldi.
-    
+
     May return None, if none of the system preferred languages is available
     in Frescobaldi.
-    
+
     """
     av_langs = available()
     av_langs.append("en")
@@ -75,10 +75,10 @@ def default():
 
 def current():
     """Returns the currently active UI language code.
-    
+
     A name is always returned, which can be "C", meaning no translation
     is desired.
-    
+
     """
     return QSettings().value("language", "", str) or default() or "C"
 

--- a/frescobaldi_app/popplerdummy.py
+++ b/frescobaldi_app/popplerdummy.py
@@ -36,10 +36,10 @@ class Surface(qpopplerview.Surface):
         self.setLayout(layout)
         layout.addWidget(self._msg)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self._msg.setText(_("Could not load the {name} module.").format(
             name = '<a href="https://github.com/wbsoft/python-poppler-qt4">popplerqt5</a>'))
-    
+
     def paintEvent(self, ev):
         QWidget.paintEvent(self, ev)

--- a/frescobaldi_app/popplertools.py
+++ b/frescobaldi_app/popplertools.py
@@ -30,29 +30,29 @@ class Document(object):
         self._filename = filename
         self._document = None
         self._dirty = True
-        
+
     def filename(self):
         """Returns the filename, set on init or via setFilename()."""
         return self._filename
-    
+
     def setFilename(self, filename):
         """Sets a filename.
-        
+
         The document will be reloaded next time it is requested.
-        
+
         """
         self._filename = filename
         self._dirty = True
-            
+
     def name(self):
         """Returns the filename without path."""
         return os.path.basename(self._filename)
-        
+
     def document(self):
         """Returns the PDF document the filename points to, reloading if the filename was set.
-        
+
         Can return None, in case the document failed to load.
-        
+
         """
         if self._dirty:
             self._document = self.load()

--- a/frescobaldi_app/popplerview.py
+++ b/frescobaldi_app/popplerview.py
@@ -58,7 +58,7 @@ class View(qpopplerview.View):
         self.surface().pageLayout().setDPI(self.physicalDpiX(), self.physicalDpiY())
         app.settingsChanged.connect(self.readSettings)
         self.readSettings()
-    
+
     def readSettings(self):
         kineticScrollingActive = QSettings().value("musicview/kinetic_scrolling", True, bool)
         scrollbarsVisible = QSettings().value("musicview/show_scrollbars", True, bool)
@@ -75,7 +75,7 @@ class MagnifierSettings(object):
     """Manages settings for the MusicView Magnifier."""
     sizeRange = (200, 800)
     scaleRange = (150, 800)
-    
+
     def __init__(self, size=300, scale=300):
         self.size = size
         self.scale = scale
@@ -94,7 +94,7 @@ class MagnifierSettings(object):
             self.scale = int(s.value("scale", self.scale))
         except ValueError:
             pass
-        
+
         self.size = bound(self.size, *cls.sizeRange)
         self.scale = bound(self.scale, *cls.scaleRange)
         return self

--- a/frescobaldi_app/portmidi/__init__.py
+++ b/frescobaldi_app/portmidi/__init__.py
@@ -34,7 +34,7 @@ import portmidi
 
 # test if portmidi really loaded:
 if portmidi.available():
-    ... enable MIDI stuff 
+    ... enable MIDI stuff
 
 # start using PortMIDI: init and quit may be used multiple times
 portmidi.init()
@@ -92,9 +92,9 @@ def available():
 
 def init():
     """Initializes the PortMIDI library for use.
-    
+
     It is safe to call this more than once.
-    
+
     """
     global _initialized
     if _setup() and not _initialized:
@@ -103,10 +103,10 @@ def init():
 
 def quit():
     """Terminates the PortMIDI library.
-    
+
     It is safe to call this more than once.
     On application exit this is also called.
-    
+
     """
     global _initialized
     if pypm and _initialized:
@@ -130,10 +130,10 @@ def get_default_output_id():
 
 def get_device_info(device_id):
     """Returns information about a midi device.
-    
+
     A five-tuple is returned:
     (interf, name, isinput, isoutput, isopen).
-    
+
     """
     _check_initialized()
     return device_info(*pypm.GetDeviceInfo(device_id))
@@ -152,7 +152,7 @@ class Input(object):
         info = get_device_info(device_id)
         if not info.isinput:
             raise MidiException("not an input device")
-        
+
         self._input = pypm.Input(device_id, buffer_size)
 
     def close(self):
@@ -185,7 +185,7 @@ class Output(object):
         info = get_device_info(device_id)
         if not info.isoutput:
             raise MidiException("not an output device")
-        
+
         self._output = pypm.Output(device_id, latency)
 
     def close(self):
@@ -196,10 +196,10 @@ class Output(object):
 
     def write(self, data):
         """Writes a list of MIDI data to the output.
-        
+
         Each element of the list should be a list[message, timestamp].
         Each message is again a list: [status, data, data, ...]
-        
+
         """
         self._output.Write(data)
 
@@ -209,9 +209,9 @@ class Output(object):
 
     def write_sys_ex(self, timestamp, message):
         """Writes a timestamped System-Exclusive MIDI message.
-        
+
         The message may be a list of integers or a bytes string.
-        
+
         """
         self._output.WriteSysEx(timestamp, message)
 
@@ -258,10 +258,10 @@ def _check_initialized():
 
 def _setup():
     """Tries to import PortMIDI in the order given in the try_order global.
-    
+
     Only one time the import is tried.
     Returns True if PortMIDI could be loaded.
-    
+
     """
     global pypm
     if pypm is None:
@@ -277,10 +277,10 @@ def _setup():
 
 def _load_module(name):
     """Loads and returns a single module.
-    
+
     The name may be dotted, but no parent modules are imported.
     Raises ImportError when the module can't be found.
-    
+
     """
     import imp
     path = None
@@ -292,9 +292,9 @@ def _load_module(name):
 # these functions try to import PortMIDI, returning the module
 def _do_import_pypm():
     """Tries to import pypm (the c binding module) directly.
-    
+
     Newer Ubuntu releases provide a python-pypm package with this module.
-    
+
     """
     import pypm
     # Reject incompatible API, such as ActiveState PyPM
@@ -305,9 +305,9 @@ def _do_import_pypm():
 
 def _do_import_pyportmidi():
     """This tries to import the c Python module from the PortMIDI distribution.
-    
+
     Unfortunately not many Linux distros also install the Python binding.
-    
+
     """
     return _load_module('pyportmidi._pyportmidi')
 

--- a/frescobaldi_app/portmidi/ctypes_pypm.py
+++ b/frescobaldi_app/portmidi/ctypes_pypm.py
@@ -1,5 +1,5 @@
 # This module provides the same api via ctypes as John Harrison's pyrex-based
-# PortMIDI binding. 
+# PortMIDI binding.
 # Don't use this module directly but via the toplevel API of this package.
 # Copyright (c) 2011 - 2014 by Wilbert Berendsen, placed in the public domain.
 
@@ -88,7 +88,7 @@ class Output(object):
             err = libpm.Pm_Close(self._midi_stream)
             _check_error(err)
             self._open = False
-    
+
     __del__ = Close
 
     def Write(self, data):
@@ -150,7 +150,7 @@ class Input(object):
             err = libpm.Pm_Close(self._midi_stream)
             _check_error(err)
             self._open = False
-        
+
     __del__ = Close
 
     def Poll(self):

--- a/frescobaldi_app/preferences/__init__.py
+++ b/frescobaldi_app/preferences/__init__.py
@@ -52,7 +52,7 @@ def pageorder():
 
 
 class PreferencesDialog(QDialog):
-    
+
     def __init__(self, mainwindow):
         super(PreferencesDialog, self).__init__(mainwindow)
         self.setWindowModality(Qt.WindowModal)
@@ -61,18 +61,18 @@ class PreferencesDialog(QDialog):
         layout = QVBoxLayout()
         layout.setSpacing(10)
         self.setLayout(layout)
-        
+
         # listview to the left, stacked widget to the right
         top = QHBoxLayout()
         layout.addLayout(top)
-        
+
         self.pagelist = QListWidget(self)
         self.stack = QStackedWidget(self)
         top.addWidget(self.pagelist, 0)
         top.addWidget(self.stack, 2)
-        
+
         layout.addWidget(widgets.Separator(self))
-        
+
         b = self.buttons = QDialogButtonBox(self)
         b.setStandardButtons(
             QDialogButtonBox.Ok
@@ -88,23 +88,23 @@ class PreferencesDialog(QDialog):
         b.button(QDialogButtonBox.Help).clicked.connect(self.showHelp)
         b.button(QDialogButtonBox.Help).setShortcut(QKeySequence.HelpContents)
         b.button(QDialogButtonBox.Apply).setEnabled(False)
-        
+
         # fill the pagelist
         self.pagelist.setIconSize(QSize(32, 32))
         self.pagelist.setSpacing(2)
         for item in pageorder():
             self.pagelist.addItem(item())
         self.pagelist.currentItemChanged.connect(self.slotCurrentItemChanged)
-        
+
         app.translateUI(self, 100)
         # read our size and selected page
         qutil.saveDialogSize(self, "preferences/dialog/size", QSize(500, 300))
         self.pagelist.setCurrentRow(_prefsindex)
-        
+
     def translateUI(self):
         self.pagelist.setFixedWidth(self.pagelist.sizeHintForColumn(0) + 12)
         self.setWindowTitle(app.caption(_("Preferences")))
-    
+
     def done(self, result):
         if result and self.buttons.button(QDialogButtonBox.Apply).isEnabled():
             self.saveSettings()
@@ -112,22 +112,22 @@ class PreferencesDialog(QDialog):
         global _prefsindex
         _prefsindex = self.pagelist.currentRow()
         super(PreferencesDialog, self).done(result)
-    
+
     def pages(self):
         """Yields the settings pages that are already instantiated."""
         for n in range(self.stack.count()):
             yield self.stack.widget(n)
-    
+
     def showHelp(self):
         userguide.show(self.pagelist.currentItem().help)
-        
+
     def loadSettings(self):
         """Loads the settings on reset."""
         for page in self.pages():
             page.loadSettings()
             page.hasChanges = False
         self.buttons.button(QDialogButtonBox.Apply).setEnabled(False)
-            
+
     def saveSettings(self):
         """Saves the settings and applies them."""
         for page in self.pages():
@@ -135,13 +135,13 @@ class PreferencesDialog(QDialog):
                 page.saveSettings()
                 page.hasChanges = False
         self.buttons.button(QDialogButtonBox.Apply).setEnabled(False)
-        
+
         # emit the signal
         app.settingsChanged()
-    
+
     def slotCurrentItemChanged(self, item):
         item.activate()
-        
+
     def changed(self):
         """Call this to enable the Apply button."""
         self.buttons.button(QDialogButtonBox.Apply).setEnabled(True)
@@ -154,7 +154,7 @@ class PrefsItemBase(QListWidgetItem):
         self._widget = None
         self.setIcon(icons.get(self.iconName))
         app.translateUI(self)
-    
+
     def activate(self):
         dlg = self.listWidget().parentWidget()
         if self._widget is None:
@@ -175,14 +175,14 @@ class General(PrefsItemBase):
     def widget(self, dlg):
         from . import general
         return general.GeneralPrefs(dlg)
-        
+
 
 class LilyPond(PrefsItemBase):
     help = "prefs_lilypond"
     iconName = "lilypond-run"
     def translateUI(self):
         self.setText(_("LilyPond Preferences"))
-        
+
     def widget(self, dlg):
         from . import lilypond
         return lilypond.LilyPondPrefs(dlg)
@@ -193,7 +193,7 @@ class Midi(PrefsItemBase):
     iconName = "audio-volume-medium"
     def translateUI(self):
         self.setText(_("MIDI Settings"))
-    
+
     def widget(self, dlg):
         from . import midi
         return midi.MidiPrefs(dlg)
@@ -204,7 +204,7 @@ class Helpers(PrefsItemBase):
     iconName = "applications-other"
     def translateUI(self):
         self.setText(_("Helper Applications"))
-        
+
     def widget(self, dlg):
         from . import helpers
         return helpers.Helpers(dlg)
@@ -215,18 +215,18 @@ class Paths(PrefsItemBase):
     iconName = "folder-open"
     def translateUI(self):
         self.setText(_("Paths"))
-        
+
     def widget(self, dlg):
         from . import paths
         return paths.Paths(dlg)
 
 
 class Documentation(PrefsItemBase):
-    help = "prefs_lilydoc"    
+    help = "prefs_lilydoc"
     iconName = "help-contents"
     def translateUI(self):
         self.setText(_("LilyPond Documentation"))
-        
+
     def widget(self, dlg):
         from . import documentation
         return documentation.Documentation(dlg)
@@ -237,18 +237,18 @@ class Shortcuts(PrefsItemBase):
     iconName = "preferences-desktop-keyboard-shortcuts"
     def translateUI(self):
         self.setText(_("Keyboard Shortcuts"))
-        
+
     def widget(self, dlg):
         from . import shortcuts
         return shortcuts.Shortcuts(dlg)
-        
+
 
 class Editor(PrefsItemBase):
     help = "prefs_editor"
     iconName = "document-properties"
     def translateUI(self):
         self.setText(_("Editor Preferences"))
-        
+
     def widget(self, dlg):
         from . import editor
         return editor.Editor(dlg)
@@ -259,7 +259,7 @@ class FontsColors(PrefsItemBase):
     iconName = "applications-graphics"
     def translateUI(self):
         self.setText(_("Fonts & Colors"))
-        
+
     def widget(self, dlg):
         from . import fontscolors
         return fontscolors.FontsColors(dlg)
@@ -270,7 +270,7 @@ class Tools(PrefsItemBase):
     iconName = "preferences-other"
     def translateUI(self):
         self.setText(_("Tools"))
-        
+
     def widget(self, dlg):
         from . import tools
         return tools.Tools(dlg)
@@ -280,24 +280,24 @@ class Page(QWidget):
     """Base class for settings pages."""
     changed = pyqtSignal()
     hasChanges = False
-    
+
     def markChanged(self):
         """Called when something changes in the dialog."""
         self.hasChanges = True
-    
+
     def loadSettings(self):
         """Should load settings from config into our widget."""
-        
+
     def saveSettings(self):
         """Should write settings from our widget to config."""
 
-    
+
 class ScrolledPage(Page):
     """Base class for settings pages that are scrollable.
-    
+
     Te scrolledWidget attribute has the widget the other components
     can be added to.
-    
+
     """
     def __init__(self, dialog):
         super(ScrolledPage, self).__init__(dialog)
@@ -309,25 +309,25 @@ class ScrolledPage(Page):
         scrollarea.setWidget(self.scrolledWidget)
         scrollarea.setWidgetResizable(True)
 
-    
+
 class GroupsPage(Page):
     """Base class for a Page with SettingsGroups.
-    
+
     The load and save methods of the SettingsGroup groups are automatically called.
-    
+
     """
     def __init__(self, dialog):
         super(GroupsPage, self).__init__(dialog)
         self.groups = []
-        
+
     def loadSettings(self):
         for group in self.groups:
             group.loadSettings()
-            
+
     def saveSettings(self):
         for group in self.groups:
             group.saveSettings()
-            
+
 
 class ScrolledGroupsPage(GroupsPage, ScrolledPage):
     def __init__(self, dialog):
@@ -338,15 +338,15 @@ class ScrolledGroupsPage(GroupsPage, ScrolledPage):
 class Group(QGroupBox):
     """This is a QGroupBox that auto-adds itself to a Page."""
     changed = pyqtSignal()
-    
+
     def __init__(self, page):
         super(Group, self).__init__()
         page.groups.append(self)
         self.changed.connect(page.changed)
-        
+
     def loadSettings(self):
         """Should load settings from config into our widget."""
-        
+
     def saveSettings(self):
         """Should write settings from our widget to config."""
 

--- a/frescobaldi_app/preferences/documentation.py
+++ b/frescobaldi_app/preferences/documentation.py
@@ -44,7 +44,7 @@ class Documentation(preferences.GroupsPage):
 
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         layout.addWidget(Paths(self))
         layout.addWidget(Browser(self))
         layout.addStretch(1)
@@ -53,26 +53,26 @@ class Documentation(preferences.GroupsPage):
 class Paths(preferences.Group):
     def __init__(self, page):
         super(Paths, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.paths = LilyDocPathsList()
         self.paths.changed.connect(self.changed)
         layout.addWidget(self.paths)
-        
+
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_("Paths to LilyPond Documentation"))
         self.paths.setToolTip(_(
             "Add paths or URLs. See \"What's This\" for more information."))
         self.paths.setWhatsThis(userguide.html("prefs_lilydoc"))
-    
+
     def loadSettings(self):
         paths = qsettings.get_string_list(QSettings(), "documentation/paths")
         self.paths.setValue(paths)
-        
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup("documentation")
@@ -86,38 +86,38 @@ class Paths(preferences.Group):
 class Browser(preferences.Group):
     def __init__(self, page):
         super(Browser, self).__init__(page)
-        
+
         layout = QGridLayout()
         self.setLayout(layout)
-        
+
         self.languagesLabel = QLabel()
         self.languages = QComboBox(currentIndexChanged=self.changed)
         layout.addWidget(self.languagesLabel, 0, 0)
         layout.addWidget(self.languages, 0, 1)
-        
+
         items = ['', '']
         items.extend(language_names.languageName(l, l) for l in lilydoc.translations)
         self.languages.addItems(items)
-        
+
         self.fontLabel = QLabel()
         self.fontChooser = QFontComboBox(currentFontChanged=self.changed)
         self.fontSize = QSpinBox(valueChanged=self.changed)
         self.fontSize.setRange(6, 32)
         self.fontSize.setSingleStep(1)
-        
+
         layout.addWidget(self.fontLabel, 1, 0)
         layout.addWidget(self.fontChooser, 1, 1)
         layout.addWidget(self.fontSize, 1, 2)
-        
+
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_("Documentation Browser"))
         self.languagesLabel.setText(_("Preferred Language:"))
         self.languages.setItemText(0, _("Default"))
         self.languages.setItemText(1, _("English (untranslated)"))
         self.fontLabel.setText(_("Font:"))
-        
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("documentation")
@@ -129,7 +129,7 @@ class Browser(preferences.Group):
         else:
             i = 0
         self.languages.setCurrentIndex(i)
-        
+
         font = self.font()
         family = s.value("fontfamily", "", str)
         if family:
@@ -150,7 +150,7 @@ class Browser(preferences.Group):
 
 class LilyDocPathsList(widgets.listedit.ListEdit):
     def openEditor(self, item):
-        
+
         dlg = widgets.dialog.Dialog(self,
             _("Please enter a local path or a URL:"),
             app.caption("LilyPond Documentation"),

--- a/frescobaldi_app/preferences/editor.py
+++ b/frescobaldi_app/preferences/editor.py
@@ -228,7 +228,7 @@ class Indenting(preferences.Group):
 class KeyBoard(preferences.Group):
     def __init__(self, page):
         super(KeyBoard, self).__init__(page)
-        
+
         layout = QGridLayout(spacing=1)
         self.setLayout(layout)
 

--- a/frescobaldi_app/preferences/fontscolors.py
+++ b/frescobaldi_app/preferences/fontscolors.py
@@ -49,13 +49,13 @@ class FontsColors(preferences.Page):
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-        
+
         self.scheme = SchemeSelector(self)
         layout.addWidget(self.scheme)
-        
+
         self.printScheme = QCheckBox()
         layout.addWidget(self.printScheme)
-        
+
         hbox = QHBoxLayout()
         self.tree = QTreeWidget(self)
         self.tree.setHeaderHidden(True)
@@ -64,7 +64,7 @@ class FontsColors(preferences.Page):
         hbox.addWidget(self.tree)
         hbox.addWidget(self.stack)
         layout.addLayout(hbox)
-        
+
         hbox = QHBoxLayout()
         self.fontLabel = QLabel()
         self.fontChooser = QFontComboBox()
@@ -76,20 +76,20 @@ class FontsColors(preferences.Page):
         hbox.addWidget(self.fontChooser, 1)
         hbox.addWidget(self.fontSize)
         layout.addLayout(hbox)
-        
+
         # add the items to our list
         self.baseColorsItem = i = QTreeWidgetItem()
         self.tree.addTopLevelItem(i)
         self.defaultStylesItem = i = QTreeWidgetItem()
         self.tree.addTopLevelItem(i)
-        
+
         self.defaultStyles = {}
         for name in textformats.defaultStyles:
             self.defaultStyles[name] = i = QTreeWidgetItem()
             self.defaultStylesItem.addChild(i)
             i.name = name
         self.defaultStylesItem.setExpanded(True)
-        
+
         self.allStyles = {}
         for group, styles in ly.colorize.default_mapping():
             i = QTreeWidgetItem()
@@ -103,14 +103,14 @@ class FontsColors(preferences.Page):
                 j.base = base
                 i.addChild(j)
                 children[name] = j
-        
+
         self.baseColorsWidget = BaseColors(self)
         self.customAttributesWidget = CustomAttributes(self)
         self.emptyWidget = QWidget(self)
         self.stack.addWidget(self.baseColorsWidget)
         self.stack.addWidget(self.customAttributesWidget)
         self.stack.addWidget(self.emptyWidget)
-        
+
         self.tree.currentItemChanged.connect(self.currentItemChanged)
         self.tree.setCurrentItem(self.baseColorsItem)
         self.scheme.currentChanged.connect(self.currentSchemeChanged)
@@ -120,18 +120,18 @@ class FontsColors(preferences.Page):
         self.fontChooser.currentFontChanged.connect(self.fontChanged)
         self.fontSize.valueChanged.connect(self.fontChanged)
         self.printScheme.clicked.connect(self.printSchemeChanged)
-        
+
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.printScheme.setText(_("Use this scheme for printing"))
         self.fontLabel.setText(_("Font:"))
         self.baseColorsItem.setText(0, _("Base Colors"))
         self.defaultStylesItem.setText(0, _("Default Styles"))
-        
+
         self.defaultStyleNames = defaultStyleNames()
         self.allStyleNames = allStyleNames()
-        
+
         for name in textformats.defaultStyles:
             self.defaultStyles[name].setText(0, self.defaultStyleNames[name])
         for group, styles in ly.colorize.default_mapping():
@@ -146,7 +146,7 @@ class FontsColors(preferences.Page):
                 except KeyError:
                     n = name
                 self.allStyles[group][1][name].setText(0, n)
-            
+
     def currentItemChanged(self, item, previous):
         if item is self.baseColorsItem:
             self.stack.setCurrentWidget(self.baseColorsWidget)
@@ -172,7 +172,7 @@ class FontsColors(preferences.Page):
                 w.setTristate(bool(inherit))
                 w.setTextFormat(data.allStyles[group][name])
             w.setTopText(toptext)
-    
+
     def currentSchemeChanged(self):
         scheme = self.scheme.currentScheme()
         if scheme not in self.data:
@@ -182,39 +182,39 @@ class FontsColors(preferences.Page):
             self.currentItemChanged(self.tree.currentItem(), None)
         with qutil.signalsBlocked(self.printScheme):
             self.printScheme.setChecked(scheme == self._printScheme)
-    
+
     def fontChanged(self):
         data = self.data[self.scheme.currentScheme()]
         data.font = self.fontChooser.currentFont()
         data.font.setPointSizeF(self.fontSize.value())
         self.updateDisplay()
         self.changed.emit()
-    
+
     def printSchemeChanged(self):
         if self.printScheme.isChecked():
             self._printScheme = self.scheme.currentScheme()
         else:
             self._printScheme = None
         self.changed.emit()
-    
+
     def addSchemeData(self, scheme, tfd):
         self.data[scheme] = tfd
-        
+
     def currentSchemeData(self):
         return self.data[self.scheme.currentScheme()]
-        
+
     def updateDisplay(self):
         data = self.data[self.scheme.currentScheme()]
-        
+
         with qutil.signalsBlocked(self.fontChooser, self.fontSize):
             self.fontChooser.setCurrentFont(data.font)
             self.fontSize.setValue(data.font.pointSizeF())
-        
+
         with qutil.signalsBlocked(self):
             # update base colors
             for name in textformats.baseColors:
                 self.baseColorsWidget.color[name].setColor(data.baseColors[name])
-        
+
         # update base colors for whole treewidget
         p = QApplication.palette()
         p.setColor(QPalette.Base, data.baseColors['background'])
@@ -222,7 +222,7 @@ class FontsColors(preferences.Page):
         p.setColor(QPalette.Highlight, data.baseColors['selectionbackground'])
         p.setColor(QPalette.HighlightedText, data.baseColors['selectiontext'])
         self.tree.setPalette(p)
-        
+
         def setItemTextFormat(item, f):
             font = QFont(data.font)
             if f.hasProperty(QTextFormat.ForegroundBrush):
@@ -237,11 +237,11 @@ class FontsColors(preferences.Page):
             font.setItalic(f.fontItalic())
             font.setUnderline(f.fontUnderline())
             item.setFont(0, font)
-            
+
         # update looks of default styles
         for name in textformats.defaultStyles:
             setItemTextFormat(self.defaultStyles[name], data.defaultStyles[name])
-        
+
         # update looks of all the specific styles
         for group, styles in ly.colorize.default_mapping():
             children = self.allStyles[group][1]
@@ -249,14 +249,14 @@ class FontsColors(preferences.Page):
                 f = QTextCharFormat(data.defaultStyles[inherit]) if inherit else QTextCharFormat()
                 f.merge(data.allStyles[group][name])
                 setItemTextFormat(children[name], f)
-        
+
     def baseColorsChanged(self, name):
         # keep data up to date with base colors
         data = self.data[self.scheme.currentScheme()]
         data.baseColors[name] = self.baseColorsWidget.color[name].color()
         self.updateDisplay()
         self.changed.emit()
-    
+
     def customAttributesChanged(self):
         item = self.tree.currentItem()
         if not item or not item.parent():
@@ -271,11 +271,11 @@ class FontsColors(preferences.Page):
             data.allStyles[group][name] = self.customAttributesWidget.textFormat()
         self.updateDisplay()
         self.changed.emit()
-        
+
     def import_(self, filename):
         from . import import_export
         import_export.importTheme(filename, self, self.scheme)
-        
+
     def export(self, name, filename):
         from . import import_export
         try:
@@ -284,12 +284,12 @@ class FontsColors(preferences.Page):
             QMessageBox.critical(self, _("Error"), _(
                 "Can't write to destination:\n\n{url}\n\n{error}").format(
                 url=filename, error=e.strerror))
-    
+
     def loadSettings(self):
         self.data = {} # holds all data with scheme as key
         self._printScheme = QSettings().value("printer_scheme", "default", str)
         self.scheme.loadSettings("editor_scheme", "editor_schemes")
-        
+
     def saveSettings(self):
         self.scheme.saveSettings("editor_scheme", "editor_schemes", "fontscolors")
         for scheme in self.scheme.schemes():
@@ -302,16 +302,16 @@ class FontsColors(preferences.Page):
 
 
 class BaseColors(QGroupBox):
-    
+
     changed = pyqtSignal(str)
-    
+
     def __init__(self, parent=None):
         super(BaseColors, self).__init__(parent)
-        
+
         grid = QGridLayout()
         grid.setSpacing(1)
         self.setLayout(grid)
-        
+
         self.color = {}
         self.labels = {}
         for name in textformats.baseColors:
@@ -322,31 +322,31 @@ class BaseColors(QGroupBox):
             row = grid.rowCount()
             grid.addWidget(l, row, 0)
             grid.addWidget(c, row, 1)
-        
+
         grid.setRowStretch(grid.rowCount(), 2)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Base Colors"))
         names = baseColorNames()
         for name in textformats.baseColors:
             self.labels[name].setText(names[name])
-        
+
 
 class CustomAttributes(QGroupBox):
-    
+
     changed = pyqtSignal()
-    
+
     def __init__(self, parent=None):
         super(CustomAttributes, self).__init__(parent)
         grid = QGridLayout()
         self.setLayout(grid)
-        
+
         self.toplabel = QLabel()
         self.toplabel.setEnabled(False)
         self.toplabel.setAlignment(Qt.AlignCenter)
         grid.addWidget(self.toplabel, 0, 0, 1, 3)
-        
+
         self.textColor = ColorButton()
         l = self.textLabel = QLabel()
         l.setBuddy(self.textColor)
@@ -355,7 +355,7 @@ class CustomAttributes(QGroupBox):
         c = ClearButton(iconSize=QSize(16, 16))
         c.clicked.connect(self.textColor.clear)
         grid.addWidget(c, 1, 2)
-        
+
         self.backgroundColor = ColorButton()
         l = self.backgroundLabel = QLabel()
         l.setBuddy(self.backgroundColor)
@@ -364,46 +364,46 @@ class CustomAttributes(QGroupBox):
         c = ClearButton(iconSize=QSize(16, 16))
         c.clicked.connect(self.backgroundColor.clear)
         grid.addWidget(c, 2, 2)
-        
+
         self.bold = QCheckBox()
         self.italic = QCheckBox()
         self.underline = QCheckBox()
         grid.addWidget(self.bold, 3, 0)
         grid.addWidget(self.italic, 4, 0)
         grid.addWidget(self.underline, 5, 0)
-        
+
         self.underlineColor = ColorButton()
         grid.addWidget(self.underlineColor, 5, 1)
         c = ClearButton(iconSize=QSize(16, 16))
         c.clicked.connect(self.underlineColor.clear)
         grid.addWidget(c, 5, 2)
         grid.setRowStretch(6, 2)
-        
+
         self.textColor.colorChanged.connect(self.changed)
         self.backgroundColor.colorChanged.connect(self.changed)
         self.underlineColor.colorChanged.connect(self.changed)
         self.bold.stateChanged.connect(self.changed)
         self.italic.stateChanged.connect(self.changed)
         self.underline.stateChanged.connect(self.changed)
-        
+
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.textLabel.setText(_("Text"))
         self.backgroundLabel.setText(_("Background"))
         self.bold.setText(_("Bold"))
         self.italic.setText(_("Italic"))
         self.underline.setText(_("Underline"))
-    
+
     def setTopText(self, text):
         self.toplabel.setText(text)
-        
+
     def setTristate(self, enable):
         self._tristate = enable
         self.bold.setTristate(enable)
         self.italic.setTristate(enable)
         self.underline.setTristate(enable)
-    
+
     def textFormat(self):
         """Returns our settings as a QTextCharFormat object."""
         f = QTextCharFormat()
@@ -444,7 +444,7 @@ class CustomAttributes(QGroupBox):
             self.underline.setChecked(f.fontUnderline())
         else:
             self.underline.setCheckState(absent)
-        
+
         if f.hasProperty(QTextFormat.ForegroundBrush):
             self.textColor.setColor(f.foreground().color())
         else:

--- a/frescobaldi_app/preferences/general.py
+++ b/frescobaldi_app/preferences/general.py
@@ -45,7 +45,7 @@ class GeneralPrefs(preferences.ScrolledGroupsPage):
 
         layout = QVBoxLayout()
         self.scrolledWidget.setLayout(layout)
-        
+
         layout.addWidget(General(self))
         layout.addWidget(SavingDocument(self))
         layout.addWidget(NewDocument(self))
@@ -56,20 +56,20 @@ class GeneralPrefs(preferences.ScrolledGroupsPage):
 class General(preferences.Group):
     def __init__(self, page):
         super(General, self).__init__(page)
-        
+
         grid = QGridLayout()
         self.setLayout(grid)
-        
+
         self.langLabel = QLabel()
         self.lang = QComboBox(currentIndexChanged=self.changed)
         grid.addWidget(self.langLabel, 0, 0)
         grid.addWidget(self.lang, 0, 1)
-        
+
         self.styleLabel = QLabel()
         self.styleCombo = QComboBox(currentIndexChanged=self.changed)
         grid.addWidget(self.styleLabel, 1, 0)
         grid.addWidget(self.styleCombo, 1, 1)
-        
+
         self.systemIcons = QCheckBox(toggled=self.changed)
         grid.addWidget(self.systemIcons, 2, 0, 1, 3)
         self.tabsClosable = QCheckBox(toggled=self.changed)
@@ -78,9 +78,9 @@ class General(preferences.Group):
         grid.addWidget(self.splashScreen, 4, 0, 1, 3)
         self.allowRemote = QCheckBox(toggled=self.changed)
         grid.addWidget(self.allowRemote, 5, 0, 1, 3)
-        
+
         grid.setColumnStretch(2, 1)
-        
+
         # fill in the language combo
         self._langs = ["C", ""]
         self.lang.addItems(('', ''))
@@ -89,13 +89,13 @@ class General(preferences.Group):
         for name, lang in langnames:
             self._langs.append(lang)
             self.lang.addItem(name)
-        
+
         # fill in style combo
         self.styleCombo.addItem('')
         self.styleCombo.addItems(QStyleFactory.keys())
-        
+
         app.translateUI(self)
-    
+
     def loadSettings(self):
         s = QSettings()
         lang = s.value("language", "", str)
@@ -115,7 +115,7 @@ class General(preferences.Group):
         self.tabsClosable.setChecked(s.value("tabs_closable", True, bool))
         self.splashScreen.setChecked(s.value("splash_screen", True, bool))
         self.allowRemote.setChecked(remote.enabled())
-    
+
     def saveSettings(self):
         s = QSettings()
         s.setValue("language", self._langs[self.lang.currentIndex()])
@@ -127,7 +127,7 @@ class General(preferences.Group):
             s.remove("guistyle")
         else:
             s.setValue("guistyle", self.styleCombo.currentText())
-        
+
     def translateUI(self):
         self.setTitle(_("General Preferences"))
         self.langLabel.setText(_("Language:"))
@@ -151,32 +151,32 @@ class General(preferences.Group):
 class StartSession(preferences.Group):
     def __init__(self, page):
         super(StartSession, self).__init__(page)
-        
+
         grid = QGridLayout()
         self.setLayout(grid)
-        
+
         def changed():
             self.changed.emit()
             self.combo.setEnabled(self.custom.isChecked())
-        
+
         self.none = QRadioButton(toggled=changed)
         self.lastused = QRadioButton(toggled=changed)
         self.custom = QRadioButton(toggled=changed)
         self.combo = QComboBox(currentIndexChanged=changed)
-        
+
         grid.addWidget(self.none, 0, 0, 1, 2)
         grid.addWidget(self.lastused, 1, 0, 1, 2)
         grid.addWidget(self.custom, 2, 0, 1, 1)
         grid.addWidget(self.combo, 2, 1, 1, 1)
 
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Session to load if Frescobaldi is started without arguments"))
         self.none.setText(_("Start with no session"))
         self.lastused.setText(_("Start with last used session"))
         self.custom.setText(_("Start with session:"))
-        
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("session")
@@ -210,24 +210,24 @@ class StartSession(preferences.Group):
 class SavingDocument(preferences.Group):
     def __init__(self, page):
         super(SavingDocument, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
 
         def customchanged():
             self.changed.emit()
             self.filenameTemplate.setEnabled(self.customFilename.isChecked())
-        
+
         self.stripwsp = QCheckBox(toggled=self.changed)
         self.backup = QCheckBox(toggled=self.changed)
         self.metainfo = QCheckBox(toggled=self.changed)
         layout.addWidget(self.stripwsp)
         layout.addWidget(self.backup)
         layout.addWidget(self.metainfo)
-        
+
         hbox = QHBoxLayout()
         layout.addLayout(hbox)
-        
+
         self.basedirLabel = l = QLabel()
         self.basedir = UrlRequester()
         hbox.addWidget(self.basedirLabel)
@@ -242,7 +242,7 @@ class SavingDocument(preferences.Group):
         filenameBox.addWidget(self.customFilename)
         filenameBox.addWidget(self.filenameTemplate)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("When saving documents"))
         self.stripwsp.setText(_("Strip trailing whitespace"))
@@ -261,7 +261,7 @@ class SavingDocument(preferences.Group):
         self.customFilename.setToolTip(_(
             "If checked, Frescobaldi will use the template to generate default file name.\n"
             "{title} and {composer} will be replaced by title and composer of that document"))
-        
+
     def loadSettings(self):
         s = QSettings()
         self.stripwsp.setChecked(s.value("strip_trailing_whitespace", False, bool))
@@ -271,7 +271,7 @@ class SavingDocument(preferences.Group):
         self.customFilename.setChecked(s.value("custom_default_filename", False, bool))
         self.filenameTemplate.setText(s.value("default_filename_template", "{composer}-{title}", str))
         self.filenameTemplate.setEnabled(self.customFilename.isChecked())
-        
+
     def saveSettings(self):
         s = QSettings()
         s.setValue("strip_trailing_whitespace", self.stripwsp.isChecked())
@@ -285,26 +285,26 @@ class SavingDocument(preferences.Group):
 class NewDocument(preferences.Group):
     def __init__(self, page):
         super(NewDocument, self).__init__(page)
-        
+
         grid = QGridLayout()
         self.setLayout(grid)
-        
+
         def changed():
             self.changed.emit()
             self.combo.setEnabled(self.template.isChecked())
-        
+
         self.emptyDocument = QRadioButton(toggled=changed)
         self.lilyVersion = QRadioButton(toggled=changed)
         self.template = QRadioButton(toggled=changed)
         self.combo = QComboBox(currentIndexChanged=changed)
-        
+
         grid.addWidget(self.emptyDocument, 0, 0, 1, 2)
         grid.addWidget(self.lilyVersion, 1, 0, 1, 2)
         grid.addWidget(self.template, 2, 0, 1, 1)
         grid.addWidget(self.combo, 2, 1, 1, 1)
         self.loadCombo()
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("When creating new documents"))
         self.emptyDocument.setText(_("Create an empty document"))
@@ -313,14 +313,14 @@ class NewDocument(preferences.Group):
         from snippet import snippets
         for i, name in enumerate(self._names):
             self.combo.setItemText(i, snippets.title(name))
-    
+
     def loadCombo(self):
         from snippet import snippets
         self._names = [name for name in snippets.names()
                         if snippets.get(name).variables.get('template')]
         self.combo.clear()
         self.combo.addItems([''] * len(self._names))
-        
+
     def loadSettings(self):
         s = QSettings()
         ndoc = s.value("new_document", "empty", str)
@@ -348,25 +348,25 @@ class NewDocument(preferences.Group):
 class ExperimentalFeatures(preferences.Group):
     def __init__(self, page):
         super(ExperimentalFeatures, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.experimentalFeatures = QCheckBox(toggled=self.changed)
         layout.addWidget(self.experimentalFeatures)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Experimental Features"))
         self.experimentalFeatures.setText(_("Enable Experimental Features"))
         self.experimentalFeatures.setToolTip('<qt>' + _(
             "If checked, features that are not yet finished are enabled.\n"
             "You need to restart Frescobaldi to see the changes."))
-    
+
     def loadSettings(self):
         s = QSettings()
         self.experimentalFeatures.setChecked(s.value("experimental-features", False, bool))
-        
+
     def saveSettings(self):
         s = QSettings()
         s.setValue("experimental-features", self.experimentalFeatures.isChecked())

--- a/frescobaldi_app/preferences/helpers.py
+++ b/frescobaldi_app/preferences/helpers.py
@@ -38,10 +38,10 @@ import widgets.urlrequester
 class Helpers(preferences.ScrolledGroupsPage):
     def __init__(self, dialog):
         super(Helpers, self).__init__(dialog)
-        
+
         layout = QVBoxLayout()
         self.scrolledWidget.setLayout(layout)
-        
+
         layout.addWidget(Apps(self))
         layout.addWidget(Printing(self))
 
@@ -49,10 +49,10 @@ class Helpers(preferences.ScrolledGroupsPage):
 class Apps(preferences.Group):
     def __init__(self, page):
         super(Apps, self).__init__(page)
-        
+
         layout = QGridLayout(spacing=1)
         self.setLayout(layout)
-        
+
         self.messageLabel = QLabel(wordWrap=True)
         layout.addWidget(self.messageLabel, 0, 0, 1, 2)
         self.labels = {}
@@ -64,9 +64,9 @@ class Apps(preferences.Group):
             e.changed.connect(page.changed)
             layout.addWidget(l, row, 0)
             layout.addWidget(e, row, 1)
-            
+
         app.translateUI(self)
-    
+
     def items(self):
         """Yields (name, title) tuples for every setting in this group."""
         yield "pdf", _("PDF:")
@@ -78,7 +78,7 @@ class Apps(preferences.Group):
         yield "directory", _("File Manager:")
         yield "shell", _("Shell:")
         yield "git", _("Git:")
-        
+
     def translateUI(self):
         self.setTitle(_("Helper Applications"))
         self.messageLabel.setText(_(
@@ -95,13 +95,13 @@ class Apps(preferences.Group):
             "Command to open a Terminal or Command window."))
         self.entries["git"].setToolTip(_(
             "Command (base) to run Git versioning actions."))
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("helper_applications")
         for name, title in self.items():
             self.entries[name].setPath(s.value(name, "", str))
-    
+
     def saveSettings(self):
         s= QSettings()
         s.beginGroup("helper_applications")
@@ -112,10 +112,10 @@ class Apps(preferences.Group):
 class Printing(preferences.Group):
     def __init__(self, page):
         super(Printing, self).__init__(page)
-        
+
         layout = QGridLayout(spacing=1)
         self.setLayout(layout)
-        
+
         self.messageLabel = QLabel(wordWrap=True)
         self.printCommandLabel = QLabel()
         self.printCommand = widgets.urlrequester.UrlRequester()
@@ -133,9 +133,9 @@ class Printing(preferences.Group):
         layout.addWidget(self.printDialogCheck, 2, 0, 1, 2)
         layout.addWidget(self.resolutionLabel, 3, 0)
         layout.addWidget(self.resolution, 3, 1)
-        
+
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_("Printing Music"))
         self.messageLabel.setText(_(
@@ -159,7 +159,7 @@ class Printing(preferences.Group):
         self.resolutionLabel.setText(_("Resolution:"))
         self.resolution.setToolTip(_(
             "Set the resolution if Frescobaldi prints using raster images."))
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("helper_applications")
@@ -167,7 +167,7 @@ class Printing(preferences.Group):
         self.printDialogCheck.setChecked(s.value("printcommand/dialog", False, bool))
         with qutil.signalsBlocked(self.resolution):
             self.resolution.setEditText(format(s.value("printcommand/dpi", 300, int)))
-    
+
     def saveSettings(self):
         s= QSettings()
         s.beginGroup("helper_applications")

--- a/frescobaldi_app/preferences/import_export.py
+++ b/frescobaldi_app/preferences/import_export.py
@@ -45,25 +45,25 @@ def exportTheme(widget, schemeName, filename):
     comment = ET.Comment(_comment.format(appinfo=appinfo))
     root.append(comment)
     d = ET.ElementTree(root)
-    
+
     font = tfd.font
     fontfamily = font.family()
     fontsize = str(font.pointSizeF())
     fontElt = ET.Element('font', {'fontFamily': fontfamily, 'fontSize': fontsize})
     root.append(fontElt)
-    
+
     baseColors = ET.Element('baseColors')
     for name, color in tfd.baseColors.items():
         elt = ET.Element(name)
         elt.set('color', color.name())
         baseColors.append(elt)
-    
+
     defaultStyles = ET.Element('defaultStyles')
     for name, fmt in tfd.defaultStyles.items():
         elt = styleToElt(fmt, name)
         if elt is not None:
             defaultStyles.append(elt)
-        
+
     allStyles = ET.Element('allStyles')
     for name, styles in tfd.allStyles.items():
         subElt = ET.Element(name)
@@ -76,11 +76,11 @@ def exportTheme(widget, schemeName, filename):
     root.append(baseColors)
     root.append(defaultStyles)
     root.append(allStyles)
-    
+
     indentXml(root)
     d.write(filename, 'UTF-8')
 
-    
+
 def importTheme(filename, widget, schemeWidget):
     """Loads the colors theme from a file"""
     try:
@@ -93,14 +93,14 @@ def importTheme(filename, widget, schemeWidget):
         _("Can't read from source:\n\n{url}\n\n{error}").format(
             url=filename, error=e))
         return
-    
+
     schemeWidget.scheme.blockSignals(True)
     key = schemeWidget.addScheme(root.get('name'))
     schemeWidget.scheme.blockSignals(False)
     tfd = textformats.TextFormatData(key)
-    
+
     fontElt = root.find('font')
-    
+
     defaultfont = "Lucida Console" if os.name == "nt" else "monospace"
     if fontElt.get('fontFamily') in QFontDatabase().families():
         fontFamily = fontElt.get('fontFamily')
@@ -112,21 +112,21 @@ def importTheme(filename, widget, schemeWidget):
 
     for elt in root.find('baseColors'):
         tfd.baseColors[elt.tag] = QColor(elt.get('color'))
-    
+
     for elt in root.find('defaultStyles'):
         tfd.defaultStyles[elt.tag] = eltToStyle(elt)
-    
+
     for style in root.find('allStyles'):
         if not style in tfd.allStyles:
             tfd.allStyles[style] = {}
         for elt in style:
             tfd.allStyles[style.tag][elt.tag] = eltToStyle(elt)
-            
+
     widget.addSchemeData(key, tfd)
     schemeWidget.disableDefault(False)
     schemeWidget.currentChanged.emit()
     schemeWidget.changed.emit()
-   
+
 
 def exportShortcut(widget, scheme, schemeName, filename):
     """Saves shortcuts to a file."""
@@ -137,13 +137,13 @@ def exportShortcut(widget, scheme, schemeName, filename):
             lst[col] = {}
         if not item.isDefault(scheme):
             lst[col][item.name] = item.shortcuts(scheme)
-        
+
     root = ET.Element('frescobaldi-shortcut')
     root.set('name', schemeName)
     comment = ET.Comment(_comment.format(appinfo=appinfo))
     root.append(comment)
     d = ET.ElementTree(root)
-    
+
     for col, shortcuts in lst.items():
         if not shortcuts:
             continue
@@ -158,10 +158,10 @@ def exportShortcut(widget, scheme, schemeName, filename):
                 shortcutElt = ET.Element('shortcut')
                 shortcutElt.text = seq.toString()
                 nameElt.append(shortcutElt)
-                
+
     indentXml(root)
     d.write(filename, 'UTF-8')
-    
+
 
 
 def importShortcut(filename, widget, schemeWidget):
@@ -176,23 +176,23 @@ def importShortcut(filename, widget, schemeWidget):
         _("Can't read from source:\n\n{url}\n\n{error}").format(
             url=filename, error=e))
         return
-    
+
     schemeWidget.scheme.blockSignals(True)
     scheme = schemeWidget.addScheme(root.get('name'))
     schemeWidget.scheme.blockSignals(False)
-    
+
     for col in root.findall('collection'):
         for name in col.findall('name'):
             shortcuts = [QKeySequence.fromString(shortcut.text) for shortcut in name.findall('shortcut')]
             item = widget.item(col.attrib['name'], name.attrib['name'])
             if item:
                 item.setShortcuts(shortcuts, scheme)
-            
+
     schemeWidget.disableDefault(False)
     schemeWidget.currentChanged.emit()
     schemeWidget.changed.emit()
-    
-    
+
+
 def styleToElt(fmt, name):
     elt = ET.Element(name)
     if fmt.hasProperty(QTextFormat.FontWeight):
@@ -207,7 +207,7 @@ def styleToElt(fmt, name):
         elt.set('backgroundColor', fmt.background().color().name())
     if fmt.hasProperty(QTextFormat.TextUnderlineColor):
         elt.set('underlineColor', fmt.underlineColor().name())
-    
+
     return elt if elt.attrib else None
 
 
@@ -229,9 +229,9 @@ def eltToStyle(elt):
         fmt.setBackground(QColor(elt.get('backgroundColor')))
     if elt.get('underlineColor'):
         fmt.setUnderlineColor(QColor(elt.get('underlineColor')))
-        
+
     return fmt
-        
+
 def indentXml(elem, level=0, tab=2):
     i = "\n" + level*" "*tab
     if len(elem):
@@ -246,8 +246,8 @@ def indentXml(elem, level=0, tab=2):
     else:
         if level and (not elem.tail or not elem.tail.strip()):
             elem.tail = i
-            
-              
+
+
 _comment = """
   Created by {appinfo.appname} {appinfo.version}.
-"""  
+"""

--- a/frescobaldi_app/preferences/lilypond.py
+++ b/frescobaldi_app/preferences/lilypond.py
@@ -63,10 +63,10 @@ class LilyPondPrefs(preferences.ScrolledGroupsPage):
 class Versions(preferences.Group):
     def __init__(self, page):
         super(Versions, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.instances = InfoList(self)
         self.instances.changed.connect(self.changed)
         self.instances.defaultButton.clicked.connect(self.defaultButtonClicked)
@@ -75,13 +75,13 @@ class Versions(preferences.Group):
         layout.addWidget(self.auto)
         app.translateUI(self)
         userguide.openWhatsThis(self)
-    
+
     def defaultButtonClicked(self):
         self._defaultCommand = self.instances.listBox.currentItem()._info.command
         for item in self.instances.items():
             item.display()
         self.changed.emit()
-            
+
     def translateUI(self):
         self.setTitle(_("LilyPond versions to use"))
         self.auto.setText(_("Automatically choose LilyPond version from document"))
@@ -105,7 +105,7 @@ class Versions(preferences.Group):
             if item._info.command == self._defaultCommand:
                 self.instances.setCurrentItem(item)
                 break
-        
+
     def saveSettings(self):
         infos = [item._info for item in self.instances.items()]
         if infos:
@@ -131,14 +131,14 @@ class InfoList(widgets.listedit.ListEdit):
         self.layout().addWidget(self.defaultButton, 3, 1)
         self.layout().addWidget(self.listBox, 0, 0, 5, 1)
         self.listBox.itemSelectionChanged.connect(self._selectionChanged)
-        
+
     def _selectionChanged(self):
         self.defaultButton.setEnabled(bool(self.listBox.currentItem()))
-        
+
     def translateUI(self):
         super(InfoList, self).translateUI()
         self.defaultButton.setText(_("Set as &Default"))
-    
+
     def infoDialog(self):
         try:
             return self._infoDialog
@@ -148,7 +148,7 @@ class InfoList(widgets.listedit.ListEdit):
 
     def createItem(self):
         return InfoItem(lilypondinfo.LilyPondInfo("lilypond"))
-    
+
     def openEditor(self, item):
         dlg = self.infoDialog()
         dlg.loadInfo(item._info)
@@ -164,13 +164,13 @@ class InfoList(widgets.listedit.ListEdit):
     def itemChanged(self, item):
         item.display()
         self.setCurrentItem(item)
-        
+
 
 class InfoItem(QListWidgetItem):
     def __init__(self, info):
         super(InfoItem, self).__init__()
         self._info = info
-    
+
     def display(self):
         text = self._info.prettyName()
         if self._info.version():
@@ -186,7 +186,7 @@ class InfoDialog(QDialog):
     def __init__(self, parent):
         super(InfoDialog, self).__init__(parent)
         self.setWindowModality(Qt.WindowModal)
-        
+
         layout = QVBoxLayout()
         layout.setSpacing(10)
         self.setLayout(layout)
@@ -196,12 +196,12 @@ class InfoDialog(QDialog):
         tab_toolcommands = QWidget()
         self.tab.addTab(tab_general, "")
         self.tab.addTab(tab_toolcommands, "")
-        
+
         # general tab
         vbox = QVBoxLayout()
         vbox.setSpacing(4)
         tab_general.setLayout(vbox)
-        
+
         hbox = QHBoxLayout()
         self.lilyname = QLineEdit()
         self.lilynameLabel = l = QLabel()
@@ -209,14 +209,14 @@ class InfoDialog(QDialog):
         hbox.addWidget(l)
         hbox.addWidget(self.lilyname)
         vbox.addLayout(hbox)
-        
+
         self.lilypond = widgets.urlrequester.UrlRequester()
         self.lilypond.setFileMode(QFileDialog.ExistingFile)
         self.lilypondLabel = l = QLabel()
         l.setBuddy(self.lilypond)
         vbox.addWidget(l)
         vbox.addWidget(self.lilypond)
-        
+
         self.auto = QCheckBox()
         vbox.addWidget(self.auto)
         vbox.addStretch(1)
@@ -225,7 +225,7 @@ class InfoDialog(QDialog):
         grid = QGridLayout()
         grid.setSpacing(4)
         tab_toolcommands.setLayout(grid)
-        
+
         self.ly_tool_widgets = {}
         row = 0
         for name, gui in self.toolnames():
@@ -236,19 +236,19 @@ class InfoDialog(QDialog):
             grid.addWidget(w, row, 1)
             row += 1
             self.ly_tool_widgets[name] = (l, w)
-        
+
         layout.addWidget(self.tab)
         layout.addWidget(widgets.Separator())
         b = self.buttons = QDialogButtonBox(self)
         layout.addWidget(b)
-        
+
         b.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         b.accepted.connect(self.accept)
         b.rejected.connect(self.reject)
         userguide.addButton(b, "prefs_lilypond")
         app.translateUI(self)
         qutil.saveDialogSize(self, "/preferences/lilypond/lilypondinfo/dialog/size")
-        
+
     def toolnames(self):
         """Yield tuples (name, GUI name) for the sub tools we allow to be configured."""
         yield 'convert-ly', _("Convert-ly:")
@@ -256,7 +256,7 @@ class InfoDialog(QDialog):
         yield 'midi2ly', _("Midi2ly:")
         yield 'musicxml2ly', _("MusicXML2ly:")
         yield 'abc2ly', _("ABC2ly:")
-    
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("LilyPond")))
         self.lilynameLabel.setText(_("Label:"))
@@ -268,7 +268,7 @@ class InfoDialog(QDialog):
         self.tab.setTabText(1, _("Tool Commands"))
         for name, gui in self.toolnames():
             self.ly_tool_widgets[name][0].setText(gui)
-        
+
     def loadInfo(self, info):
         """Takes over settings for the dialog from the LilyPondInfo object."""
         self.lilyname.setText(info.name)
@@ -295,10 +295,10 @@ class InfoDialog(QDialog):
 class Running(preferences.Group):
     def __init__(self, page):
         super(Running, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.saveDocument = QCheckBox(clicked=self.changed)
         self.deleteFiles = QCheckBox(clicked=self.changed)
         self.embedSourceCode = QCheckBox(clicked=self.changed)
@@ -314,7 +314,7 @@ class Running(preferences.Group):
         layout.addWidget(self.includeLabel)
         layout.addWidget(self.include)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Running LilyPond"))
         self.saveDocument.setText(_("Save document if possible"))
@@ -334,7 +334,7 @@ class Running(preferences.Group):
             "If checked, LilyPond's output messages will be in English.\n"
             "This can be useful for bug reports."))
         self.includeLabel.setText(_("LilyPond include path:"))
-    
+
     def loadSettings(self):
         s = settings()
         self.saveDocument.setChecked(s.value("save_on_run", False, bool))
@@ -343,7 +343,7 @@ class Running(preferences.Group):
         self.noTranslation.setChecked(s.value("no_translation", False, bool))
         include_path = qsettings.get_string_list(s, "include_path")
         self.include.setValue(include_path)
-        
+
     def saveSettings(self):
         s = settings()
         s.setValue("save_on_run", self.saveDocument.isChecked())
@@ -356,19 +356,19 @@ class Running(preferences.Group):
 class Target(preferences.Group):
     def __init__(self, page):
         super(Target, self).__init__(page)
-        
+
         layout = QGridLayout()
         self.setLayout(layout)
-        
+
         self.targetPDF = QRadioButton(toggled=page.changed)
         self.targetSVG = QRadioButton(toggled=page.changed)
         self.openDefaultView = QCheckBox(clicked=page.changed)
-        
+
         layout.addWidget(self.targetPDF, 0, 0)
         layout.addWidget(self.targetSVG, 0, 1)
         layout.addWidget(self.openDefaultView, 1, 0, 1, 5)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Default output format"))
         self.targetPDF.setText(_("PDF"))
@@ -381,7 +381,7 @@ class Target(preferences.Group):
         self.openDefaultView.setToolTip(_(
             "Shows the PDF or SVG music view when a compile job finishes "
             "successfully."))
-    
+
     def loadSettings(self):
         s = settings()
         target = s.value("default_output_target", "pdf", str)
@@ -392,7 +392,7 @@ class Target(preferences.Group):
             self.targetSVG.setChecked(False)
             self.targetPDF.setChecked(True)
         self.openDefaultView.setChecked(s.value("open_default_view", True, bool))
-        
+
     def saveSettings(self):
         s = settings()
         if self.targetSVG.isChecked():

--- a/frescobaldi_app/preferences/midi.py
+++ b/frescobaldi_app/preferences/midi.py
@@ -39,14 +39,14 @@ import listmodel
 class MidiPrefs(preferences.GroupsPage):
     def __init__(self, dialog):
         super(MidiPrefs, self).__init__(dialog)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         layout.addWidget(MidiPorts(self))
         layout.addWidget(Prefs(self))
         layout.addStretch(0)
-    
+
     def saveSettings(self):
         super(MidiPrefs, self).saveSettings()
         midihub.settingsChanged()
@@ -55,7 +55,7 @@ class MidiPrefs(preferences.GroupsPage):
 class MidiPorts(preferences.Group):
     def __init__(self, page):
         super(MidiPorts, self).__init__(page)
-        
+
         self._portsMessage = QLabel(wordWrap=True)
         self._playerLabel = QLabel()
         self._playerPort = QComboBox(editable=True,
@@ -63,10 +63,10 @@ class MidiPorts(preferences.Group):
         self._inputLabel = QLabel()
         self._inputPort = QComboBox(editable=True,
             editTextChanged=self.changed, insertPolicy=QComboBox.NoInsert)
-        
+
         self._reloadMidi = QPushButton(icon=icons.get('view-refresh'))
         self._reloadMidi.clicked.connect(self.refreshMidiPorts)
-        
+
         grid = QGridLayout()
         self.setLayout(grid)
         grid.addWidget(self._portsMessage, 0, 0, 1, 3)
@@ -75,10 +75,10 @@ class MidiPorts(preferences.Group):
         grid.addWidget(self._inputLabel, 2, 0)
         grid.addWidget(self._inputPort, 2, 1, 1, 2)
         grid.addWidget(self._reloadMidi, 3, 2)
-        
+
         app.translateUI(self)
         self.loadMidiPorts()
-    
+
     def translateUI(self):
         self.setTitle(_("MIDI Ports"))
         self._portsMessage.setText(_(
@@ -135,7 +135,7 @@ class MidiPorts(preferences.Group):
         s.beginGroup("midi")
         self._playerPort.setEditText(s.value("player/output_port", output_port, str))
         self._inputPort.setEditText(s.value("midi/input_port", input_port, str))
-        
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup("midi")
@@ -146,26 +146,26 @@ class MidiPorts(preferences.Group):
 class Prefs(preferences.Group):
     def __init__(self, page):
         super(Prefs, self).__init__(page)
-        
+
         self._closeOutputs = QCheckBox(clicked=self.changed)
         self._pollingLabel = QLabel()
         self._pollingTime = QSpinBox()
         self._pollingTime.setRange(0, 1000)
         self._pollingTime.setSuffix(" ms")
         self._pollingTime.valueChanged.connect(self.changed)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         layout.addWidget(self._closeOutputs)
         app.translateUI(self)
-        
+
         hbox = QHBoxLayout()
         layout.addLayout(hbox)
-        
+
         hbox.addWidget(self._pollingLabel)
         hbox.addWidget(self._pollingTime)
-    
+
     def translateUI(self):
         self.setTitle(_("Preferences"))
         self._closeOutputs.setText(_("Close unused MIDI output"))
@@ -196,7 +196,7 @@ class Prefs(preferences.Group):
             s.value("midi/close_outputs", False, bool))
         self._pollingTime.setValue(
             s.value("midi/polling_time", 10, int))
-    
+
     def saveSettings(self):
         s = QSettings()
         s.setValue("midi/close_outputs", self._closeOutputs.isChecked())

--- a/frescobaldi_app/preferences/paths.py
+++ b/frescobaldi_app/preferences/paths.py
@@ -37,7 +37,7 @@ class Paths(preferences.GroupsPage):
 
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         layout.addWidget(HyphenPaths(self))
         layout.addStretch(1)
 
@@ -45,25 +45,25 @@ class Paths(preferences.GroupsPage):
 class HyphenPaths(preferences.Group):
     def __init__(self, page):
         super(HyphenPaths, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.listedit = widgets.listedit.FilePathEdit()
         self.listedit.changed.connect(self.changed)
         layout.addWidget(self.listedit)
-        
+
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Folders containing hyphenation dictionaries"))
-        
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("hyphenation")
         paths = qsettings.get_string_list(s, "paths")
         self.listedit.setValue(paths)
-        
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup("hyphenation")

--- a/frescobaldi_app/preferences/shortcuts.py
+++ b/frescobaldi_app/preferences/shortcuts.py
@@ -46,11 +46,11 @@ _lastaction = '' # last selected action name (saved during running but not on ex
 class Shortcuts(preferences.Page):
     def __init__(self, dialog):
         super(Shortcuts, self).__init__(dialog)
-        
+
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-        
+
         self.scheme = SchemeSelector(self)
         layout.addWidget(self.scheme)
         self.searchEntry = LineEdit()
@@ -63,10 +63,10 @@ class Shortcuts(preferences.Page):
         self.tree.setAllColumnsShowFocus(True)
         self.tree.setAnimated(True)
         layout.addWidget(self.tree)
-        
+
         self.edit = QPushButton(icons.get("preferences-desktop-keyboard-shortcuts"), '')
         layout.addWidget(self.edit)
-        
+
         # signals
         self.searchEntry.textChanged.connect(self.updateFilter)
         self.scheme.currentChanged.connect(self.slotSchemeChanged)
@@ -74,7 +74,7 @@ class Shortcuts(preferences.Page):
         self.tree.currentItemChanged.connect(self.slotCurrentItemChanged)
         self.tree.itemDoubleClicked.connect(self.editCurrentItem)
         self.edit.clicked.connect(self.editCurrentItem)
-        
+
         # make a dict of all actions with the actions as key and the names as
         # value, with the collection prepended (for loading/saving)
         win = dialog.parent()
@@ -82,10 +82,10 @@ class Shortcuts(preferences.Page):
         for collection in actioncollectionmanager.manager(win).actionCollections():
             for name, action in collection.actions().items():
                 allactions[action] = (collection, name)
-        
+
         # keep a list of actions not in the menu structure
         left = list(allactions.keys())
-        
+
         def add_actions(menuitem, actions):
             """Add actions to a QTreeWidgetItem."""
             for a in actions:
@@ -97,7 +97,7 @@ class Shortcuts(preferences.Page):
                     left.remove(a)
                     menuitem.addChild(ShortcutItem(a, *allactions[a]))
             menuitem.setFlags(Qt.ItemIsEnabled) # disable selection
-            
+
         def build_menu_item(action):
             """Return a QTreeWidgetItem with children for all the actions in the submenu."""
             menuitem = QTreeWidgetItem()
@@ -105,16 +105,16 @@ class Shortcuts(preferences.Page):
             menuitem.setText(0, _("Menu {name}").format(name=text))
             add_actions(menuitem, action.menu().actions())
             return menuitem
-        
+
         # present the actions nicely ordered as in the menus
         for a in win.menuBar().actions():
             menuitem = build_menu_item(a)
             if menuitem.childCount():
                 self.tree.addTopLevelItem(menuitem)
-        
+
         # sort leftover actions
         left.sort(key=lambda i: i.text())
-        
+
         # show actions that are left, grouped by collection
         titlegroups = {}
         for a in left[:]: # copy
@@ -128,7 +128,7 @@ class Shortcuts(preferences.Page):
                 item.addChild(ShortcutItem(a, *allactions[a]))
             self.tree.addTopLevelItem(item)
             item.setFlags(Qt.ItemIsEnabled) # disable selection
-            
+
         # show other actions that were not in the menus
         item = QTreeWidgetItem([_("Other commands:")])
         for a in left:
@@ -137,9 +137,9 @@ class Shortcuts(preferences.Page):
         if item.childCount():
             self.tree.addTopLevelItem(item)
             item.setFlags(Qt.ItemIsEnabled) # disable selection
-        
+
         self.tree.expandAll()
-        
+
         item = self.tree.topLevelItem(0).child(0)
         if _lastaction:
             # find the previously selected item
@@ -149,7 +149,7 @@ class Shortcuts(preferences.Page):
                     break
         self.tree.setCurrentItem(item)
         self.tree.resizeColumnToContents(0)
-        
+
     def items(self):
         """Yield all the items in the actions tree."""
         def children(item):
@@ -162,12 +162,12 @@ class Shortcuts(preferences.Page):
                     yield c
         for c in children(self.tree.invisibleRootItem()):
             yield c
-    
+
     def item(self, collection, name):
         for item in self.items():
             if item.collection.name == collection and item.name == name:
                 return item
-             
+
     def saveSettings(self):
         self.scheme.saveSettings("shortcut_scheme", "shortcut_schemes", "shortcuts")
         for item in self.items():
@@ -175,19 +175,19 @@ class Shortcuts(preferences.Page):
                 item.save(scheme)
             item.clearSettings()
             item.switchScheme(self.scheme.currentScheme())
-        
+
     def loadSettings(self):
         self.scheme.loadSettings("shortcut_scheme", "shortcut_schemes")
         # clear the settings in all the items
         for item in self.items():
             item.clearSettings()
             item.switchScheme(self.scheme.currentScheme())
-        
+
     def slotSchemeChanged(self):
         """Called when the Scheme combobox is changed by the user."""
         for item in self.items():
             item.switchScheme(self.scheme.currentScheme())
-        
+
     def slotCurrentItemChanged(self, item):
         if isinstance(item, ShortcutItem):
             self.edit.setText(
@@ -198,11 +198,11 @@ class Shortcuts(preferences.Page):
         else:
             self.edit.setText(_("(no shortcut)"))
             self.edit.setEnabled(False)
-        
+
     def import_(self, filename):
         from . import import_export
         import_export.importShortcut(filename, self, self.scheme)
-        
+
     def export(self, name, filename):
         from . import import_export
         try:
@@ -211,7 +211,7 @@ class Shortcuts(preferences.Page):
             QMessageBox.critical(self, _("Error"), _(
                 "Can't write to destination:\n\n{url}\n\n{error}").format(
                 url=filename, error=e.strerror))
-    
+
     def findShortcutConflict(self, shortcut):
         """Find the possible shortcut conflict and return the conflict name."""
         if shortcut:
@@ -225,8 +225,8 @@ class Shortcuts(preferences.Page):
                     for s1 in a.shortcuts():
                         if s1.matches(shortcut) or shortcut.matches(s1):
                             return qutil.removeAccelerator(a.text())
-        return None           
-    
+        return None
+
     def editCurrentItem(self):
         item = self.tree.currentItem()
         if not isinstance(item, ShortcutItem):
@@ -253,7 +253,7 @@ class Shortcuts(preferences.Page):
                             if s1.matches(s2) or s2.matches(s1):
                                 l.remove(s1)
                     i.setShortcuts(l, scheme)
-                
+
             # store the shortcut
             item.setShortcuts(shortcuts, scheme)
             self.changed.emit()
@@ -293,40 +293,40 @@ class ShortcutItem(QTreeWidgetItem):
         self.setIcon(0, action.icon())
         self.setText(0, qutil.removeAccelerator(action.text()))
         self._shortcuts = {}
-        
+
     def clearSettings(self):
         self._shortcuts.clear()
-    
+
     def action(self, scheme):
         """Returns a new QAction that represents our item.
-        
+
         The action contains the text, icon and current shortcut.
-        
+
         """
         action = QAction(self.icon(0), self.text(0).replace('&', '&&'), None)
         action.setShortcuts(self._shortcuts[scheme][0])
         return action
-    
+
     def shortcuts(self, scheme):
         """Returns the list of shortcuts currently set for scheme."""
         return list(self._shortcuts[scheme][0])
-    
+
     def isDefault(self, scheme):
         return self._shortcuts[scheme][1]
-    
+
     def setShortcuts(self, shortcuts, scheme):
         default = shortcuts == self.defaultShortcuts()
         self._shortcuts[scheme] = (shortcuts, default)
         self.display(scheme)
-        
+
     def defaultShortcuts(self):
         """Returns a (possibly empty) list of QKeySequence objects.
-        
+
         The list represents the default shortcut for this item, if any.
-        
+
         """
         return self.collection.defaults().get(self.name, [])
-        
+
     def switchScheme(self, scheme):
         if scheme not in self._shortcuts:
             s = QSettings()
@@ -342,7 +342,7 @@ class ShortcutItem(QTreeWidgetItem):
                 # default
                 self._shortcuts[scheme] = (self.defaultShortcuts(), True)
         self.display(scheme)
-    
+
     def save(self, scheme):
         try:
             shortcuts, default = self._shortcuts[scheme]
@@ -354,7 +354,7 @@ class ShortcutItem(QTreeWidgetItem):
             s.remove(key)
         else:
             s.setValue(key, shortcuts)
-            
+
     def display(self, scheme):
         text = ''
         shortcuts, default = self._shortcuts[scheme]
@@ -365,13 +365,13 @@ class ShortcutItem(QTreeWidgetItem):
             if default:
                 text += "  " + _("(default)")
         self.setText(1, text)
-        
+
     def matches(self, scheme, text):
         """Return True if the text matches our description or shortcuts.
-        
+
         Shortcuts are checked in the specified scheme.
         The match is case insensitive.
-        
+
         """
         text = text.lower()
         if text in self.text(0).lower():

--- a/frescobaldi_app/preferences/tools.py
+++ b/frescobaldi_app/preferences/tools.py
@@ -47,19 +47,19 @@ class Tools(preferences.ScrolledGroupsPage):
 
         layout = QVBoxLayout()
         self.scrolledWidget.setLayout(layout)
-        
+
         layout.addWidget(LogTool(self))
         layout.addWidget(MusicView(self))
         layout.addWidget(CharMap(self))
         layout.addWidget(DocumentList(self))
         layout.addWidget(Outline(self))
         layout.addStretch(1)
-            
+
 
 class LogTool(preferences.Group):
     def __init__(self, page):
         super(LogTool, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
 
@@ -75,18 +75,18 @@ class LogTool(preferences.Group):
         box.addWidget(self.fontChooser, 1)
         box.addWidget(self.fontSize)
         layout.addLayout(box)
-        
+
         self.showlog = QCheckBox(toggled=self.changed)
         layout.addWidget(self.showlog)
-        
+
         self.rawview = QCheckBox(toggled=self.changed)
         layout.addWidget(self.rawview)
-        
+
         self.hideauto = QCheckBox(toggled=self.changed)
         layout.addWidget(self.hideauto)
-        
+
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("LilyPond Log"))
         self.fontLabel.setText(_("Font:"))
@@ -98,7 +98,7 @@ class LogTool(preferences.Group):
         self.hideauto.setToolTip(_(
             "If checked, Frescobaldi will not show the log for automatically\n"
             "started engraving jobs (LilyPond->Auto-engrave)."))
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("log")
@@ -124,13 +124,13 @@ class LogTool(preferences.Group):
 class MusicView(preferences.Group):
     def __init__(self, page):
         super(MusicView, self).__init__(page)
-        
+
         layout = QGridLayout()
         self.setLayout(layout)
-        
+
         self.newerFilesOnly = QCheckBox(toggled=self.changed)
         layout.addWidget(self.newerFilesOnly, 0, 0, 1, 3)
-        
+
         self.magnifierSizeLabel = QLabel()
         self.magnifierSizeSlider = QSlider(Qt.Horizontal, valueChanged=self.changed)
         self.magnifierSizeSlider.setSingleStep(50)
@@ -142,7 +142,7 @@ class MusicView(preferences.Group):
         layout.addWidget(self.magnifierSizeLabel, 1, 0)
         layout.addWidget(self.magnifierSizeSlider, 1, 1)
         layout.addWidget(self.magnifierSizeSpinBox, 1, 2)
-        
+
         self.magnifierScaleLabel = QLabel()
         self.magnifierScaleSlider = QSlider(Qt.Horizontal, valueChanged=self.changed)
         self.magnifierScaleSlider.setSingleStep(50)
@@ -154,13 +154,13 @@ class MusicView(preferences.Group):
         layout.addWidget(self.magnifierScaleLabel, 2, 0)
         layout.addWidget(self.magnifierScaleSlider, 2, 1)
         layout.addWidget(self.magnifierScaleSpinBox, 2, 2)
-        
+
         self.enableKineticScrolling = QCheckBox(toggled=self.changed)
         layout.addWidget(self.enableKineticScrolling)
         self.showScrollbars = QCheckBox(toggled=self.changed)
         layout.addWidget(self.showScrollbars)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Music View"))
         self.newerFilesOnly.setText(_("Only load updated PDF documents"))
@@ -179,12 +179,12 @@ class MusicView(preferences.Group):
         # L10N: "Kinetic Scrolling" is a checkbox label, as in "Enable Kinetic Scrolling"
         self.enableKineticScrolling.setText(_("Kinetic Scrolling"))
         self.showScrollbars.setText(_("Show Scrollbars"))
-            
+
     def loadSettings(self):
         s = popplerview.MagnifierSettings.load()
         self.magnifierSizeSlider.setValue(s.size)
         self.magnifierScaleSlider.setValue(s.scale)
-        
+
         s = QSettings()
         s.beginGroup("musicview")
         newerFilesOnly = s.value("newer_files_only", True, bool)
@@ -193,7 +193,7 @@ class MusicView(preferences.Group):
         self.enableKineticScrolling.setChecked(kineticScrollingActive)
         showScrollbars = s.value("show_scrollbars", True, bool)
         self.showScrollbars.setChecked(showScrollbars)
-    
+
     def saveSettings(self):
         s = popplerview.MagnifierSettings()
         s.size = self.magnifierSizeSlider.value()
@@ -210,28 +210,28 @@ class MusicView(preferences.Group):
 class CharMap(preferences.Group):
     def __init__(self, page):
         super(CharMap, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.fontLabel = QLabel()
         self.fontChooser = QFontComboBox(currentFontChanged=self.changed)
         self.fontSize = QDoubleSpinBox(valueChanged=self.changed)
         self.fontSize.setRange(6.0, 32.0)
         self.fontSize.setSingleStep(0.5)
         self.fontSize.setDecimals(1)
-        
+
         box = QHBoxLayout()
         box.addWidget(self.fontLabel)
         box.addWidget(self.fontChooser, 1)
         box.addWidget(self.fontSize)
         layout.addLayout(box)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Special Characters"))
         self.fontLabel.setText(_("Font:"))
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("charmaptool")
@@ -254,17 +254,17 @@ class CharMap(preferences.Group):
 class DocumentList(preferences.Group):
     def __init__(self, page):
         super(DocumentList, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
         self.groupCheck = QCheckBox(toggled=self.changed)
         layout.addWidget(self.groupCheck)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setTitle(_("Documents"))
         self.groupCheck.setText(_("Group documents by directory"))
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("document_list")
@@ -279,7 +279,7 @@ class DocumentList(preferences.Group):
 class Outline(preferences.Group):
     def __init__(self, page):
         super(Outline, self).__init__(page)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
         self.label = QLabel()
@@ -292,16 +292,16 @@ class Outline(preferences.Group):
         layout.addWidget(self.label)
         layout.addWidget(self.patternList)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_("Outline"))
         self.defaultButton.setText(_("Default"))
         self.defaultButton.setToolTip(_("Restores the built-in outline patterns."))
         self.label.setText(_("Patterns to match in text that are shown in outline:"))
-    
+
     def reloadDefaults(self):
         self.patternList.setValue(documentstructure.default_outline_patterns)
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup("documentstructure")
@@ -310,7 +310,7 @@ class Outline(preferences.Group):
         except TypeError:
             patterns = []
         self.patternList.setValue(patterns)
-    
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup("documentstructure")
@@ -333,7 +333,7 @@ class OutlinePatterns(widgets.listedit.ListEdit):
             return True
         return False
 
-            
+
 def is_regex(text):
     """Return True if text is a valid regular expression."""
     try:

--- a/frescobaldi_app/process.py
+++ b/frescobaldi_app/process.py
@@ -29,45 +29,45 @@ from PyQt5.QtCore import QObject, QProcess, pyqtSignal
 
 class Process(QObject):
     """A very simple wrapper to run a QProcess.
-    
+
     Initialize the process with the command line (as a list) to run.
     Then (or later) call start() to run it. At that moment the 'process'
     attribute is available, which contains the QProcess instance managing
     the process.
-    
+
     The done() signal is emitted with a boolean success value. In slots
     connected (synchronously) the process attribute is still available.
-    
+
     """
-    
+
     done = pyqtSignal(bool)
-    
+
     def __init__(self, command):
         """Sets up the command to run."""
         QObject.__init__(self)
         self.command = command
-    
+
     def start(self):
         """Really starts a QProcess, executing the command line."""
         self.setup()
         self.process.start(self.command[0], self.command[1:])
-    
+
     def setup(self):
         """Called on start(), sets up the QProcess in the process attribute."""
         self.process = p = QProcess()
         p.finished.connect(self._finished)
         p.error.connect(self._error)
-        
+
     def _finished(self, exitCode):
         self._done(exitCode == 0)
-    
+
     def _error(self):
         self._done(False)
-    
+
     def _done(self, success):
         self.done.emit(success)
         self.cleanup()
-    
+
     def cleanup(self):
         """Deletes the process."""
         self.process.deleteLater()
@@ -76,31 +76,31 @@ class Process(QObject):
 
 class Scheduler(object):
     """A very simple scheduler that runs one Process at a time.
-    
+
     You can use this to run e.g. commandline tools asynchronously and you
     don't want to have them running at the same time.
-    
+
     """
     def __init__(self):
         self._schedule = []
-    
+
     def add(self, process):
         """Adds the process to run."""
         process.done.connect(self._done)
         self._schedule.append(process)
         if len(self._schedule) == 1:
             self._schedule[0].start()
-    
+
     def remove(self, process):
         """Removes the process from the schedule.
-        
+
         This only works if the process has not been started yet.
-        
+
         """
         if process in self._schedule[1:]:
             self._schedule.remove(process)
             process.done.disconnect(self._done)
-    
+
     def _done(self):
         del self._schedule[0]
         if self._schedule:

--- a/frescobaldi_app/progress.py
+++ b/frescobaldi_app/progress.py
@@ -45,10 +45,10 @@ class ProgressBar(plugin.ViewSpacePlugin):
         viewSpace.viewChanged.connect(self.viewChanged)
         app.jobStarted.connect(self.jobStarted)
         app.jobFinished.connect(self.jobFinished)
-        
+
     def viewChanged(self, view):
         self.showProgress(view.document())
-    
+
     def showProgress(self, document):
         job = jobmanager.job(document)
         if job and job.is_running():
@@ -66,11 +66,11 @@ class ProgressBar(plugin.ViewSpacePlugin):
                 self._bar.setTextVisible(True)
         else:
             self._bar.stop(False)
-    
+
     def jobStarted(self, document, job):
         if document == self.viewSpace().document():
             self.showProgress(document)
-    
+
     def jobFinished(self, document, job, success):
         if document == self.viewSpace().document():
             self._bar.stop(success and not jobattributes.get(job).hidden)

--- a/frescobaldi_app/qmidi/player.py
+++ b/frescobaldi_app/qmidi/player.py
@@ -31,33 +31,33 @@ import midifile.player
 
 class Player(QThread, midifile.player.Player):
     """An implementation of midifile.player.Player using a QThread and QTimer.
-    
+
     emit signals:
-    
+
     stateChanged(playing):
         True or False if playing state changes
-        
+
     time(msec):
         The playing time, emit by default every 1000ms
-        
+
     beat(measnum, beat, num, den):
         the measure number, beat number, time signature numerator and denom.,
         where 0 = whole note, 1 = half note, 2 = quarter note, etc.
-    
+
     user(object):
         any user object that might be added to an event
-    
+
     """
     stateChanged = pyqtSignal(bool)
     time = pyqtSignal(int)
     beat = pyqtSignal(int, int, int, int)
     user = pyqtSignal(object)
-    
+
     def __init__(self, parent=None):
         QThread.__init__(self, parent)
         midifile.player.Player.__init__(self)
         self._timer = None
-    
+
     def run(self):
         self._timer = QTimer(singleShot=True, timerType=Qt.PreciseTimer)
         self._timer.timeout.connect(self.timer_timeout, Qt.DirectConnection)
@@ -67,16 +67,16 @@ class Player(QThread, midifile.player.Player):
             self.timer_stop_playing()
         self._timer = None
         self.stateChanged.emit(False)
-    
+
     def start(self):
         if self.has_events():
             QThread.start(self)
-    
+
     def stop(self):
         if self.isRunning():
             self.exit(1)
             self.wait()
-    
+
     def set_position(self, position, offset=0):
         """Overridden because we can't start/stop the timer from the gui thread."""
         playing = self.isRunning()
@@ -85,11 +85,11 @@ class Player(QThread, midifile.player.Player):
         super(Player, self).set_position(position, offset)
         if playing:
             self.start()
-    
+
     def timer_start(self, msec):
         """Starts the timer to fire once, the specified msec from now."""
         self._timer.start(int(msec))
-    
+
     def timer_stop(self):
         self._timer.stop()
 
@@ -99,10 +99,10 @@ class Player(QThread, midifile.player.Player):
 
     def time_event(self, time):
         self.time.emit(time)
-    
+
     def beat_event(self, measnum, beat, num, den):
         self.beat.emit(measnum, beat, num, den)
-    
+
     def user_event(self, obj):
         self.user.emit(obj)
 

--- a/frescobaldi_app/qpageview/cache.py
+++ b/frescobaldi_app/qpageview/cache.py
@@ -34,51 +34,51 @@ class ImageEntry:
 
 class ImageCache:
     """Cache generated images.
-    
+
     Store and retrieve them under a key (see render.Renderer.key()).
-    
-    
+
+
     """
     maxsize = 104857600 # 100M
     currentsize = 0
 
     def __init__(self):
         self._cache = weakref.WeakKeyDictionary()
-    
+
     def clear(self):
         """Remove all cached images."""
         self._cache.clear()
-    
+
     def __getitem__(self, key):
         """Retrieve the exact image.
-        
+
         Raises a KeyError when there is no cached image for the key.
-        
+
         """
         return self._cache[key.group][key.page][key.size].image
-    
+
     def __setitem__(self, key, image):
         """Store the image.
-        
+
         Automatically removes the oldest cached images to keep the cache
         under maxsize.
-        
+
         """
         try:
             self.currentsize -= self._cache[key.group][key.page][key.size].bcount
         except KeyError:
             pass
-        
+
         purgeneeded = self.currentsize > self.maxsize
-        
+
         e = ImageEntry(image)
         self.currentsize += e.bcount
-        
+
         self._cache.setdefault(key.group, {}).setdefault(key.page, {})[key.size] = e
-        
+
         if not purgeneeded:
             return
-        
+
         # purge old images if needed,
         # cache groups may have disappeared so count all images
         items = []
@@ -93,7 +93,7 @@ class ImageCache:
             for group, groupd in self._cache.items()
                 for page, paged in groupd.items()
                     for size, entry in sorted(paged.items())[:1]))
-        
+
         # now count the newest images until maxsize ...
         items = reversed(items)
         currentsize = 0
@@ -109,13 +109,13 @@ class ImageCache:
                 del self._cache[group][page]
                 if not self._cache[group]:
                     del self._cache[group]
-    
+
     def closest(self, key):
         """Retrieve the correct image but with a different size.
-        
+
         This can be used for interim display while the real image is being
         rendered.
-        
+
         """
         try:
             entries = self._cache[key.group][key.page]

--- a/frescobaldi_app/qpageview/layout.py
+++ b/frescobaldi_app/qpageview/layout.py
@@ -37,7 +37,7 @@ from .constants import (
     Rotate_90,
     Rotate_180,
     Rotate_270,
-    
+
     Horizontal,
     Vertical,
 )
@@ -45,9 +45,9 @@ from .constants import (
 
 class AbstractPageLayout(list):
     """Manages page.Page instances with a list-like api.
-    
+
     You can iterate over the layout itself, which yields all Page instances.
-    
+
     The following instance attributes are used, with these defaults:
 
         margin = 4
@@ -58,12 +58,12 @@ class AbstractPageLayout(list):
         rotation = Rotate_0
         width = 0
         height = 0
-    
+
     After having changes pages or layout attributes, call update() to update
     the layout.
-    
+
     """
-    
+
     margin = 4
     spacing = 8
     zoomFactor = 1.0
@@ -72,53 +72,53 @@ class AbstractPageLayout(list):
     rotation = Rotate_0
     width = 0
     height = 0
-    
+
     def __bool__(self):
         """Always return True."""
         return True
-    
+
     def count(self):
         """Return the number of Page instances."""
         return len(self)
-    
+
     def empty(self):
         """Return True if there are zero pages."""
         return len(self) == 0
-    
+
     def copy(self):
         """Return a copy of this layout with copies of all the pages."""
         layout = copy.copy(self)
         layout[:] = (p.copy() for p in self)
         return layout
-    
+
     def setSize(self, size):
         """Set our size. Normally done after layout by computeSize()."""
         self.width = size.width()
         self.height = size.height()
-        
+
     def size(self):
         """Return our size as QSize()."""
         return QSize(self.width, self.height)
-    
+
     def pageAt(self, point):
         """Return the page that contains the given QPoint."""
         # Specific layouts may use faster algorithms to find the page.
         for page in self:
             if page.rect().contains(point):
                 return page
-    
+
     def pagesAt(self, r):
         """Yield the pages touched by the given QRect or QRegion."""
         # Specific layouts may use faster algorithms to find the pages.
         for page in self:
             if r.intersects(page.rect()):
                 yield page
-    
+
     def widestPage(self):
         """Return the widest page, if any.
-        
+
         Uses the page's natural width and its scale in X-direction.
-        
+
         """
         if self.count():
             def key(page):
@@ -128,12 +128,12 @@ class AbstractPageLayout(list):
                 else:
                     return psize.width() * page.scaleX
             return max(self, key=key)
-    
+
     def highestPage(self):
         """Return the highest page, if any.
-        
+
         Uses the page's natural height and its scale in Y-direction.
-        
+
         """
         if self.count():
             def key(page):
@@ -143,7 +143,7 @@ class AbstractPageLayout(list):
                 else:
                     return psize.height() * page.scaleY
             return max(self, key=key)
-    
+
     def fit(self, size, mode):
         """Fits the layout in the given size (QSize) and ViewMode."""
         if mode and self.count():
@@ -153,51 +153,51 @@ class AbstractPageLayout(list):
             if mode & FitHeight:
                 zoomfactors.append(self.zoomFitHeight(size.height()))
             self.zoomFactor = min(zoomfactors)
-    
+
     def zoomFitWidth(self, width):
         """Return the zoom factor this layout would need to fit in the width.
-        
-        This method is called by fit(). The default implementation returns a 
+
+        This method is called by fit(). The default implementation returns a
         suitable zoom factor for the widest Page.
-        
+
         """
         return self.widestPage().zoomForWidth(self, width - self.margin * 2)
-    
+
     def zoomFitHeight(self, height):
         """Return the zoom factor this layout would need to fit in the height.
-        
-        This method is called by fit(). The default implementation returns a 
+
+        This method is called by fit(). The default implementation returns a
         suitable zoom factor for the highest Page.
-        
+
         """
         return self.highestPage().zoomForHeight(self, height - self.margin * 2)
-    
+
     def update(self):
         """Compute the size of all pages and updates their positions.
         Finally set our own size.
-        
+
         You should call this after having added or deleted pages or after
         having changed the scale, dpi, zoom factor, spacing or margins.
-        
+
         This function returns True if the total size has changed.
-        
+
         """
         self.updatePageSizes()
         self.updatePagePositions()
         return self.computeSize()
-    
+
     def updatePageSizes(self):
         """Compute the correct size of every Page."""
         for page in self:
             page.updateSizeFromLayout(self)
 
     def updatePagePositions(self):
-        """Determine the position of every Page. 
-        
-        You should implement this method to perform a meaningful layout, which 
-        means setting the position of all the pages. This positions should 
+        """Determine the position of every Page.
+
+        You should implement this method to perform a meaningful layout, which
+        means setting the position of all the pages. This positions should
         respect the margin (and preferably also the spacing).
-        
+
         """
         top = self.margin
         for page in self:
@@ -205,15 +205,15 @@ class AbstractPageLayout(list):
             page.y = top
             top += page.height
             top += self.spacing
-    
+
     def computeSize(self):
         """Compute and set the total size of the layout.
-        
+
         In most cases the implementation of this method is sufficient: it
         computes the bounding rectangle of all Pages and adds the margin.
-        
+
         True is returned if the total size has changed.
-        
+
         """
         r = QRect()
         for page in self:
@@ -228,14 +228,14 @@ class AbstractPageLayout(list):
 
 class PageLayout(AbstractPageLayout):
     """A basic layout that shows pages from right to left or top to bottom.
-    
+
     Additional instance attribute:
-    
+
         `orientation`: Horizontal or Vertical (default)
-    
+
     """
     orientation = Vertical
-        
+
     def updatePagePositions(self):
         """Order our pages."""
         if self.orientation == Vertical:
@@ -256,19 +256,19 @@ class PageLayout(AbstractPageLayout):
 
 class RowPageLayout(AbstractPageLayout):
     """A layout that orders pages in rows.
-    
+
     Additional instance attributes:
-    
+
         `pagesPerRow`     = 2, the number of pages to display in a row
         `pagesFirstRow`   = 1, the number of pages to display in the first row
         `fitAllColumns`   = True, whether "fit width" uses all columns
-    
+
     """
-    
+
     pagesPerRow = 2
     pagesFirstRow = 1
     fitAllColumns = True
-    
+
     def zoomFitWidth(self, width):
         """Reimplemented to respect the fitAllColumns setting."""
         width -= self.margin * 2
@@ -276,7 +276,7 @@ class RowPageLayout(AbstractPageLayout):
             ncols = min(self.pagesPerRow, self.count())
             width = (width - self.spacing * (ncols - 1)) // ncols
         return self.widestPage().zoomForWidth(self, width)
-        
+
     def updatePagePositions(self):
         """Reimplemented to perform our positioning algorithm."""
         pages = list(self)
@@ -286,7 +286,7 @@ class RowPageLayout(AbstractPageLayout):
             pages[0:0] = [None] * ((cols - self.pagesFirstRow) % cols)
         else:
             cols = len(pages)
-        
+
         col_widths = []
         col_offsets = []
         offset = self.margin
@@ -295,7 +295,7 @@ class RowPageLayout(AbstractPageLayout):
             col_widths.append(width)
             col_offsets.append(offset)
             offset += width + self.spacing
-        
+
         top = self.margin
         for row in (pages[i:i + cols] for i in range(0, len(pages), cols or 1)):
             height = max(p.height for p in row if p)

--- a/frescobaldi_app/qpageview/locking.py
+++ b/frescobaldi_app/qpageview/locking.py
@@ -34,12 +34,12 @@ _lock = threading.RLock()
 
 def lock(item):
     """Return a threading.RLock instance for the given item.
-    
+
     Use:
-    
+
     with lock(document):
         do_something
-        
+
     """
     with _lock:
         try:

--- a/frescobaldi_app/qpageview/magnifier.py
+++ b/frescobaldi_app/qpageview/magnifier.py
@@ -36,61 +36,61 @@ DRAG_LONG  = 2      # remain visible and drag when picked up with the mouse
 
 class Magnifier(QWidget):
     """A Magnifier is added to a View with surface.setMagnifier().
-    
+
     It is shown when a mouse button is pressed together with a modifier
     (by default Ctrl). It can then be resized by moving the mouse is with
     two buttons pressed, or by wheeling with resizemodifier pressed.
-    
+
     Its size can be changed with resize() and the scale (defaulting to 3.0)
     with setScale().
-    
+
     If can also be shown programatically with the show() method. In this case
     it can be dragged with the left mouse button.
-    
+
     Wheel zooming with the modifier (by default Ctrl) zooms the magnifier.
-    
+
     Instance attributes:
-    
+
         showmodifier: the modifier to popup (Qt.ControlModifier)
-        
+
         zoommodifier: the modifier to wheel zoom (Qt.ControlModifier)
-        
+
         resizemodifier: the key to press for wheel resizing (Qt.ShiftModifier)
-        
+
         showbutton: the mouse button causing the magnifier to popup (by default
                     Qt.LeftButton)
-        
+
         resizebutton: the extra mouse button to be pressed when resizing the
                     magnifier (by default Qt.RightButton)
-        
+
         MAX_EXTRA_ZOOM: the maximum zoom (relative to the View's maximum zoom
                     level)
-        
-    
+
+
     """
-    
+
     # modifier for show
     showmodifier = Qt.ControlModifier
-    
+
     # modifier for wheel zoom
     zoommodifier = Qt.ControlModifier
-    
+
     # extra modifier for wheel resize
     resizemodifier = Qt.ShiftModifier
-    
+
     # button for show
     showbutton = Qt.LeftButton
-    
+
     # extra button for resizing
     resizebutton = Qt.RightButton
-    
+
     # Maximum extra zoom above the View.MAX_ZOOM
     MAX_EXTRA_ZOOM = 1.25
-    
+
     # Minimal size
     MIN_SIZE = 20
-    
-    
+
+
     def __init__(self):
         super().__init__()
         self._dragging = False
@@ -102,32 +102,32 @@ class Magnifier(QWidget):
         self.setBackgroundRole(QPalette.Dark)
         self.resize(250, 250)
         self.hide()
-        
+
     def moveCenter(self, pos):
         """Called by the View, centers the widget on the given QPoint."""
         r = self.geometry()
         r.moveCenter(pos)
         self.setGeometry(r)
-    
+
     def setScale(self, scale):
         """Sets the scale, relative to the dislayed size in the View."""
         self._scale = scale
         self.update()
-    
+
     def scale(self):
         """Returns the scale, defaulting to 3.0 (=300%)."""
         return self._scale
-    
+
     def resizeEvent(self, ev):
         """Called on resize, sets our circular mask."""
         self.setMask(QRegion(self.rect(), QRegion.Ellipse))
-        
+
     def eventFilter(self, viewport, ev):
         """Handles multiple events from the viewport.
-        
+
         * update on View scroll
         * show the magnifier on left click+modifier
-        
+
         """
         if ev.type() == QEvent.UpdateRequest:
             self.update()
@@ -176,7 +176,7 @@ class Magnifier(QWidget):
                     QCursor.setPos(viewport.mapToGlobal(self.geometry().center()))
                 return True
         return False
-    
+
     def mousePressEvent(self, ev):
         """Start dragging the magnifier."""
         ev.ignore() # don't propagate to view
@@ -184,7 +184,7 @@ class Magnifier(QWidget):
             self._dragging = DRAG_LONG
             self._dragpos = ev.pos()
             self.setCursor(Qt.ClosedHandCursor)
-    
+
     def mouseMoveEvent(self, ev):
         """Move the magnifier if we were dragging it."""
         ev.ignore() # don't propagate to view
@@ -193,7 +193,7 @@ class Magnifier(QWidget):
             self.move(pos - self._dragpos)
             view = self.parent().parent()
             view.scrollForDragging(pos)
-    
+
     def mouseReleaseEvent(self, ev):
         """The button is released, stop moving ourselves."""
         ev.ignore() # don't propagate to view
@@ -202,7 +202,7 @@ class Magnifier(QWidget):
             self.unsetCursor()
             view = self.parent().parent()
             view.stopScrolling() # just if needed
-    
+
     def wheelEvent(self, ev):
         """Implement zooming the magnifying glass."""
         if ev.modifiers() & self.zoommodifier:
@@ -220,29 +220,29 @@ class Magnifier(QWidget):
                 self.setScale(self._scale * factor)
         else:
             super().wheelEvent(ev)
-    
+
     def paintEvent(self, ev):
         """Called when paint is needed, finds out which page to magnify."""
         view = self.parent().parent()
         layout = view.pageLayout()
-        
+
         scale = max(min(self._scale, view.MAX_ZOOM * self.MAX_EXTRA_ZOOM / layout.zoomFactor), view.MIN_ZOOM / layout.zoomFactor)
-        
+
         # the position of our center on the layout
         c = self.rect().center() + self.pos() - view.layoutPosition()
-        
+
         # make a region scaling back to the view scale
         rect = QRect(0, 0, self.width() / scale, self.height() / scale)
         rect.moveCenter(c)
         region = QRegion(rect, QRegion.Ellipse) # touches the Pages we need to draw
-        
+
         # our rect on the enlarged pages
         our_rect = self.rect()
         our_rect.moveCenter(QPoint(c.x() * scale, c.y() * scale))
-        
+
         # the virtual position of the whole scaled-up layout
         ev_rect = ev.rect().translated(our_rect.topLeft())
-        
+
         painter = QPainter(self)
         for p in layout.pagesAt(region):
             # reuse the copy of the page if still existing
@@ -260,9 +260,9 @@ class Magnifier(QWidget):
             painter.translate(page.pos() - our_rect.topLeft())
             page.paint(painter, rect, self.repaintPage)
             painter.restore()
-            
+
         self.drawBorder(painter)
-    
+
     def drawBorder(self, painter):
         """Draw a nice looking glass border."""
         painter.setRenderHint(QPainter.Antialiasing, True)

--- a/frescobaldi_app/qpageview/page.py
+++ b/frescobaldi_app/qpageview/page.py
@@ -36,43 +36,43 @@ from .constants import (
 
 class AbstractPage:
     """A Page is a rectangle that is positioned in a PageLayout.
-    
-    A Page represents one page, added to a PageLayout that is displayed in a 
-    View. Although there is no mechanism to enforce it, a Page is normally only 
+
+    A Page represents one page, added to a PageLayout that is displayed in a
+    View. Although there is no mechanism to enforce it, a Page is normally only
     used in one PageLayout at a time.
-    
+
     A Page has instance attributes...
-    
+
     ...that normally do not change during its lifetime:
-    
+
         `pageWidth`     the original width in points (1/72 inch)
         `pageHeight`    the original height in points (1/72 inch)
-    
+
     ... that can be modified by the user (having defaults at the class level):
-    
+
         `rotation`      the rotation (Rotate_0)
         `scaleX`        the scale in X-direction (1.0)
         `scaleY`        the scale in Y-direction (1.0)
         `paperColor`    the paper color (None). If None, the renderer's
                         paperColor is used.
-        
+
     ... and that are set by the layout when computing the size and positioning
         the pages:
-    
+
         `x`             the position x-coordinate
         `y`             the position y-coordinate
         `width`         the width in pixels
         `height`        the height in pixels
         `computedRotation` the rotation in which finally to render
-    
+
     A page is rendered by a renderer, which can live in a class
     or instance attribute.
-    
-        
+
+
     """
-    
+
     renderer = None
-    
+
     rotation = Rotate_0
     scaleX = 1.0
     scaleY = 1.0
@@ -86,33 +86,33 @@ class AbstractPage:
         self.pageWidth = 0.0
         self.pageHeight = 0.0
         self.computedRotation = Rotate_0
-    
+
     def copy(self):
         """Return a copy of the page with the same instance attributes."""
         return copy.copy(self)
-        
+
     def rect(self):
         """Return our QRect(), with position and size."""
         return QRect(self.x, self.y, self.width, self.height)
-    
+
     def setPos(self, point):
         """Set our position (QPoint).
-        
+
         Normally this is done by the layout in the updatePagePositions() method.
-        
+
         """
         self.x = point.x()
         self.y = point.y()
-    
+
     def pos(self):
         """Return our position (QPoint)."""
         return QPoint(self.x, self.y)
-    
+
     def setSize(self, size):
         """Set our size (QSize).
-        
+
         Normally this is done by the layout in the updateSizeFromLayout() method.
-        
+
         """
         self.width = size.width()
         self.height = size.height()
@@ -120,51 +120,51 @@ class AbstractPage:
     def size(self):
         """Return our size (QSize)."""
         return QSize(self.width, self.height)
-    
+
     def setPageSize(self, sizef):
         """Set our natural page size (QSizeF).
-        
+
         This value is only used in the computeSize() method, to get the size
         in pixels of the page.
-        
+
         By the default implementation of computeSize(), the page size is assumed
         to be in points, 1/72 of an inch.
-        
+
         """
         self.pageWidth = sizef.width()
         self.pageHeight = sizef.height()
-    
+
     def pageSize(self):
         """Return our natural page size (QSizeF).
-        
+
         This value is only used in the computeSize() method, to get the size
         in pixels of the page.
-        
+
         By the default implementation of computeSize(), the page size is assumed
         to be in points, 1/72 of an inch.
-        
+
         """
         return QSizeF(self.pageWidth, self.pageHeight)
-    
+
     def updateSizeFromLayout(self, layout):
         """Compute and set the size() of the page.
-        
+
         This method is called on layout update by the updatePageSizes method.
-        The default implementation takes into account our pageSizeF(), scale 
-        and rotation, and then the rotation, scale, DPI and zoom factor of 
+        The default implementation takes into account our pageSizeF(), scale
+        and rotation, and then the rotation, scale, DPI and zoom factor of
         the layout. It uses the computeSize() method to perform the calculation.
-        
+
         """
         self.computedRotation = rotation = (self.rotation + layout.rotation) & 3
         self.width, self.height = self.computeSize(
             rotation, layout.dpiX, layout.dpiY, layout.zoomFactor)
-    
+
     def computeSize(self, rotation, dpiX, dpiY, zoomFactor):
         """Return a tuple (w, h) representing the size of the page in pixels.
-        
+
         This size is computed based on the page's natural size, its scale and
         the specified rotation, dpi, scale and zoomFactor.
-        
+
         """
         w = self.pageWidth * self.scaleX
         h = self.pageHeight * self.scaleY
@@ -182,7 +182,7 @@ class AbstractPage:
         else:
             w = self.pageWidth / self.scaleX
         return width * 72.0 / layout.dpiX / w
-        
+
     def zoomForHeight(self, layout, height):
         """Return the zoom we need to display ourselves at the given height."""
         if (self.rotation + layout.rotation) & 1:
@@ -190,25 +190,25 @@ class AbstractPage:
         else:
             h = self.pageHeight / self.scaleY
         return height * 72.0 / layout.dpiY / h
-    
+
     def paint(self, painter, rect, callback=None):
         """Reimplement this to paint our Page.
-        
+
         The View calls this method in the paint event. If you can't paint
         quickly, just return and schedule an image to be rendered in the
         background. If a callback is specified, it is called when the image
         is ready with the page as argument.
-        
+
         By default, this method calls the renderer's paint() method.
-        
+
         """
         self.renderer and self.renderer.paint(self, painter, rect, callback)
 
     def mutex(self):
         """Return an object that should be locked when rendering the page.
-        
+
         Page are guaranteed not to be rendered at the same time when they
         return the same mutex object. By default, None is returned.
-        
+
         """
 

--- a/frescobaldi_app/qpageview/poppler.py
+++ b/frescobaldi_app/qpageview/poppler.py
@@ -39,12 +39,12 @@ from .constants import (
 
 class PopplerPage(page.AbstractPage):
     """A Page capable of displaying one page of a Poppler.Document instance.
-    
+
     It has two additional instance attributes:
-    
+
         `document`: the Poppler.Document instance
         `pageNumber`: the page number to render
-        
+
     """
     def __init__(self, document, pageNumber, renderer=None):
         super().__init__()
@@ -53,14 +53,14 @@ class PopplerPage(page.AbstractPage):
         self.setPageSize(document.page(pageNumber).pageSizeF())
         if renderer is not None:
             self.renderer = renderer
-        
+
     @classmethod
     def createPages(cls, document, renderer=None):
         """Convenience class method returning a list of instances of this class.
-        
+
         The Page instances are created from the document, in page number order.
         The specified Renderer is used, or else the global poppler renderer.
-        
+
         """
         return [cls(document, num, renderer) for num in range(document.numPages())]
 
@@ -76,7 +76,7 @@ class Renderer(render.AbstractImageRenderer):
     )
     renderBackend = popplerqt5.Poppler.Document.SplashBackend
     oversampleThreshold = 96
-    
+
     def key(self, page):
         """Reimplemented to keep a reference to the poppler document."""
         key = super().key(page)
@@ -84,7 +84,7 @@ class Renderer(render.AbstractImageRenderer):
             page.document,
             (page.pageNumber, page.computedRotation),
             key.size)
-    
+
     def render(self, page):
         """Generate an image for this Page."""
         doc = page.document
@@ -106,16 +106,16 @@ class Renderer(render.AbstractImageRenderer):
         image.setDotsPerMeterX(xres * 39.37)
         image.setDotsPerMeterY(yres * 39.37)
         return image
-    
+
     def render_poppler_image(self, doc, pageNum,
                                    xres=72.0, yres=72.0,
                                    x=-1, y=-1, w=-1, h=-1, rotate=Rotate_0,
                                    paperColor=None):
         """Render an image, almost like calling page.renderToImage().
-        
+
         The document is properly locked during rendering and render options
         are set.
-        
+
         """
         with locking.lock(doc):
             if self.renderHint is not None:

--- a/frescobaldi_app/qpageview/rubberband.py
+++ b/frescobaldi_app/qpageview/rubberband.py
@@ -39,22 +39,22 @@ _INSIDE  = 15
 
 class Rubberband(QWidget):
     """A Rubberband to select a rectangular region.
-    
+
     Instance variables:
-        
+
         showbutton (Qt.RightButton), the button used to drag a new rectangle
-        
+
         dragbutton (Qt.LeftButton), the button to alter an existing rectangle
-    
+
     """
-    
+
     # the button used to drag a new rectangle
     showbutton = Qt.RightButton
-    
+
     # the button to alter an existing rectangle
     dragbutton = Qt.LeftButton
-    
-    
+
+
     def __init__(self):
         super().__init__()
         self._dragging = False
@@ -91,7 +91,7 @@ class Rubberband(QWidget):
         # Clip middles
         region += QRect(0, self.rect().height() // 2 - 10, self.rect().width(), 20)
         region += QRect(self.rect().width() // 2 - 10, 0, 20, self.rect().height())
-        
+
         # Draw thicker rectangles, clipped at corners and sides.
         painter.setClipRegion(region)
         painter.drawRect(self.rect())
@@ -129,7 +129,7 @@ class Rubberband(QWidget):
             self.setCursor(cursor)
         else:
             self.unsetCursor()
-    
+
     def scrollBy(self, diff):
         """Called by the View when scrolling."""
         if not self._dragging:
@@ -137,7 +137,7 @@ class Rubberband(QWidget):
         elif self._dragedge != _INSIDE:
             self._draggeom.moveTo(self._draggeom.topLeft() + diff)
             self.dragBy(-diff)
-        
+
     def startDrag(self, pos, button):
         """Start dragging the rubberband."""
         self._dragging = True
@@ -145,7 +145,7 @@ class Rubberband(QWidget):
         self._dragedge = self.edge(pos)
         self._draggeom = self.geometry()
         self._dragbutton = button
-    
+
     def drag(self, pos):
         """Continue dragging the rubberband, scrolling the View if necessary."""
         diff = pos - self._dragpos
@@ -170,20 +170,20 @@ class Rubberband(QWidget):
             # we're dragging a corner, use correct diagonal cursor
             bdiag = (edge in (3, 12)) ^ (self._draggeom.width() * self._draggeom.height() >= 0)
             self.setCursor(Qt.SizeBDiagCursor if bdiag else Qt.SizeFDiagCursor)
-    
+
     def stopDrag(self):
         """Stop dragging the rubberband. Return True if a rectangle was drawn."""
         self._dragging = False
         # TODO: use the kinetic scroller if implemented
         view = self.parent().parent()
         view.stopScrolling()
-        
+
         if self.width() < 8 and self.height() < 8:
             self.unsetCursor()
             self.hide()
             return False
         return True
-    
+
     def eventFilter(self, viewport, ev):
         if not self._dragging:
             if ev.type() == QEvent.MouseButtonPress and ev.button() == self.showbutton:
@@ -202,7 +202,7 @@ class Rubberband(QWidget):
                 # don't consume event when the right button was used
                 return self._dragbutton != Qt.RightButton
         return False
-    
+
     def mousePressEvent(self, ev):
         pos = self.mapToParent(ev.pos())
         if not self._dragging:
@@ -211,7 +211,7 @@ class Rubberband(QWidget):
             elif ev.button() == self.showbutton:
                 if self.showbutton != Qt.RightButton or self.edge(pos) != _INSIDE:
                     self.startDrag(pos, ev.button())
-    
+
     def mouseMoveEvent(self, ev):
         pos = self.mapToParent(ev.pos())
         if self._dragging:
@@ -219,7 +219,7 @@ class Rubberband(QWidget):
         else:
             edge = self.edge(pos)
             self.adjustCursor(edge)
-    
+
     def mouseReleaseEvent(self, ev):
         if self._dragging and ev.button() == self._dragbutton:
             self.stopDrag()

--- a/frescobaldi_app/qpageview/svg.py
+++ b/frescobaldi_app/qpageview/svg.py
@@ -43,7 +43,7 @@ class BasicSvgPage(page.AbstractPage):
         self._svg_r = QSvgRenderer()
         if load_file:
             self.load(load_file)
-    
+
     def load(self, load_file):
         """Load filename or QByteArray."""
         success = self._svg_r.load(load_file)
@@ -51,7 +51,7 @@ class BasicSvgPage(page.AbstractPage):
             self.pageWidth = self._svg_r.defaultSize().width()
             self.pageHeight = self._svg_r.defaultSize().height()
         return success
-    
+
     def paint(self, painter, rect, callback=None):
         painter.fillRect(rect, self.paperColor or QColor(Qt.white))
         page = QRect(0, 0, self.width, self.height)
@@ -69,22 +69,22 @@ class SvgPage(BasicSvgPage):
         super().__init__(load_file)
         if renderer is not None:
             self.renderer = renderer
-    
+
     def paint(self, painter, rect, callback=None):
         self.renderer.paint(self, painter, rect, callback)
 
 
 class Renderer(render.AbstractImageRenderer):
     """Render SVG pages.
-    
+
     Additional instance attributes:
-        
+
         imageFormat     (QImage.Format_ARGB32_Premultiplied) the QImage format to use.
-    
+
     """
     # QImage format to use
     imageFormat = QImage.Format_ARGB32_Premultiplied
-    
+
     def render(self, page):
         """Generate an image for this Page."""
         i = QImage(page.width, page.height, self.imageFormat)
@@ -98,11 +98,11 @@ class Renderer(render.AbstractImageRenderer):
         painter.translate(-rect.center())
         page._svg_r.render(painter, QRectF(rect))
         return i
-    
+
 
 # install a default renderer, so PopplerPage can be used directly
 SvgPage.renderer = Renderer()
 
 
 
-    
+

--- a/frescobaldi_app/qpopplerview/cache.py
+++ b/frescobaldi_app/qpopplerview/cache.py
@@ -58,7 +58,7 @@ def setmaxsize(maxsize):
     global _maxsize
     _maxsize = maxsize * 1048576
     purge()
-    
+
 
 def maxsize():
     """Returns the maximum cache size in Megabytes."""
@@ -80,16 +80,16 @@ def clear(document=None):
 
 def image(page, exact=True):
     """Returns a rendered image for given Page if in cache.
-    
+
     If exact is True (default), the function returns None if the exact size was
     not in the cache. If exact is False, the function may return a temporary
     rendering of the page scaled from a different size, if that was available.
-    
+
     """
     document = page.document()
     pageKey = (page.pageNumber(), page.rotation())
     sizeKey = (page.physWidth(), page.physHeight())
-    
+
     if exact:
         try:
             entry = _cache[document][pageKey][sizeKey]
@@ -125,7 +125,7 @@ def add(image, document, pageNumber, rotation, width, height):
     pageKey = (pageNumber, rotation)
     sizeKey = (width, height)
     _cache.setdefault(document, {}).setdefault(pageKey, {})[sizeKey] = [image, time.time()]
-    
+
     # maintain cache size
     global _maxsize, _currentsize
     _currentsize += image.byteCount()
@@ -135,9 +135,9 @@ def add(image, document, pageNumber, rotation, width, height):
 
 def purge():
     """Removes old images from the cache to limit the space used.
-    
+
     (Not necessary to call, as the cache will monitor its size automatically.)
-    
+
     """
     # make a list of the images, sorted on time, newest first
     images = iter(sorted((
@@ -192,9 +192,9 @@ def options(document=None):
 
 def setoptions(options, document=None):
     """Sets a RenderOptions instance for the given document or as the global one if no document is given.
-    
+
     Use None for the options to unset (delete) the options.
-    
+
     """
     global _globaloptions, _options
     if not document:
@@ -215,13 +215,13 @@ class Scheduler(object):
         self._jobs = {}         # jobs on key
         self._waiting = weakref.WeakKeyDictionary()      # jobs on page
         self._running = None
-        
+
     def schedulejob(self, page):
         """Creates or retriggers an existing Job.
-        
+
         If a Job was already scheduled for the page, it is canceled.
         The page's update() method will be called when the Job has completed.
-        
+
         """
         # uniquely identify the image to be generated
         key = (page.pageNumber(), page.rotation(), page.physWidth(), page.physHeight())
@@ -235,7 +235,7 @@ class Scheduler(object):
         self._schedule.append(job)
         self._waiting[page] = job
         self.checkStart()
-        
+
     def checkStart(self):
         """Starts a job if none is running and at least one is waiting."""
         while self._schedule and not self._running:
@@ -246,7 +246,7 @@ class Scheduler(object):
                 break
             else:
                 self.done(job)
-            
+
     def done(self, job):
         """Called when the job has completed."""
         del self._jobs[job.key]
@@ -277,7 +277,7 @@ class Runner(QThread):
         self.document = document # keep reference now so that it does not die during this thread
         self.finished.connect(self.slotFinished)
         self.start()
-        
+
     def run(self):
         """Main method of this thread, called by Qt on start()."""
         page = self.document.page(self.job.pageNumber)
@@ -302,7 +302,7 @@ class Runner(QThread):
                        _("Failed to render page") );
         elif multiplier == 2:
             self.image = self.image.scaledToWidth(self.job.width, Qt.SmoothTransformation)
-        
+
     def slotFinished(self):
         """Called when the thread has completed."""
         add(self.image, self.document, self.job.pageNumber, self.job.rotation, self.job.width, self.job.height)

--- a/frescobaldi_app/qpopplerview/highlight.py
+++ b/frescobaldi_app/qpopplerview/highlight.py
@@ -28,31 +28,31 @@ from PyQt5.QtWidgets import QApplication
 
 class Highlighter(object):
     """A Highlighter can draw rectangles to highlight e.g. links in a Poppler.Document.
-    
+
     An instance represents a certain type of highlighting, e.g. of a particular style.
     The paintRects() method is called with a list of rectangles that need to be drawn.
-    
+
     To implement different highlighting behaviour just inherit paintRects().
     The default implementation of paintRects() uses the color() method to get the
     color to use and the lineWidth (default: 2) and radius (default: 3) class attributes.
-    
+
     lineWidth specifies the thickness in pixels of the border drawn,
     radius specifies the distance in pixels the border is drawn (by default with rounded corners)
     around the area to be highlighted.
-    
+
     """
-    
+
     lineWidth = 2
     radius = 3
-    
+
     def color(self):
         """The default paintRects() method uses this method to return the color to use.
-        
+
         By default the application's palette highlight color is returned.
-        
+
         """
         return QApplication.palette().highlight().color()
-    
+
     def paintRects(self, painter, rects):
         """Override this method to implement different drawing behaviour."""
         pen = QPen(self.color())

--- a/frescobaldi_app/qpopplerview/layout.py
+++ b/frescobaldi_app/qpopplerview/layout.py
@@ -38,17 +38,17 @@ from . import (
 
 class AbstractLayout(QObject):
     """Manages page.Page instances with a list-like api.
-    
+
     You can iterate over the layout itself, which yields all Page instances.
     You can also iterate over pages(), which only yields the Page instances
     that are visible().
-    
+
     """
-    
+
     redraw = pyqtSignal(QRect)
     changed = pyqtSignal()
     scaleChanged = pyqtSignal(float)
-    
+
     def __init__(self):
         super(AbstractLayout, self).__init__()
         self._pages = []
@@ -58,57 +58,57 @@ class AbstractLayout(QObject):
         self._scale = 1.0
         self._scaleChanged = False
         self._dpi = (72, 72)
-        
+
     def own(self, page):
         """(Internal) Makes the page have ourselves as layout."""
         if page.layout():
             page.layout().remove(page)
         page._layout = weakref.ref(self)
         page.computeSize()
-    
+
     def disown(self, page):
         """(Internal) Removes ourselves as owner of the page."""
         page._layout = lambda: None
-        
+
     def append(self, page):
         self.own(page)
         self._pages.append(page)
-        
+
     def insert(self, position, page):
         self.own(page)
         self._pages.insert(position, page)
-    
+
     def extend(self, pages):
         for page in pages:
             self.append(page)
-            
+
     def remove(self, page):
         self._pages.remove(page)
         self.disown(page)
-    
+
     def pop(self, index=None):
         page = self._pages.pop(index)
         self.disown(page)
         return page
-    
+
     def clear(self):
         del self[:]
-    
+
     def count(self):
         return len(self._pages)
-        
+
     def __len__(self):
         return len(self._pages)
-    
+
     def __bool__(self):
         return True
-    
+
     def __contains__(self, page):
         return page in self._pages
-    
+
     def __getitem__(self, item):
         return self._pages[item]
-        
+
     def __delitem__(self, item):
         if isinstance(item, slice):
             for page in self._pages[item]:
@@ -116,7 +116,7 @@ class AbstractLayout(QObject):
         else:
             self.disown(self._pages[item])
         del self._pages[item]
-    
+
     def __setitem__(self, item, new):
         if isinstance(item, slice):
             old = self._pages[item]
@@ -129,41 +129,41 @@ class AbstractLayout(QObject):
             self.disown(self._pages[item])
             self._pages[item] = new
             self.own(new)
-    
+
     def index(self, page):
         """Returns the index at which the given Page can be found in our Layout."""
         return self._pages.index(page)
-        
+
     def setSize(self, size):
         """Sets our size. Mainly done after layout."""
         self._size = size
-        
+
     def size(self):
         """Returns our size as QSize()."""
         return self._size
-    
+
     def width(self):
         """Returns our width."""
         return self._size.width()
-    
+
     def height(self):
         """Returns our height."""
         return self._size.height()
-    
+
     def setDPI(self, xdpi, ydpi=None):
         """Sets our DPI in X and Y direction. If Y isn't given, uses the X value."""
         self._dpi = xdpi, ydpi or xdpi
         for page in self:
             page.computeSize()
-    
+
     def dpi(self):
         """Returns our DPI as a tuple(XDPI, YDPI)."""
         return self._dpi
-        
+
     def scale(self):
         """Returns the scale (1.0 == 100%)."""
         return self._scale
-    
+
     def setScale(self, scale):
         """Sets the scale (1.0 == 100%) of all our Pages."""
         if scale != self._scale:
@@ -171,51 +171,51 @@ class AbstractLayout(QObject):
             for page in self:
                 page.setScale(scale)
             self._scaleChanged = True
-    
+
     def setPageWidth(self, width, sameScale=True):
         """Sets the width of all pages.
-        
+
         If sameScale is True (default), the largest page will be scaled to the given
         width (minus margin).  All pages will then be scaled to that scale.
         If sameScale is False all pages will be scaled individually to the same width.
-        
+
         """
         if sameScale and any(self.pages()):
             self.setScale(self.widest().scaleForWidth(width))
         else:
             for page in self:
                 page.setWidth(width)
-    
+
     def setPageHeight(self, height, sameScale=True):
         """Sets the height of all pages.
-        
+
         If sameScale is True (default), the largest page will be scaled to the given
         height (minus margin).  All pages will then be scaled to that scale.
         If sameScale is False all pages will be scaled individually to the same height.
-        
+
         """
         if sameScale and any(self.pages()):
             self.setScale(self.highest().scaleForWidth(height))
         else:
             for page in self:
                 page.setHeight(height)
-            
+
     def setMargin(self, margin):
         """Sets the margin around the pages in pixels."""
         self._margin = margin
-        
+
     def margin(self):
         """Returns the margin around the pages in pixels."""
         return self._margin
-        
+
     def setSpacing(self, spacing):
         """Sets the space between the pages in pixels."""
         self._spacing = spacing
-        
+
     def spacing(self):
         """Returns the space between the pages in pixels."""
         return self._spacing
-        
+
     def fit(self, size, mode):
         """Fits the layout in the given ViewMode."""
         if mode and any(self.pages()):
@@ -225,25 +225,25 @@ class AbstractLayout(QObject):
             if mode & FitHeight:
                 scales.append(self.scaleFitHeight(size.height()))
             self.setScale(min(scales))
-    
+
     def scaleFitHeight(self, height):
         """Return the scale this layout would need to fit in the height.
-        
+
         This method is called by fit().
         The default implementation returns a suitable scale for the highest Page.
-        
+
         """
         return self.highest().scaleForHeight(height - self.margin() * 2)
-    
+
     def scaleFitWidth(self, width):
         """Return the scale this layout would need to fit in the width.
-        
+
         This method is called by fit().
         The default implementation returns a suitable scale for the widest Page.
-        
+
         """
         return self.widest().scaleForWidth(width - self.margin() * 2)
-            
+
     def update(self):
         """Performs the layout (positions the Pages and adjusts our size)."""
         self.reLayout()
@@ -251,25 +251,25 @@ class AbstractLayout(QObject):
             self.scaleChanged.emit(self._scale)
             self._scaleChanged = False
         self.changed.emit()
-        
+
     def reLayout(self):
         """This is called by update().
-        
+
         You must implement this method to position the Pages and adjust our size.
         See Layout for a possible implementation.
-        
+
         """
         pass
-    
+
     def updatePage(self, page):
         """Called by the Page when an image has been generated."""
         self.redraw.emit(page.rect())
-        
+
     def page(self, document, pageNumber):
         """Returns the page (visible or not) from a Poppler.Document with page number.
-        
+
         Returns None if that page is not available.
-        
+
         """
         # Specific layouts may use faster algorithms to find the page.
         try:
@@ -282,27 +282,27 @@ class AbstractLayout(QObject):
         for page in self:
             if page.document() == document and page.pageNumber() == pageNumber:
                 return page
-    
+
     def pages(self):
         """Yields our pages that are visible()."""
         for page in self:
             if page.visible():
                 yield page
-        
+
     def pageAt(self, point):
         """Returns the page that contains the given QPoint."""
         # Specific layouts may use faster algorithms to find the page.
         for page in self.pages():
             if page.rect().contains(point):
                 return page
-    
+
     def pagesAt(self, rect):
         """Yields the pages touched by the given QRect."""
         # Specific layouts may use faster algorithms to find the pages.
         for page in self.pages():
             if page.rect().intersects(rect):
                 yield page
-        
+
     def linkAt(self, point):
         """Returns (page, link) if pos points to a Poppler.Link in a Page, else (None, None)."""
         page = self.pageAt(point)
@@ -311,29 +311,29 @@ class AbstractLayout(QObject):
             if links:
                 return page, links[0]
         return None, None
-        
+
     def widest(self):
         """Returns the widest visible page (in its natural page size)."""
         pages = list(self.pages())
         if pages:
             return max(pages, key = lambda p: p.pageSize().width())
-            
+
     def highest(self):
         """Returns the highest visible page (in its natural page size)."""
         pages = list(self.pages())
         if pages:
             return max(pages, key = lambda p: p.pageSize().height())
-    
+
     def maxWidth(self):
         """Returns the width of the widest visible page."""
         page = self.widest()
         return page.width() if page else 0
-        
+
     def maxHeight(self):
         """Returns the height of the highest visible page."""
         page = self.highest()
         return page.height() if page else 0
-        
+
     def load(self, document):
         """Convenience method to load all the pages of the given Poppler.Document using page.Page()."""
         self.clear()
@@ -348,15 +348,15 @@ class Layout(AbstractLayout):
     def __init__(self):
         super(Layout, self).__init__()
         self._orientation = Qt.Vertical
-        
+
     def setOrientation(self, orientation):
         """Sets our orientation to either Qt.Vertical or Qt.Horizontal."""
         self._orientation = orientation
-        
+
     def orientation(self):
         """Returns our orientation (either Qt.Vertical or Qt.Horizontal)."""
         return self._orientation
-    
+
     def reLayout(self):
         """Orders our pages."""
         if self._orientation == Qt.Vertical:
@@ -375,7 +375,7 @@ class Layout(AbstractLayout):
                 left += page.width() + self._spacing
             left += self._margin - self._spacing
             self.setSize(QSize(left, height))
-            
+
 
 class RowLayout(AbstractLayout):
     """A layout that orders pages in rows."""
@@ -384,41 +384,41 @@ class RowLayout(AbstractLayout):
         self._npages = 2
         self._npages_first = 1
         self._fit_width_uses_all_columns = True
-    
+
     def setPagesPerRow(self, n):
         """Set the number of pages to show per row."""
         self._npages = n
-    
+
     def pagesPerRow(self):
         """Return the number of pages to show per row."""
         return self._npages
-    
+
     def setPagesFirstRow(self, n):
         """Set the number of pages to show in the first row."""
         self._npages_first = n
-    
+
     def pagesFirstRow(self):
         """Return the number of pages to show in the first row."""
         return self._npages_first
-    
+
     def setFitWidthUsesAllColumns(self, allcols):
         """Set "Fit Width uses all columns" to True or False.
-        
+
         If True, the FitWidth view mode tries to display all columns in the
         requested width. If False, the widest Page determines the used scale.
-        
+
         The default setting is True.
-        
+
         """
         self._fit_width_uses_all_columns = allcols
-    
+
     def fitFitWidthUsesAllColumns(self):
         """Return whether the Fit Width view mode displays all columns in the
         requested width.
-        
+
         """
         return self._fit_width_uses_all_columns
-    
+
     def scaleFitWidth(self, width):
         """Reimplemented to respect the fitFitWidthUsesAllColumns() setting."""
         width -= self.margin() * 2
@@ -426,7 +426,7 @@ class RowLayout(AbstractLayout):
             ncols = min(self._npages, self.count())
             width = (width - self.spacing() * (ncols - 1)) // ncols
         return self.widest().scaleForWidth(width)
-        
+
     def reLayout(self):
         pages = list(self.pages())
         cols = self._npages
@@ -435,7 +435,7 @@ class RowLayout(AbstractLayout):
             pages[0:0] = [None] * ((cols - self._npages_first) % cols)
         else:
             cols = len(pages)
-        
+
         col_widths = []
         col_offsets = []
         offset = self._margin
@@ -448,7 +448,7 @@ class RowLayout(AbstractLayout):
         total_width = offset + self._margin
         if col != -1:
             total_width -= self._spacing
-        
+
         top = self._margin
         x = -1
         for row in (pages[i:i + cols] for i in range(0, len(pages), cols or 1)):

--- a/frescobaldi_app/qpopplerview/locking.py
+++ b/frescobaldi_app/qpopplerview/locking.py
@@ -31,12 +31,12 @@ _lock = threading.RLock()
 
 def lock(document):
     """Returns a threading.RLock instance for the given Poppler.Document.
-    
+
     Use:
-    
+
     with lock(document):
         do_something
-        
+
     """
     with _lock:
         try:

--- a/frescobaldi_app/qpopplerview/magnifier.py
+++ b/frescobaldi_app/qpopplerview/magnifier.py
@@ -33,49 +33,49 @@ from . import cache
 
 class Magnifier(QWidget):
     """A Magnifier is added to a Surface with surface.setMagnifier().
-    
+
     It is shown when a mouse button is pressed together with a modifier
     (by default Ctrl, see surface.py).
-    
+
     Its size can be changed with resize() and the scale (defaulting to 4.0)
     with setScale().
-    
+
     """
-    
+
     # Maximum extra zoom above the View.MAX_ZOOM
     MAX_EXTRA_ZOOM = 1.25
-    
+
     def __init__(self, parent = None):
         super(Magnifier, self).__init__(parent)
         self._page= None
         self.setScale(4.0)
         self.resize(250, 250)
         self.hide()
-        
+
     def moveCenter(self, pos):
         """Called by the surface, centers the widget on the given QPoint."""
         r = self.geometry()
         r.moveCenter(pos)
         r.translate(self.parent().surface().pos())
         self.setGeometry(r)
-    
+
     def setScale(self, scale):
         """Sets the scale, relative to the 100% size of a Page.
-        
+
         Uses the dpi() from the layout (pageLayout()) of the surface.
-        
+
         """
         self._scale = scale
         self.update()
-    
+
     def scale(self):
         """Returns the scale, defaulting to 4.0 (=400%)."""
         return self._scale
-    
+
     def resizeEvent(self, ev):
         """Called on resize, sets our circular mask."""
         self.setMask(QRegion(self.rect(), QRegion.Ellipse))
-        
+
     def paintEvent(self, ev):
         """Called when paint is needed, finds out which page to magnify."""
         layout = self.parent().surface().pageLayout()
@@ -84,7 +84,7 @@ class Magnifier(QWidget):
         if not page:
             return
         pagePos = pos - page.pos()
-        
+
         max_zoom = self.parent().surface().view().MAX_ZOOM * self.MAX_EXTRA_ZOOM
         newPage = Page(page, min(max_zoom, self._scale * page.scale()))
         if not newPage.same_page(self._page):
@@ -92,14 +92,14 @@ class Magnifier(QWidget):
                 self._page.magnifier = None
             self._page = newPage
             self._page.magnifier = self
-        
+
         relx = pagePos.x() / float(page.width())
         rely = pagePos.y() / float(page.height())
-        
+
         image = cache.image(self._page)
         img_rect = QRect(self.rect())
         img_rect.setSize( img_rect.size()*self._page._retinaFactor );
-        
+
         if not image:
             cache.generate(self._page)
             image = cache.image(self._page, False)
@@ -117,10 +117,10 @@ class Magnifier(QWidget):
 
 class Page(object):
     """A data structure describing a Page like page.Page.
-    
+
     Has the methods the cache needs to create, store and find images
     for our magnifier.
-    
+
     """
     def __init__(self, page, scale):
         """Creates Page, based on the page.Page object and the scale."""
@@ -133,7 +133,7 @@ class Page(object):
         self._retinaFactor = page._retinaFactor
         self._rotation = page.rotation()
         self.magnifier = None
-        
+
     def same_page(self, other):
         return (
             other is not None and
@@ -146,13 +146,13 @@ class Page(object):
 
     def document(self):
         return self._document()
-    
+
     def pageNumber(self):
         return self._pageNumber
-    
+
     def width(self):
         return self._width
-    
+
     def height(self):
         return self._height
 
@@ -161,10 +161,10 @@ class Page(object):
 
     def physHeight(self):
         return self._height*self._retinaFactor
-    
+
     def rotation(self):
         return self._rotation
-    
+
     def update(self):
         if self.magnifier:
             self.magnifier.update()

--- a/frescobaldi_app/qpopplerview/pager.py
+++ b/frescobaldi_app/qpopplerview/pager.py
@@ -28,19 +28,19 @@ from PyQt5.QtCore import pyqtSignal, QEvent, QTimer, QObject
 
 class Pager(QObject):
     """Provides an interface for paging in a View by page number.
-    
+
     Pages are numbered starting with 1 in this api!
-    
+
     """
     currentPageChanged = pyqtSignal(int)
     pageCountChanged = pyqtSignal(int)
-    
+
     def __init__(self, view):
         """Initializes the Pager with the View.
-        
+
         Also connects with the Surface of the View and its Layout,
         so don't interchange them after initializing the Pager.
-        
+
         """
         super(Pager, self).__init__(view)
         self._currentPage = 0
@@ -49,19 +49,19 @@ class Pager(QObject):
         self._pageNumSet = False
         self._updateTimer = QTimer(
             singleShot=True, interval=100, timeout=self._updatePageNumber)
-        
+
         # connect
         view.installEventFilter(self)
         view.surface().installEventFilter(self)
         view.surface().pageLayout().changed.connect(self._layoutChanged)
-        
+
         # Connect to the kineticScrollingEnabled signal to avoid unneeded updates.
         view.kineticScrollingActive.connect(self.blockListening)
-        
+
     def currentPage(self):
         """Returns the current page number (0 if there are no pages)."""
         return self._currentPage
-        
+
     def setCurrentPage(self, num):
         """Shows the specified page number."""
         changed, self._currentPage = self._currentPage != num, num
@@ -71,14 +71,14 @@ class Pager(QObject):
         self.blockListening(False)
         if changed:
             self.currentPageChanged.emit(self._currentPage)
-        
+
     def pageCount(self):
         """Returns the number of pages."""
         return self._pageCount
-    
+
     def view(self):
         return self.parent()
-    
+
     def _layoutChanged(self):
         """Called internally whenever the layout is updated."""
         layout = self.view().surface().pageLayout()
@@ -86,7 +86,7 @@ class Pager(QObject):
         if old != self._pageCount:
             self.pageCountChanged.emit(self._pageCount)
         self._updatePageNumber()
-    
+
     def _updatePageNumber(self):
         """Called internally on layout change or view resize or surface move."""
         self._currentPage, old = self.view().currentPageNumber() + 1, self._currentPage
@@ -99,13 +99,13 @@ class Pager(QObject):
     def blockListening(self, block):
         """Block/unblock listening to event, used to avoid multiple updates when we know lots
         of events are going to be sent to the pager.
-        
+
         Blocking can be nested, only the outermost unblock will really unblock the event processing."""
         if block:
             self._blockLevel += 1
         else:
             self._blockLevel -= 1
-        
+
         if self._blockLevel == 0:
             if self._pageNumSet:
                 self._pageNumSet = False

--- a/frescobaldi_app/qpopplerview/popplerqt5_dummy.py
+++ b/frescobaldi_app/qpopplerview/popplerqt5_dummy.py
@@ -37,7 +37,7 @@ class _noinst(object):
     """A class that can't be instantiated."""
     def __new__(cls, *args, **kwargs):
         raise TypeError("can't instantiate %s" % cls.__name__)
-        
+
 
 class Poppler(_noinst):
     class Document(_noinst):
@@ -49,42 +49,42 @@ class Poppler(_noinst):
         Antialiasing = RenderHint(1)
         TextAntialiasing = RenderHint(2)
         TextHinting = RenderHint(4)
-        
+
     class Page(_noinst):
         class Orientation(int): pass
         Landscape = Orientation(0)
         Portrait = Orientation(1)
         Seascape = Orientation(2)
         UpsideDown = Orientation(3)
-        
+
         class PageAction(int): pass
         Opening = PageAction(0)
         Closing = PageAction(1)
-        
+
         class PainterFlag(int): pass
         DontSaveAndRestore = PainterFlag(1)
-        
+
         class Rotation(int): pass
         Rotate0 = Rotation(0)
         Rotate90 = Rotation(1)
         Rotate180 = Rotation(2)
         Rotate270 = Rotation(3)
-        
+
         class SearchDirection(int): pass
         NextResult = SearchDirection(0)
         PreviousResult = SearchDirection(1)
-        
+
         class SearchMode(int): pass
         CaseSensitive = SearchMode(0)
         CaseInsensitive = SearchMode(1)
-        
+
         class TextLayout(int): pass
         PhysicalLayout = TextLayout(0)
         RawOrderLayout = TextLayout(1)
-        
-        
+
+
     class LinkDestination(_noinst): pass
-    
+
     class Link(_noinst): pass
     class LinkAction(Link): pass
     class LinkAnnotation(Link):pass

--- a/frescobaldi_app/qpopplerview/printer.py
+++ b/frescobaldi_app/qpopplerview/printer.py
@@ -32,7 +32,7 @@ from . import render
 
 def psfile(doc, printer, output, pageList=None, margins=(0, 0, 0, 0)):
     """Writes a PostScript rendering of a Poppler::Document to the output.
-    
+
     doc: a Poppler::Document instance
     printer: a QPrinter instance from which the papersize is read
     output: a filename or opened QIODevice (will not be closed)
@@ -40,9 +40,9 @@ def psfile(doc, printer, output, pageList=None, margins=(0, 0, 0, 0)):
         from the QPrinter instance. Page numbers start with 1.
     margins: a sequence of four values describing the margins (left, top, right,
         bottom) in Point (1/72 inch), all defaulting to 0.
-    
+
     Returns True on success, False on error.
-    
+
     """
     if pageList is None:
         if (printer.printRange() == QPrinter.AllPages
@@ -54,37 +54,37 @@ def psfile(doc, printer, output, pageList=None, margins=(0, 0, 0, 0)):
         for num in pageList:
             if num < 1 or num > doc.numPages():
                 raise ValueError("invalid page number: {0}".format(num))
-    
+
     ps = doc.psConverter()
     ps.setPageList(pageList)
-        
+
     if isinstance(output, QIODevice):
         ps.setOutputDevice(output)
     else:
         ps.setOutputFileName(output)
-    
+
     paperSize = printer.paperSize(QPrinter.Point)
     ps.setPaperHeight(paperSize.height())
     ps.setPaperWidth(paperSize.width())
-    
+
     left, top, right, bottom = margins
     ps.setLeftMargin(left)
     ps.setTopMargin(top)
     ps.setRightMargin(right)
     ps.setBottomMargin(bottom)
-    
+
     with lock(doc):
         return ps.convert()
 
 
 class Printer(object):
     """Prints a Poppler.Document to a QPrinter.
-    
+
     This is currently done using raster images at (by default) 300 DPI,
     because the Arthur backend of Poppler (that can render to a painter)
     does not work correctly in all cases and is not well supported by
     the Poppler developers at this time.
-    
+
     """
     def __init__(self):
         self._stop = False
@@ -95,48 +95,48 @@ class Printer(object):
         opts.setRenderHint(0)
         opts.setPaperColor(QColor(Qt.white))
         self.setRenderOptions(opts)
-        
+
     def setDocument(self, document):
         """Sets the Poppler.Document to print (mandatory)."""
         self._document = document
-        
+
     def document(self):
         """Returns the previously set Poppler.Document."""
         return self._document
-        
+
     def setPrinter(self, printer):
         """Sets the QPrinter to print to (mandatory)."""
         self._printer = printer
-        
+
     def printer(self):
         """Returns the previously set QPrinter."""
         return self._printer
-    
+
     def setResolution(self, dpi):
         """Sets the resolution in dots per inch."""
         self._resolution = dpi
-    
+
     def resolution(self):
         """Returns the resolution in dots per inch."""
         return self._resolution
-    
+
     def setRenderOptions(self, options):
         """Sets the render options (see render.py)."""
         self._renderoptions = options
-    
+
     def renderOptions(self):
         """Returns the render options (see render.py).
-        
+
         By default, all antialiasing is off and the papercolor is white.
-        
+
         """
         return self._renderoptions
-        
+
     def pageList(self):
         """Should return a list of desired page numbers (starting with 1).
-        
+
         The default implementation reads the pages from the QPrinter.
-        
+
         """
         p = self.printer()
         if (p.printRange() == QPrinter.AllPages
@@ -145,7 +145,7 @@ class Printer(object):
         else:
             pages = range(max(p.fromPage(), 1), min(p.toPage(), self.document().numPages()) + 1)
         return list(pages)
-    
+
     def print_(self):
         """Prints the document."""
         self._stop = False
@@ -153,19 +153,19 @@ class Printer(object):
         p = self.printer()
         p.setFullPage(True)
         p.setResolution(resolution)
-        
+
         center = p.paperRect().center()
         painter = QPainter(p)
-        
+
         pages  = self.pageList()
         if p.pageOrder() != QPrinter.FirstPageFirst:
             pages.reverse()
 
         total = len(pages)
-        
+
         opts = self.renderOptions()
         document = self.document()
-        
+
         for num, pageNum in enumerate(pages, 1):
             if self._stop:
                 return p.abort()
@@ -179,9 +179,9 @@ class Printer(object):
             rect = img.rect()
             rect.moveCenter(center)
             painter.drawImage(rect, img)
-        
+
         return painter.end()
-        
+
     def abort(self):
         """Instructs the printer to cancel the job."""
         self._stop = True
@@ -189,16 +189,16 @@ class Printer(object):
     def aborted(self):
         """Returns whether abort() was called."""
         return self._stop
-        
+
     def progress(self, num, total, pageNumber):
         """Called when printing a page.
-        
+
         num: counts the pages (starts with 1)
         total: the total number of pages
         pageNumber: the page number in the document (starts also with 1)
-        
+
         The default implementation does nothing.
-        
+
         """
         pass
 

--- a/frescobaldi_app/qpopplerview/rectangles.py
+++ b/frescobaldi_app/qpopplerview/rectangles.py
@@ -36,28 +36,28 @@ class Rectangles(object):
     """
     Manages a list of rectangular objects and quickly finds objects at
     some point, in some rectangle or intersecting some rectangle.
-    
+
     The implementation uses four lists of the objects sorted on either
     coordinate, so retrieval is fast.
-    
+
     Bulk adding is done in the constructor or via the bulk_add() method (which
     clears the indexes, that are recreated on first search).  Single objects
     can be added and deleted, keeping the indexes, but that's slower.
-    
+
     """
     _func = lambda obj: obj.rect().normalized().getCoords()
-    
+
     def __init__(self, objects=None, func=None):
         """Initializes the Rectangles object.
-        
+
         objects should be an iterable of rectangular objects.
-        
+
         function(obj) should return a four-tuple (left, top, right, bottom)
         of the coordinates of the rectangle.  The coordinates should be normalized,
         i.e. top <= bottom and left <= right.
-        
+
         The default function is: lambda obj: obj.rect().normalized().getCoords()
-        
+
         """
         self._items = {} # maps object to the result of func(object)
         self._index = {} # maps side to indices, objects (index=coordinate of that side)
@@ -65,7 +65,7 @@ class Rectangles(object):
             self._func = func
         if objects:
             self.bulk_add(objects)
-    
+
     def add(self, obj):
         """Adds an object to our list. Keeps the index intact."""
         if obj in self._items:
@@ -75,16 +75,16 @@ class Rectangles(object):
             i = bisect.bisect_left(indices, coords[side])
             indices.insert(i, coords[side])
             objects.insert(i, obj)
-    
+
     def bulk_add(self, objects):
         """Adds many new items to the index using the function given in the constructor.
-        
+
         After this, the index is cleared and recreated on the first search operation.
-        
+
         """
         self._items.update((obj, self._func(obj)) for obj in objects)
         self._index.clear()
-        
+
     def remove(self, obj):
         """Removes an object from our list. Keeps the index intact."""
         del self._items[obj]
@@ -92,12 +92,12 @@ class Rectangles(object):
             i = objects.index(obj)
             del objects[i]
             del indices[i]
-            
+
     def clear(self):
         """Empties the list of items."""
         self._items.clear()
         self._index.clear()
-        
+
     def at(self, x, y):
         """Returns a set() of objects that are touched by the given point."""
         return self._test(
@@ -105,7 +105,7 @@ class Rectangles(object):
             (self._larger, Bottom, y),
             (self._smaller, Left, x),
             (self._larger, Right, x))
-         
+
     def inside(self, left, top, right, bottom):
         """Returns a set() of objects that are fully in the given rectangle."""
         return self._test(
@@ -113,7 +113,7 @@ class Rectangles(object):
             (self._smaller, Bottom, bottom),
             (self._larger, Left, left),
             (self._smaller, Right, right))
-    
+
     def intersecting(self, left, top, right, bottom):
         """Returns a set() of objects intersecting the given rectangle."""
         return self._test(
@@ -150,21 +150,21 @@ class Rectangles(object):
 
     def __len__(self):
         return len(self._items)
-        
+
     def __contains__(self, obj):
         return obj in self._items
-        
+
     def __bool__(self):
         return bool(self._items)
-        
+
     # private helper methods
     def _test(self, *tests):
         """Performs tests and returns objects that fulfill all of them.
-        
+
         Every test should be a three tuple(method, side, value).
         Method is either self._smaller or self._larger.
         Returns a (possibly empty) set.
-        
+
         """
         result = None
         for meth, side, value in tests:
@@ -176,7 +176,7 @@ class Rectangles(object):
             if not result:
                 break
         return result
-    
+
     def _smaller(self, side, value):
         """Returns objects for side below value."""
         indices, objects = self._sorted(side)
@@ -188,9 +188,9 @@ class Rectangles(object):
         indices, objects = self._sorted(side)
         i = bisect.bisect_left(indices, value)
         return objects[i:]
-        
+
     def _sorted(self, side):
-        """Returns a two-tuple (indices, objects) sorted on index for the given side.""" 
+        """Returns a two-tuple (indices, objects) sorted on index for the given side."""
         try:
             return self._index[side]
         except KeyError:
@@ -202,5 +202,5 @@ class Rectangles(object):
                 result = [], []
             self._index[side] = result
             return result
-            
+
 

--- a/frescobaldi_app/qpopplerview/render.py
+++ b/frescobaldi_app/qpopplerview/render.py
@@ -29,49 +29,49 @@ class RenderOptions(object):
         self._renderHint = None
         self._paperColor = None
         self._oversampleThreshold = 0
-    
+
     def read(self, document):
         """Reads rendering options from the given Poppler.Document."""
         self._renderHint = document.renderHints()
         self._paperColor = document.paperColor()
-        
+
     def write(self, document):
         """Writes our rendering options to the given Poppler.Document."""
         if self._renderHint is not None:
             document.setRenderHint(int(document.renderHints()), False)
             document.setRenderHint(self._renderHint)
-        
+
         if self._paperColor is not None:
             document.setPaperColor(self._paperColor)
-        
+
     def setRenderHint(self, hint):
         """Sets the Poppler.Document.RenderHints. Use None to unset."""
         self._renderHint = hint
-    
+
     def renderHint(self):
         """Returns the currently set RenderHint(s)."""
         return self._renderHint
-        
+
     def setPaperColor(self, color):
         """Sets the paper color for rendering. Use None to unset."""
         self._paperColor = color
-        
+
     def paperColor(self):
         """Returns the currently set paper color."""
         return self._paperColor
-    
+
     def setOversampleThreshold(self, value):
         """Sets the oversample threshold resolution.
-        
+
         Below this resolution, the image will be rendered in double size
         and scaled down, to provide a smoother image. Otherwise, the horizontal
         lines may appear too thick.
-        
+
         The default value is 0, meaning no oversampling.
-        
+
         """
         self._oversampleThreshold = value
-        
+
     def oversampleThreshold(self):
         """Return the current oversample threshold resolution."""
         return self._oversampleThreshold

--- a/frescobaldi_app/qpopplerview/surface.py
+++ b/frescobaldi_app/qpopplerview/surface.py
@@ -87,20 +87,20 @@ class CustomRubberBand(QWidget):
         # Clip middles
         region += QRect(0, self.rect().height() // 2 - 10, self.rect().width(), 20)
         region += QRect(self.rect().width() // 2 - 10, 0, 20, self.rect().height())
-        
+
         # Draw thicker rectangles, clipped at corners and sides.
         painter.setClipRegion(region)
         painter.drawRect(self.rect())
- 
+
 class Surface(QWidget):
-    
+
     rightClicked = pyqtSignal(QPoint)
     linkClicked = pyqtSignal(QEvent, page.Page, popplerqt5.Poppler.Link)
     linkHovered = pyqtSignal(page.Page, popplerqt5.Poppler.Link)
     linkLeft = pyqtSignal()
-    linkHelpRequested = pyqtSignal(QPoint, page.Page, popplerqt5.Poppler.Link)    
+    linkHelpRequested = pyqtSignal(QPoint, page.Page, popplerqt5.Poppler.Link)
     selectionChanged = pyqtSignal(QRect)
-    
+
     def __init__(self, view):
         super(Surface, self).__init__(view)
         self.setBackgroundRole(QPalette.Dark)
@@ -122,12 +122,12 @@ class Surface(QWidget):
         self.setLinksEnabled(True)
         self.setSelectionEnabled(True)
         self.setShowUrlTips(True)
-        
+
         self.view().cursorNeedUpdate.connect(self.updateCursor)
- 
+
     def pageLayout(self):
         return self._pageLayout
-        
+
     def setPageLayout(self, layout):
         old, self._pageLayout = self._pageLayout, layout
         if old:
@@ -135,15 +135,15 @@ class Surface(QWidget):
             old.changed.disconnect(self.updateLayout)
         layout.redraw.connect(self.redraw)
         layout.changed.connect(self.updateLayout)
-    
+
     def view(self):
         """Returns our associated View."""
         return self._view()
-    
+
     def viewportRect(self):
         """Returns the rectangle of us that is visible in the View."""
         return self.view().viewport().rect().translated(-self.pos())
-        
+
     def setSelectionEnabled(self, enabled):
         """Enables or disables selecting rectangular regions."""
         self._selectionEnabled = enabled
@@ -151,62 +151,62 @@ class Surface(QWidget):
             self.clearSelection()
             self._rubberBand.hide()
             self._selecting = False
-    
+
     def selectionEnabled(self):
         """Returns True if selecting rectangular regions is enabled."""
         return self._selectionEnabled
-        
+
     def setLinksEnabled(self, enabled):
         """Enables or disables the handling of Poppler.Links in the pages."""
         self._linksEnabled = enabled
-    
+
     def linksEnabled(self):
         """Returns True if the handling of Poppler.Links in the pages is enabled."""
         return self._linksEnabled
-    
+
     def setShowUrlTips(self, enabled):
         """Enables or disables showing the URL in a tooltip when hovering a link.
-        
+
         (Of course also setLinksEnabled(True) if you want this.)
-        
+
         """
         self._showUrlTips = enabled
-        
+
     def showUrlTips(self):
         """Returns True if URLs are shown in a tooltip when hovering a link."""
         return self._showUrlTips
-        
+
     def setMagnifier(self, magnifier):
         """Sets the Magnifier to use (or None to disable the magnifier).
-        
+
         The Surface takes ownership of the Magnifier.
-        
+
         """
         if self._magnifier:
             self._magnifier.setParent(None)
         magnifier.setParent(self.view())
         self._magnifier = magnifier
-    
+
     def magnifier(self):
         """Returns the currently set magnifier."""
         return self._magnifier
-    
+
     def setMagnifierModifiers(self, modifiers):
         """Sets the modifiers (e.g. Qt.CTRL) to show the magnifier.
-        
+
         Use None to show the magnifier always (instead of dragging).
-        
+
         """
         self._magnifierModifiers = modifiers
-    
+
     def magnifierModifiers(self):
         """Returns the currently set keyboard modifiers (e.g. Qt.CTRL) to show the magnifier."""
         return self._magnifierModifiers
-        
+
     def hasSelection(self):
         """Returns True if there is a selection."""
         return bool(self._selection)
-        
+
     def setSelection(self, rect):
         """Sets the selection rectangle."""
         rect = rect.normalized()
@@ -215,19 +215,19 @@ class Surface(QWidget):
         self._rubberBand.setGeometry(rect)
         if rect != old:
             self.selectionChanged.emit(rect)
-        
+
     def selection(self):
         """Returns the selection rectangle (normalized) or an invalid QRect()."""
         return QRect(self._selection)
-    
+
     def clearSelection(self):
         """Hides the selection rectangle."""
         self.setSelection(QRect())
-        
+
     def selectedPages(self):
         """Return a list of the Page objects the selection encompasses."""
         return list(self.pageLayout().pagesAt(self.selection()))
-    
+
     def selectedPage(self):
         """Return the Page thas is selected for the largest part, or None."""
         pages = self.selectedPages()
@@ -237,7 +237,7 @@ class Surface(QWidget):
             size = page.rect().intersected(self.selection()).size()
             return size.width() + size.height()
         return max(pages, key = key)
-    
+
     def selectedPageRect(self, page):
         """Return the QRect on the page that falls in the selection."""
         return self.selection().normalized().intersected(page.rect()).translated(-page.pos())
@@ -245,23 +245,23 @@ class Surface(QWidget):
     def selectedText(self):
         """Return all text falling in the selection."""
         return '\n'.join(page.text(self.selection()) for page in self.selectedPages())
-    
+
     def redraw(self, rect):
         """Called when the Layout wants to redraw a rectangle."""
         self.update(rect)
-        
+
     def updateLayout(self):
         """Conforms ourselves to our layout (that must already be updated.)"""
         self.clearSelection()
         self.resize(self._pageLayout.size())
         self.update()
-        
+
     def highlight(self, highlighter, areas, msec=0):
         """Highlights the list of areas using the given highlighter.
-        
+
         Every area is a two-tuple (page, rect), where rect is a rectangle inside (0, 0, 1, 1) like the
         linkArea attribute of a Poppler.Link.
-        
+
         """
         d = collections.defaultdict(list)
         for page, area in areas:
@@ -279,7 +279,7 @@ class Surface(QWidget):
         self.clearHighlight(highlighter)
         self._highlights[highlighter] = (d, t)
         self.update(sum((page.rect() for page in d), QRegion()))
-        
+
     def clearHighlight(self, highlighter):
         """Removes the highlighted areas of the given highlighter."""
         try:
@@ -288,14 +288,14 @@ class Surface(QWidget):
             return
         del self._highlights[highlighter]
         self.update(sum((page.rect() for page in d), QRegion()))
-    
+
     def paintEvent(self, ev):
         """Handle PaintEvent on the surface to highlight the selection."""
         painter = QPainter(self)
         pages = list(self.pageLayout().pagesAt(ev.rect()))
         for page in pages:
             page.paint(painter, ev.rect())
-        
+
         for highlighter, (d, t) in self._highlights.items():
             rects = []
             for page in pages:
@@ -305,19 +305,19 @@ class Surface(QWidget):
                     continue
             if rects:
                 highlighter.paintRects(painter, rects)
-    
+
     def handleMousePressEvent(self, ev):
         """Handle mouse press for various operations
             - links to source,
-            - magnifier, 
+            - magnifier,
             - selection highlight,
-            
+
             If event was used, return true to indicate processing should stop.
         """
-        
+
         # As the event comes from the view, we need to map it locally.
         pos = self.mapFromParent(ev.pos())
-               
+
         # selecting?
         if self._selectionEnabled:
             if self.hasSelection():
@@ -340,14 +340,14 @@ class Surface(QWidget):
                         self.linkClickEvent(ev, page, link)
                         return True
                 if ev.button() == Qt.RightButton or int(ev.modifiers()) & _SCAM:
-                    if not (int(ev.modifiers()) & _SCAM == self._magnifierModifiers 
+                    if not (int(ev.modifiers()) & _SCAM == self._magnifierModifiers
                             and  ev.button() == Qt.LeftButton):
                         self._selecting = True
                         self._selectionEdge = _RIGHT | _BOTTOM
                         self._selectionRect = QRect(pos, QSize(0, 0))
                         self._selectionPos = pos
                         return True
-        
+
         # link?
         if self._linksEnabled:
             page, link = self.pageLayout().linkAt(pos)
@@ -366,19 +366,19 @@ class Surface(QWidget):
             return True
 
         return False
-        
+
     def handleMouseReleaseEvent(self, ev):
         """Handle mouse release events for various operations:
             - hide magnifier,
             - selection.
-            
+
             If event was used, return true to indicate processing should stop.
         """
         consumed = False
         if self._magnifying:
             self._magnifier.hide()
             self._magnifying = False
-            self.unsetCursor() 
+            self.unsetCursor()
             consumed = True
         elif self._selecting:
             self._selecting = False
@@ -389,23 +389,23 @@ class Surface(QWidget):
                 self.setSelection(selection)
             if self._scrolling:
                 self.stopScrolling()
-            self.unsetCursor() 
+            self.unsetCursor()
             consumed = True
         if ev.button() == Qt.RightButton:
             # As the event comes from the view, we need to map it locally.
             self.rightClick(self.mapFromParent(ev.pos()))
             consumed = True
-        
+
         return consumed
-            
+
     def handleMouseMoveEvent(self, ev):
         """Handle mouse move events for various operations:
             - move magnifier,
             - selection extension.
-            
+
             If event was used, return true to indicate processing should stop.
         """
-        consumed = False 
+        consumed = False
         if self._magnifying:
             # As the event comes from the view, we need to map it locally.
             self._magnifier.moveCenter(self.mapFromParent(ev.pos()))
@@ -432,14 +432,14 @@ class Surface(QWidget):
             elif self._scrolling:
                 self.stopScrolling()
             consumed = True
-              
+
         return consumed
-        
+
     def handleMoveEvent(self, ev):
         """Handle  move events for various operations:
             - move magnifier,
             - selection extension.
-            
+
             If event was used, return true to indicate processing should stop.
         """
         consumed = False
@@ -452,7 +452,7 @@ class Surface(QWidget):
             consumed = True
 
         return consumed
-        
+
     def handleHelpEvent(self, ev):
         """Handle help event: show link if any."""
         if self._linksEnabled:
@@ -463,10 +463,10 @@ class Surface(QWidget):
 
     def updateKineticCursor(self, active):
         """Cursor handling when kinetic move starts/stops.
-        
+
         - reset the cursor and hide tooltips if visible at start,
         - update the cursor and show the appropriate tooltips at stop.
-        
+
         Used as a slot linked to the kineticStarted() signal.
         """
         if active:
@@ -481,13 +481,13 @@ class Surface(QWidget):
                     self.linkHelpEvent(QCursor.pos(), page, link)
 
     def updateCursor(self, evpos):
-        """Set the cursor to the right glyph, depending on action""" 
+        """Set the cursor to the right glyph, depending on action"""
         pos = self.mapFromGlobal(evpos)
         cursor = None
         edge = _OUTSIDE
         if self._selectionEnabled and self.hasSelection():
             edge = selectionEdge(pos, self.selection())
-            
+
         if edge is not _OUTSIDE:
             if edge in (_TOP, _BOTTOM):
                 cursor = Qt.SizeVerCursor
@@ -513,70 +513,70 @@ class Surface(QWidget):
                 self._currentLinkId = lid
                 if link:
                     self.linkHoverEnter(page, link)
-        
+
         self.setCursor(cursor) if cursor else self.unsetCursor()
-    
+
     def linkHelpEvent(self, globalPos, page, link):
         """Called when a QHelpEvent occurs on a link.
-        
+
         The default implementation shows a tooltip if showUrls() is True,
         and emits the linkHelpRequested() signal.
-        
+
         """
         if self._showUrlTips and isinstance(link, popplerqt5.Poppler.LinkBrowse):
             QToolTip.showText(globalPos, link.url(), self, page.linkRect(link.linkArea()))
         self.linkHelpRequested.emit(globalPos, page, link)
-        
+
     def rightClick(self, pos):
         """Called when the right mouse button is released.
-        
+
         (Use this instead of the contextMenuEvent as that one also
         fires when starting a right-button selection.)
         The default implementation emits the rightClicked(pos) signal and also
         sends a ContextMenu event to the View widget.
-        
+
         """
         self.rightClicked.emit(pos)
         QApplication.postEvent(self.view().viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, pos + self.pos()))
-        
+
     def linkClickEvent(self, ev, page, link):
         """Called when a link is clicked.
-        
+
         The default implementation emits the linkClicked(event, page, link) signal.
-        
+
         """
         self.linkClicked.emit(ev, page, link)
-        
+
     def linkHoverEnter(self, page, link):
         """Called when the mouse hovers over a link.
-        
+
         The default implementation emits the linkHovered(page, link) signal.
-        
+
         """
         self.linkHovered.emit(page, link)
-        
+
     def linkHoverLeave(self):
         """Called when the mouse does not hover a link anymore.
-        
+
         The default implementation emits the linkLeft() signal.
-        
+
         """
         self.linkLeft.emit()
 
     def startScrolling(self, dx, dy):
         """Starts scrolling dx, dy about 10 times a second.
-        
+
         Stops automatically when the end is reached.
-        
+
         """
         self._scrolling = QPoint(dx, dy)
         self._scrollTimer.isActive() or self._scrollTimer.start()
-        
+
     def stopScrolling(self):
         """Stops scrolling."""
         self._scrolling = False
         self._scrollTimer.stop()
-        
+
     def _scrollTimeout(self):
         """(Internal) Called by the _scrollTimer."""
         # change the scrollbars, but check how far they really moved.
@@ -585,7 +585,7 @@ class Surface(QWidget):
         diff = pos - self.pos()
         if not diff:
             self.stopScrolling()
-    
+
     def _moveSelection(self, pos):
         """(Internal) Moves the dragged selection edge or corner to the given pos (QPoint)."""
         diff = pos - self._selectionPos

--- a/frescobaldi_app/qpopplerview/view.py
+++ b/frescobaldi_app/qpopplerview/view.py
@@ -47,14 +47,14 @@ _SCAM = (Qt.SHIFT | Qt.CTRL | Qt.ALT | Qt.META)
 
 
 class View(KineticScrollArea):
-    
+
     MAX_ZOOM = 4.0
-    
+
     viewModeChanged = pyqtSignal(int)
-    
+
     def __init__(self, parent=None):
         super(View, self).__init__(parent)
-        
+
         self.setAlignment(Qt.AlignCenter)
         self.setBackgroundRole(QPalette.Dark)
         self.setMouseTracking(True)
@@ -62,14 +62,14 @@ class View(KineticScrollArea):
         self._viewMode = FixedScale
         self._wheelZoomEnabled = True
         self._wheelZoomModifier = Qt.CTRL
-        
+
         self._pinchStartFactor = None
         super(View, self).grabGesture(Qt.PinchGesture)
 
         # delayed resize
         self._centerPos = False
         self._resizeTimer = QTimer(singleShot = True, timeout = self._resizeTimeout)
-        
+
     def surface(self):
         """Returns our Surface, the widget drawing the page(s)."""
         sf = self.widget()
@@ -77,7 +77,7 @@ class View(KineticScrollArea):
             sf = surface.Surface(self)
             self.setSurface(sf)
         return sf
-    
+
     def setSurface(self, sf):
         """Sets the given surface as our widget."""
         self.setWidget(sf)
@@ -85,11 +85,11 @@ class View(KineticScrollArea):
         sf.setMouseTracking(True)
         self.kineticScrollingActive.connect(sf.updateKineticCursor)
 
-    
+
     def viewMode(self):
         """Returns the current ViewMode."""
         return self._viewMode
-        
+
     def setViewMode(self, mode):
         """Sets the current ViewMode."""
         if mode == self._viewMode:
@@ -98,34 +98,34 @@ class View(KineticScrollArea):
         if mode:
             self.fit()
         self.viewModeChanged.emit(mode)
-    
+
     def wheelZoomEnabled(self):
         """Returns whether wheel zoom is enabled."""
         return self._wheelZoomEnabled
-        
+
     def setWheelZoomEnabled(self, enabled):
         """Sets whether wheel zoom is enabled.
-        
+
         Wheel zoom is zooming using the mouse wheel and a keyboard modifier key
         (defaulting to Qt.CTRL).  Use setWheelZoomModifier() to set a key (or
         key combination).
-        
+
         """
         self._wheelZoomEnabled = enabled
-    
+
     def wheelZoomModifier(self):
         """Returns the modifier key to wheel-zoom with (defaults to Qt.CTRL)."""
         return self._wheelZoomModifier
-        
+
     def setWheelZoomModifier(self, key):
         """Sets the modifier key to wheel-zoom with (defaults to Qt.CTRL).
-        
+
         Can also be set to a ORed value, e.g. Qt.SHIFT|Qt.ALT.
         Only use Qt.ALT, Qt.CTRL, Qt.SHIFT and/or Qt.META.
-        
+
         """
         self._wheelZoomModifier = key
-        
+
     def load(self, document):
         """Convenience method to load all the pages from the given Poppler.Document."""
         self.surface().pageLayout().load(document)
@@ -142,7 +142,7 @@ class View(KineticScrollArea):
     def scale(self):
         """Returns the scale of the pages in the View."""
         return self.surface().pageLayout().scale()
-        
+
     def setScale(self, scale):
         """Sets the scale of all pages in the View."""
         self.surface().pageLayout().setScale(scale)
@@ -167,31 +167,31 @@ class View(KineticScrollArea):
 
     def fit(self):
         """(Internal). Fits the layout according to the view mode.
-        
+
         Prevents scrollbar/resize loops by precalculating which scrollbars will appear.
-        
+
         """
         mode = self.viewMode()
         if mode == FixedScale:
             return
-        
+
         maxsize = self.maximumViewportSize()
-        
+
         # can vertical or horizontal scrollbars appear?
         vcan = self.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
         hcan = self.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
-        
+
         # width a scrollbar takes off the viewport size
         framewidth = 0
         if self.style().styleHint(QStyle.SH_ScrollView_FrameOnlyAroundContents, None, self):
             framewidth = self.style().pixelMetric(QStyle.PM_DefaultFrameWidth) * 2
         scrollbarextent = self.style().pixelMetric(QStyle.PM_ScrollBarExtent, None, self) + framewidth
-        
+
         # first try to fit full size
         layout = self.surface().pageLayout()
         layout.fit(maxsize, mode)
         layout.reLayout()
-        
+
         # minimal values
         minwidth = maxsize.width()
         minheight = maxsize.height()
@@ -199,11 +199,11 @@ class View(KineticScrollArea):
             minwidth -= scrollbarextent
         if hcan:
             minheight -= scrollbarextent
-        
+
         # do width and/or height fit?
         fitw = layout.width() <= maxsize.width()
         fith = layout.height() <= maxsize.height()
-        
+
         if not fitw and not fith:
             if vcan or hcan:
                 layout.fit(QSize(minwidth, minheight), mode)
@@ -238,7 +238,7 @@ class View(KineticScrollArea):
                         layout.fit(QSize(maxsize.width(), h - 1), mode)
                         break
         layout.update()
-        
+
     def resizeEvent(self, ev):
         super(View, self).resizeEvent(ev)
         # Adjust the size of the document if desired
@@ -251,7 +251,7 @@ class View(KineticScrollArea):
             if not self._resizeTimer.isActive():
                 self._resizeTimeout()
             self._resizeTimer.start(150)
-    
+
     def _resizeTimeout(self):
         if self._centerPos is None:
             return
@@ -268,22 +268,22 @@ class View(KineticScrollArea):
 
     def zoom(self, scale, pos=None):
         """Changes the display scale (1.0 is 100%).
-        
+
         If pos is given, keeps that point at the same place if possible.
         Pos is a QPoint relative to ourselves.
-        
+
         """
         scale = max(0.05, min(self.MAX_ZOOM, scale))
         if scale == self.scale():
             return
-        
+
         if self.surface().pageLayout().count() == 0:
             self.setScale(scale)
             return
-            
+
         if pos is None:
             pos = self.viewport().rect().center()
-        
+
         surfacePos = pos - self.surface().pos()
         page = self.surface().pageLayout().pageAt(surfacePos)
         if page:
@@ -300,13 +300,13 @@ class View(KineticScrollArea):
         surfacePos = pos - self.surface().pos()
         # use fastScrollBy as we do not want kinetic scrolling here regardless of its state.
         self.fastScrollBy(newPos - surfacePos)
-            
+
     def zoomIn(self, pos=None, factor=1.1):
         self.zoom(self.scale() * factor, pos)
-        
+
     def zoomOut(self, pos=None, factor=1.1):
         self.zoom(self.scale() / factor, pos)
-        
+
     def wheelEvent(self, ev):
         if (self._wheelZoomEnabled and
             int(ev.modifiers()) & _SCAM == self._wheelZoomModifier):
@@ -315,7 +315,7 @@ class View(KineticScrollArea):
                 self.zoom(self.scale() * factor, ev.pos())
         else:
             super(View, self).wheelEvent(ev)
-    
+
     def mousePressEvent(self, ev):
         """Mouse press event handler. Passes the event to the surface, and back to
         the base class if the surface did not do anything with it."""
@@ -353,9 +353,9 @@ class View(KineticScrollArea):
             if self.gestureEvent(ev):
                 ev.accept() # Accepts all gestures in the event
                 return True
-        
+
         return super(View, self).event(ev)
-    
+
     def gestureEvent(self, event):
         """Gesture event handler. Return False if event is not accepted.
         Currently only cares about PinchGesture. Could also handle Swipe
@@ -400,7 +400,7 @@ class View(KineticScrollArea):
                 page = layout.pageAt(pos + dist)
                 if page:
                     return page
-    
+
     def currentPageNumber(self):
         """Returns the number (index in the layout) of the currentPage(), or -1 if there are no pages."""
         page = self.currentPage()
@@ -414,17 +414,17 @@ class View(KineticScrollArea):
         if num < len(layout) and num != self.currentPageNumber():
             margin = QPoint(layout.margin(), layout.margin())
             self.scrollBy(layout[num].pos() + self.surface().pos() - margin)
-            
+
     def position(self):
         """Returns a three-tuple(num, x, y) describing the page currently in the center of the View.
-        
+
         the number is the index of the Page in the Layout, and x and y are the coordinates in the
         range 0.0 -> 1.0 of the point that is at the center of the View.
-        
+
         This way a position can be retained even if the scale or the orientation of the Layout changed.
-        
+
         Returns None, None, None if the layout is empty.
-        
+
         """
         page = self.currentPage()
         if page:
@@ -438,7 +438,7 @@ class View(KineticScrollArea):
 
     def setPosition(self, position, overrideKinetic=False):
         """Sets the position to a three-tuple as previously returned by position().
-        
+
         Setting overrideKinetic to true allows for fast setup, instead of scrolling all the way to the visible point.
         """
         layout = self.surface().pageLayout()

--- a/frescobaldi_app/qsettings.py
+++ b/frescobaldi_app/qsettings.py
@@ -27,12 +27,12 @@ from PyQt5.QtCore import QUrl
 
 def get_string_list(settings, key):
     """Makes sure a list of strings is returned for the key.
-    
+
     You can write the value with settings.setValue(key, ['bla', 'bla',]), but
     when you need to read the value with settings.value(key, [], str), things
     go wrong when an empty list was stored. So please use this function when
     reading a list of strings from QSettings.
-    
+
     """
     try:
         value = settings.value(key, [], str)
@@ -49,12 +49,12 @@ def get_string_list(settings, key):
 
 def get_url_list(settings, key):
     """Makes sure a list of QUrl instances is returned for the key.
-    
+
     You can write the value with settings.setValue(key, [url, url]), but
     when you need to read the value with settings.value(key, [], QUrl), things
     go wrong when an empty list was stored. So please use this function when
     reading a list of strings from QSettings.
-    
+
     """
     try:
         value = settings.value(key, [], QUrl)

--- a/frescobaldi_app/quickinsert/__init__.py
+++ b/frescobaldi_app/quickinsert/__init__.py
@@ -41,11 +41,11 @@ class QuickInsertPanel(panel.Panel):
         mainwindow.addDockWidget(Qt.LeftDockWidgetArea, self)
         self.actionCollection = QuickInsertActions(self)
         actioncollectionmanager.manager(mainwindow).addActionCollection(self.actionCollection)
-    
+
     def translateUI(self):
         self.setWindowTitle(_("Quick Insert"))
         self.toggleViewAction().setText(_("Quick &Insert"))
-        
+
     def createWidget(self):
         from . import widget
         return widget.QuickInsert(self)
@@ -57,7 +57,7 @@ class QuickInsertActions(actioncollection.ShortcutCollection):
     def __init__(self, panel):
         super(QuickInsertActions, self).__init__(panel.mainwindow())
         self.panel = weakref.ref(panel)
-    
+
     def createDefaultShortcuts(self):
         self.setDefaultShortcuts('staccato', [QKeySequence('Ctrl+.')])
         self.setDefaultShortcuts('spanner_slur', [QKeySequence('Ctrl+(')])
@@ -65,8 +65,8 @@ class QuickInsertActions(actioncollection.ShortcutCollection):
 
     def realAction(self, name):
         return self.panel().widget().actionForName(name)
-        
+
     def title(self):
         return _("Quick Insert")
-    
+
 

--- a/frescobaldi_app/quickinsert/articulations.py
+++ b/frescobaldi_app/quickinsert/articulations.py
@@ -56,7 +56,7 @@ shorthands = {
 
 class Articulations(tool.Tool):
     """Articulations tool in the quick insert panel toolbox.
-    
+
     """
     def __init__(self, panel):
         super(Articulations, self).__init__(panel)
@@ -66,21 +66,21 @@ class Articulations(tool.Tool):
             autoRaise=True,
             popupMode=QToolButton.InstantPopup,
             icon=icons.get('edit-clear'))
-        
+
         mainwindow = panel.parent().mainwindow()
         mainwindow.selectionStateChanged.connect(self.removemenu.setEnabled)
         self.removemenu.setEnabled(mainwindow.hasSelection())
-        
+
         ac = documentactions.DocumentActions.instance(mainwindow).actionCollection
         self.removemenu.addAction(ac.tools_quick_remove_articulations)
         self.removemenu.addAction(ac.tools_quick_remove_ornaments)
         self.removemenu.addAction(ac.tools_quick_remove_instrument_scripts)
-        
+
         layout = QHBoxLayout()
         layout.addWidget(self.shorthands)
         layout.addWidget(self.removemenu)
         layout.addStretch(1)
-        
+
         self.layout().addLayout(layout)
         for cls in (
                 ArticulationsGroup,
@@ -91,22 +91,22 @@ class Articulations(tool.Tool):
             self.layout().addWidget(cls(self))
         self.layout().addStretch(1)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.shorthands.setText(_("Allow shorthands"))
         self.shorthands.setToolTip(_(
             "Use short notation for some articulations like staccato."))
         self.removemenu.setToolTip(_(
             "Remove articulations etc."))
-    
+
     def icon(self):
         """Should return an icon for our tab."""
         return symbols.icon("articulation_prall")
-    
+
     def title(self):
         """Should return a title for our tab."""
         return _("Articulations")
-  
+
     def tooltip(self):
         """Returns a tooltip"""
         return _("Different kinds of articulations and other signs.")
@@ -144,7 +144,7 @@ class Group(buttongroup.ButtonGroup):
 class ArticulationsGroup(Group):
     def translateUI(self):
         self.setTitle(_("Articulations"))
-        
+
     def actionTexts(self):
         yield 'accent', _("Accent")
         yield 'marcato', _("Marcato")
@@ -158,7 +158,7 @@ class ArticulationsGroup(Group):
 class OrnamentsGroup(Group):
     def translateUI(self):
         self.setTitle(_("Ornaments"))
-        
+
     def actionTexts(self):
         yield 'trill', _("Trill")
         yield 'prall', _("Prall")
@@ -179,7 +179,7 @@ class OrnamentsGroup(Group):
 class SignsGroup(Group):
     def translateUI(self):
         self.setTitle(_("Signs"))
-        
+
     def actionTexts(self):
         yield 'fermata', _("Fermata")
         yield 'shortfermata', _("Short fermata")
@@ -194,7 +194,7 @@ class SignsGroup(Group):
 class OtherGroup(Group):
     def translateUI(self):
         self.setTitle(_("Other"))
-    
+
     def actionTexts(self):
         yield 'upbow', _("Upbow")
         yield 'downbow', _("Downbow")
@@ -212,10 +212,10 @@ class OtherGroup(Group):
 
 def articulation_positions(cursor):
     """Returns a list of positions where an articulation can be added.
-    
+
     Every position is given as a QTextCursor instance.
     If the cursor has a selection, all positions in the selection are returned.
-    
+
     """
     c = lydocument.cursor(cursor)
     if not cursor.hasSelection():
@@ -226,7 +226,7 @@ def articulation_positions(cursor):
     else:
         rests = False
         partial = ly.document.INSIDE
-    
+
     positions = []
     for item in ly.rhythm.music_items(c, partial):
         if not rests and item.tokens and isinstance(item.tokens[0], ly.lex.lilypond.Rest):

--- a/frescobaldi_app/quickinsert/barlines.py
+++ b/frescobaldi_app/quickinsert/barlines.py
@@ -32,7 +32,7 @@ from . import buttongroup
 
 class BarLines(tool.Tool):
     """Barlines tool in the quick insert panel toolbox.
-    
+
     """
     def __init__(self, panel):
         super(BarLines, self).__init__(panel)
@@ -43,11 +43,11 @@ class BarLines(tool.Tool):
     def icon(self):
         """Should return an icon for our tab."""
         return symbols.icon("bar_single")
-    
+
     def title(self):
         """Should return a title for our tab."""
         return _("Bar Lines")
-  
+
     def tooltip(self):
         """Returns a tooltip"""
         return _("Bar lines, breathing signs, etcetera.")
@@ -56,7 +56,7 @@ class BarLines(tool.Tool):
 class BarlinesGroup(buttongroup.ButtonGroup):
     def translateUI(self):
         self.setTitle(_("Bar Lines"))
-        
+
     def barlines(self):
         yield "bar_double", "||", "||", _("Double bar line")
         yield "bar_end", "|.", "|.", _("Ending bar line")
@@ -80,17 +80,17 @@ class BarlinesGroup(buttongroup.ButtonGroup):
         yield "bar_repeat_angled_end", None, ":|]", _("Angled repeat end")
         yield "bar_repeat_angled_double", None, ":|][|:", _("Angled repeat both")
         yield "bar_kievan", None, "k", _("Kievan bar line")
-    
+
     def actionData(self):
         self._barlines = {}
         for name, ly_text, ly_text_2_18, title in self.barlines():
             yield name, symbols.icon(name), None
             self._barlines[name] = ly_text, ly_text_2_18
-        
+
     def actionTexts(self):
         for name, ly_text, ly_text_2_18, title in self.barlines():
             yield name, title
-    
+
     def actionTriggered(self, name):
         version = documentinfo.docinfo(self.mainwindow().currentDocument()).version()
         glyphs = self._barlines[name]
@@ -109,7 +109,7 @@ class BreatheGroup(buttongroup.ButtonGroup):
     def actionData(self):
         for name, title in self.actionTexts():
             yield name, symbols.icon(name), None
-            
+
     def actionTexts(self):
         yield 'breathe_rcomma', _("Default Breathing Sign")
         yield 'breathe_rvarcomma', _("Straight Breathing Sign")

--- a/frescobaldi_app/quickinsert/buttongroup.py
+++ b/frescobaldi_app/quickinsert/buttongroup.py
@@ -39,16 +39,16 @@ import widgets.shortcuteditdialog
 
 class ButtonGroup(QGroupBox):
     """Inherit this class to create a group of buttons.
-    
+
     You should implement:
     - translateUI() to set the title
     - actionData() to yield name, icon, function for every button
     - actionTexts() to yield name, text for every button
     - actionTriggered() (if you don't supply a function) to implement the
       handler for the action.
-    
+
     """
-      
+
     def __init__(self, tool):
         super(ButtonGroup, self).__init__(tool)
         self._tool = weakref.ref(tool)
@@ -61,31 +61,31 @@ class ButtonGroup(QGroupBox):
         self.createButtons()
         app.translateUI(self)
         app.languageChanged.connect(self.setActionTexts)
-        
+
     def translateUI(self):
         """Should set our title."""
         pass
-    
+
     def tool(self):
         return self._tool()
-    
+
     def mainwindow(self):
         return self.tool().panel().parent().mainwindow()
-    
+
     def actionDict(self):
         """Returns the Quick Insert action dictionary."""
         return self.tool().panel().actionDict
-        
+
     def direction(self):
         """ The value of the generic direction widget.
-        
+
         -1 == Down
          0 == Neutral
          1 == Up
-         
+
         """
         return 1 - self.tool().panel().direction.currentIndex()
-        
+
     def createActions(self):
         actionDict = self.actionDict()
         self._names = []
@@ -96,13 +96,13 @@ class ButtonGroup(QGroupBox):
                 function = (lambda name: lambda: self.actionTriggered(name))(name)
             a.triggered.connect(function)
             self._names.append(name)
-    
+
     def setActionTexts(self):
         actionDict = self.actionDict()
         for name, text in self.actionTexts():
             actionDict[name].setText(text)
             actionDict[name].setToolTip(text)
-    
+
     def createButtons(self):
         actionDict = self.actionDict()
         layout = self.layout()
@@ -111,33 +111,33 @@ class ButtonGroup(QGroupBox):
         for num, name in enumerate(self._names, row*columns):
             b = Button(self, name, actionDict[name])
             layout.addWidget(b, *divmod(num, columns))
-            
+
     def focusView(self):
         """Always called when an action is triggered; focuses the main view."""
         self.mainwindow().currentView().setFocus()
-        
+
     def actionData(self):
         """Should yield name, icon, function (may be None) for every action."""
         pass
-    
+
     def actionTexts(self):
         """Should yield name, text for very action."""
         pass
-    
+
     def actionTriggered(self, name):
         """Called by default when a button is activated."""
         print (("Action triggered: {0}").format(name)) # DEBUG
-    
+
     def insertText(self, text, indent=True, blankline=False):
         """Insert text in the current document and focuses the document again.
-        
+
         Besides the text, the following keyword arguments may be used:
-        
+
         indent (default: True): The text will be indented if there are one or
             more newlines in it.
         blankline (default: False): A newline will be prepended to text if the
             cursor is currently not on a blank line.
-        
+
         """
         cursor = self.mainwindow().textCursor()
         if blankline and not cursor.hasSelection() and not cursortools.isblank_before(cursor):
@@ -158,10 +158,10 @@ class Button(QToolButton):
         self.setDefaultAction(action)
         self.setAutoRaise(True)
         self.setIconSize(QSize(22, 22))
-    
+
     def actionCollection(self):
         return self.parent().tool().panel().parent().actionCollection
-    
+
     def key(self):
         """Returns a textual representation of the configured shortcut if it exists."""
         shortcuts = self.actionCollection().shortcuts(self.objectName())
@@ -170,7 +170,7 @@ class Button(QToolButton):
             if len(shortcuts) > 1:
                 key += "..."
             return key
-    
+
     def event(self, ev):
         if ev.type() == QEvent.ToolTip:
             text = self.defaultAction().text()
@@ -180,7 +180,7 @@ class Button(QToolButton):
             QToolTip.showText(ev.globalPos(), text)
             return True
         return super(Button, self).event(ev)
-    
+
     def contextMenuEvent(self, ev):
         m = QMenu(self)
         a = m.addAction(_("Configure Keyboard Shortcut ({key})").format(key = self.key() or _("None")))
@@ -198,9 +198,9 @@ class Button(QToolButton):
         mgr = actioncollectionmanager.manager(mainwindow)
         skip = (self.actionCollection(), self.objectName())
         cb = mgr.findShortcutConflict
-        
+
         dlg = shortcuteditdialog.ShortcutEditDialog(self, cb, skip)
         if dlg.editAction(action, default):
             mgr.removeShortcuts(action.shortcuts())
             self.actionCollection().setShortcuts(self.objectName(), action.shortcuts())
-        
+

--- a/frescobaldi_app/quickinsert/dynamics.py
+++ b/frescobaldi_app/quickinsert/dynamics.py
@@ -48,18 +48,18 @@ class Dynamics(tool.Tool):
             autoRaise=True,
             popupMode=QToolButton.InstantPopup,
             icon=icons.get('edit-clear'))
-        
+
         mainwindow = panel.parent().mainwindow()
         mainwindow.selectionStateChanged.connect(self.removemenu.setEnabled)
         self.removemenu.setEnabled(mainwindow.hasSelection())
-        
+
         ac = documentactions.DocumentActions.instance(mainwindow).actionCollection
         self.removemenu.addAction(ac.tools_quick_remove_dynamics)
-        
+
         layout = QHBoxLayout()
         layout.addWidget(self.removemenu)
         layout.addStretch(1)
-        
+
         self.layout().addLayout(layout)
         self.layout().addWidget(DynamicGroup(self))
         self.layout().addWidget(SpannerGroup(self))
@@ -68,11 +68,11 @@ class Dynamics(tool.Tool):
     def icon(self):
         """Should return an icon for our tab."""
         return symbols.icon("dynamic_f")
-    
+
     def title(self):
         """Should return a title for our tab."""
         return _("Dynamics")
-  
+
     def tooltip(self):
         """Returns a tooltip"""
         return _("Dynamic symbols.")
@@ -140,13 +140,13 @@ class DynamicGroup(Group):
     def translateUI(self):
         # L10N: dynamic signs
         self.setTitle(_("Signs"))
-    
+
     def actionData(self):
         """Should yield name, icon, function (may be None) for every action."""
         for m in dynamic_marks:
             name = 'dynamic_' + m
             yield name, symbols.icon(name), None
-    
+
     def actionTexts(self):
         """Should yield name, text for very action."""
         for m in dynamic_marks:
@@ -158,12 +158,12 @@ class DynamicGroup(Group):
 class SpannerGroup(Group):
     def translateUI(self):
         self.setTitle(_("Spanners"))
-    
+
     def actionData(self):
         """Should yield name, icon, function (may be None) for every action."""
         for name, title in self.actionTexts():
             yield name, symbols.icon(name), None
-    
+
     def actionTexts(self):
         """Should yield name, text for very action."""
         yield 'dynamic_hairpin_cresc', _("Hairpin crescendo")
@@ -171,7 +171,7 @@ class SpannerGroup(Group):
         yield 'dynamic_hairpin_dim', _("Hairpin diminuendo")
         yield 'dynamic_dim', _("Diminuendo")
         yield 'dynamic_decresc', _("Decrescendo")
-        
+
 
 def dynamics(cursor):
     """Returns a tuple of dynamic tokens (including _ or ^) at the cursor."""

--- a/frescobaldi_app/quickinsert/spanners.py
+++ b/frescobaldi_app/quickinsert/spanners.py
@@ -47,20 +47,20 @@ class Spanners(tool.Tool):
             autoRaise=True,
             popupMode=QToolButton.InstantPopup,
             icon=icons.get('edit-clear'))
-        
+
         mainwindow = panel.parent().mainwindow()
         mainwindow.selectionStateChanged.connect(self.removemenu.setEnabled)
         self.removemenu.setEnabled(mainwindow.hasSelection())
-        
+
         ac = documentactions.DocumentActions.instance(mainwindow).actionCollection
         self.removemenu.addAction(ac.tools_quick_remove_slurs)
         self.removemenu.addAction(ac.tools_quick_remove_beams)
         self.removemenu.addAction(ac.tools_quick_remove_ligatures)
-        
+
         layout = QHBoxLayout()
         layout.addWidget(self.removemenu)
         layout.addStretch(1)
-        
+
         self.layout().addLayout(layout)
         self.layout().addWidget(ArpeggioGroup(self))
         self.layout().addWidget(GlissandoGroup(self))
@@ -71,11 +71,11 @@ class Spanners(tool.Tool):
     def icon(self):
         """Should return an icon for our tab."""
         return symbols.icon("spanner_phrasingslur")
-    
+
     def title(self):
         """Should return a title for our tab."""
         return _("Spanners")
-  
+
     def tooltip(self):
         """Returns a tooltip"""
         return _("Slurs, spanners, etcetera.")
@@ -84,12 +84,12 @@ class Spanners(tool.Tool):
 class ArpeggioGroup(buttongroup.ButtonGroup):
     def translateUI(self):
         self.setTitle(_("Arpeggios"))
-    
+
     def actionData(self):
         """Should yield name, icon, function (may be None) for every action."""
         for name, title in self.actionTexts():
             yield name, symbols.icon(name), None
-    
+
     def actionTexts(self):
         """Should yield name, text for very action."""
         yield 'arpeggio_normal', _("Arpeggio")
@@ -97,7 +97,7 @@ class ArpeggioGroup(buttongroup.ButtonGroup):
         yield 'arpeggio_arrow_down', _("Arpeggio with Down Arrow")
         yield 'arpeggio_bracket', _("Bracket Arpeggio")
         yield 'arpeggio_parenthesis', _("Parenthesis Arpeggio")
-        
+
     def actionTriggered(self, name):
         # convert arpeggio_normal to arpeggioNormal, etc.
         name = _arpeggioTypes[name]
@@ -126,17 +126,17 @@ class ArpeggioGroup(buttongroup.ButtonGroup):
                     c.insertText(name + '\n' + indent)
                 # just pick the first place
                 return
-        
+
 
 class GlissandoGroup(buttongroup.ButtonGroup):
     def translateUI(self):
         self.setTitle(_("Glissandos"))
-    
+
     def actionData(self):
         """Should yield name, icon, function (may be None) for every action."""
         for name, title in self.actionTexts():
             yield name, symbols.icon(name), None
-    
+
     def actionTexts(self):
         """Should yield name, text for very action."""
         yield 'glissando_normal', _("Glissando")
@@ -164,7 +164,7 @@ class GlissandoGroup(buttongroup.ButtonGroup):
 class SpannerGroup(buttongroup.ButtonGroup):
     def translateUI(self):
         self.setTitle(_("Spanners"))
-    
+
     def actionData(self):
         for name, title in self.actionTexts():
             yield name, symbols.icon(name), None
@@ -198,11 +198,11 @@ class SpannerGroup(buttongroup.ButtonGroup):
 class GraceGroup(buttongroup.ButtonGroup):
     def translateUI(self):
         self.setTitle(_("Grace Notes"))
-        
+
     def actionData(self):
         for name, title in self.actionTexts():
             yield name, symbols.icon(name), None
-            
+
     def actionTexts(self):
         yield 'grace_grace', _("Grace Notes")
         yield 'grace_beam', _("Grace Notes w. beaming")
@@ -210,7 +210,7 @@ class GraceGroup(buttongroup.ButtonGroup):
         yield 'grace_appog', _("Appoggiatura")
         yield 'grace_slash', _("Slashed no slur")
         yield 'grace_after', _("After grace")
-        
+
     def actionTriggered(self, name):
         d = ['_', '', '^'][self.direction()+1]
         single = ''
@@ -234,15 +234,15 @@ class GraceGroup(buttongroup.ButtonGroup):
             outer = '\\slashedGrace { ', ' }'
         elif name == "grace_after":
             inner = d + '{ '
-            outer = '\\afterGrace ', ' }'               
+            outer = '\\afterGrace ', ' }'
 
         cursor = self.mainwindow().textCursor()
         with cursortools.compress_undo(cursor):
-            if inner:     
+            if inner:
                 for i, ci in zip(inner, spanner_positions(cursor)):
                     ci.insertText(i)
             if cursor.hasSelection():
-                ins = self.mainwindow().textCursor()      
+                ins = self.mainwindow().textCursor()
                 ins.setPosition(cursor.selectionStart())
                 ins.insertText(outer[0])
                 ins.setPosition(cursor.selectionEnd())
@@ -269,11 +269,11 @@ class GraceGroup(buttongroup.ButtonGroup):
 
 def spanner_positions(cursor):
     """Return a list with 0 to 2 QTextCursor instances.
-    
+
     At the first cursor a starting spanner item can be inserted, at the
     second an ending item.
-    
-    """   
+
+    """
     c = lydocument.cursor(cursor)
     if cursor.hasSelection():
         partial = ly.document.INSIDE
@@ -281,21 +281,21 @@ def spanner_positions(cursor):
         # just select until the end of the current line
         c.select_end_of_block()
         partial = ly.document.OUTSIDE
-    
+
     items = list(ly.rhythm.music_items(c, partial=partial))
     if cursor.hasSelection():
         del items[1:-1]
     else:
         del items[2:]
-    
+
     positions = []
     for i in items:
         c = QTextCursor(cursor.document())
         c.setPosition(i.end)
         positions.append(c)
     return positions
-        
-    
+
+
 
 
 _arpeggioTypes = {

--- a/frescobaldi_app/quickinsert/tool.py
+++ b/frescobaldi_app/quickinsert/tool.py
@@ -29,7 +29,7 @@ from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 class Tool(QWidget):
     """Base class for a tool in the quick insert panel toolbox.
-    
+
     """
     def __init__(self, panel):
         super(Tool, self).__init__(panel)
@@ -37,15 +37,15 @@ class Tool(QWidget):
         layout = QVBoxLayout()
         self.setLayout(layout)
         layout.setContentsMargins(0, 0, 0, 0)
-    
+
     def panel(self):
         """Returns the panel."""
         return self._panel()
-    
+
     def icon(self):
         """Should return an icon for our tab."""
         pass
-    
+
     def title(self):
         """Should return a title for our tab."""
         pass

--- a/frescobaldi_app/quickinsert/widget.py
+++ b/frescobaldi_app/quickinsert/widget.py
@@ -46,11 +46,11 @@ class QuickInsert(QWidget):
         self._dockwidget = weakref.ref(dockwidget)
         # filled in by ButtonGroup subclasses
         self.actionDict = {}
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
         layout.setContentsMargins(0, 0, 0, 0)
-        
+
         self.helpButton = QToolButton(
             icon = icons.get("help-contents"),
             autoRaise = True,
@@ -67,11 +67,11 @@ class QuickInsert(QWidget):
         hor.addWidget(self.directionLabel)
         hor.addWidget(self.direction)
         layout.addLayout(hor)
-        
+
         self.toolbox = QToolBox(self)
         gadgets.toolboxwheeler.ToolBoxWheeler(self.toolbox)
         layout.addWidget(self.toolbox)
-        
+
         for cls in (
                 articulations.Articulations,
                 dynamics.Dynamics,
@@ -80,10 +80,10 @@ class QuickInsert(QWidget):
             ):
             widget = cls(self)
             self.toolbox.addItem(widget, widget.icon(), '')
-        
+
         app.translateUI(self)
         userguide.openWhatsThis(self)
-        
+
         # restore remembered current page
         name = QSettings().value("quickinsert/current_tool", "", str)
         if name:
@@ -92,11 +92,11 @@ class QuickInsert(QWidget):
                     self.toolbox.setCurrentIndex(i)
                     break
         self.toolbox.currentChanged.connect(self.slotCurrentChanged)
-        
+
     def slotCurrentChanged(self, index):
         name = self.toolbox.widget(index).__class__.__name__.lower()
         QSettings().setValue("quickinsert/current_tool", name)
-    
+
     def translateUI(self):
         self.setWhatsThis(_(
             "<p>With the Quick Insert Panel you can add various music "
@@ -110,7 +110,7 @@ class QuickInsert(QWidget):
         for i in range(self.toolbox.count()):
             self.toolbox.setItemText(i, self.toolbox.widget(i).title())
             self.toolbox.setItemToolTip(i, self.toolbox.widget(i).tooltip())
-            
+
     def actionForName(self, name):
         """This is called by the ShortcutCollection of our dockwidget, e.g. if the user presses a key."""
         try:

--- a/frescobaldi_app/quickremove.py
+++ b/frescobaldi_app/quickremove.py
@@ -35,12 +35,12 @@ import ly.lex.lilypond
 
 def remove(func):
     """Decorator turning a function yielding ranges into removing the ranges.
-    
-    Note that you should call the function with a QTextCursor as the first 
-    argument. The returned decorator converts the QTextCursor to a 
-    ly.document.Cursor, calls the function and removes the ranges returned 
+
+    Note that you should call the function with a QTextCursor as the first
+    argument. The returned decorator converts the QTextCursor to a
+    ly.document.Cursor, calls the function and removes the ranges returned
     by the function.
-    
+
     """
     @functools.wraps(func)
     def decorator(cursor, *args):
@@ -72,12 +72,12 @@ def is_instrument_script(token):
 
 def find_positions(cursor, predicate, predicate_dir=None):
     """Yields positions (start, end) for tokens predicate returns True for.
-    
+
     The tokens (gotten from the cursor's selection) may be preceded by a
     ly.lex.lilypond.Direction token.
     If predicate_dir is specified, it is used for the items following a
     Direction tokens, otherwise predicate is also used for that case.
-    
+
     """
     if predicate_dir is None:
         predicate_dir = predicate
@@ -103,7 +103,7 @@ def comments(cursor):
         if isinstance(token, ly.lex.Comment):
             yield token.pos, token.end
 
-    
+
 @remove
 def articulations(cursor):
     """Remove articulations from the cursor's selection."""
@@ -184,10 +184,10 @@ def markup(cursor):
 @remove
 def smart_delete(cursor, backspace=False):
     r"""This function intelligently deletes an item the cursor is at.
-    
+
     Basically it behaves like normal Delete (cursor.deleteChar()) or BackSpace
     (cursor.deletePreviousChar()), but it performs the following:
-    
+
     - if the item is a matching object (, ), [, ], \[, \] etc, the other item is
       deleted as well
     - if the item is an articulation it is deleted completely with direction
@@ -195,7 +195,7 @@ def smart_delete(cursor, backspace=False):
     - if the cursor is on a note, the whole notename is deleted including
       postfix stuff
     - if the cursor is on the '<' of a chord, the whole chord is deleted
-    
+
     TODO: implement
     """
     pass

--- a/frescobaldi_app/qutil.py
+++ b/frescobaldi_app/qutil.py
@@ -35,14 +35,14 @@ import appinfo
 
 def saveDialogSize(dialog, key, default=QSize()):
     """Makes the size of a QDialog persistent.
-    
+
     Resizes a QDialog from the setting saved in QSettings().value(key),
     defaulting to the optionally specified default size, and stores the
     size of the dialog at its finished() signal.
-    
+
     Call this method at the end of the dialog constructor, when its
     widgets are instantiated.
-    
+
     """
     size = QSettings().value(key, default, QSize)
     if size:
@@ -78,12 +78,12 @@ def deleteLater(*qobjs):
 
 def addAccelerators(actions, used=[]):
     """Adds accelerators to the list of QActions (or QLabels used as buddy).
-    
+
     Actions that have accelerators are skipped, the accelerators that they use
     are not used. This can be used for e.g. menus that are created on the fly.
-    
+
     used is a sequence of already used accelerators (in lower case).
-    
+
     """
     # filter out the actions that already have an accelerator
     todo = []
@@ -92,13 +92,13 @@ def addAccelerators(actions, used=[]):
         if a.text():
             accel = getAccelerator(a.text())
             used.add(accel) if accel else todo.append(a)
-    
+
     def finditers(action):
         """Yields two-tuples (priority, re.finditer object).
-        
+
         The finditer object finds suitable accelerator positions.
         The priority can be used if multiple actions want the same shortcut.
-        
+
         """
         text = action.text()
         if isinstance(action, QAction) and not action.shortcut().isEmpty():
@@ -109,15 +109,15 @@ def addAccelerators(actions, used=[]):
                 yield 0, re.finditer(r'\b{0:c}'.format(key), text, re.I)
         yield 1, re.finditer(r'\b\w', text)
         yield 2, re.finditer(r'\B\w', text)
-    
+
     def find(action):
         """Yields three-tuples (priority, pos, accel) from finditers()."""
         for prio, matches in finditers(action):
             for m in matches:
                 yield prio, m.start(), m.group().lower()
-    
+
     todo = [(a, find(a)) for a in todo]
-    
+
     while todo:
         # just pick the first accel for every action
         accels = {}
@@ -126,7 +126,7 @@ def addAccelerators(actions, used=[]):
                 if accel not in used:
                     accels.setdefault(accel, []).append((prio, pos, a, source))
                     break
-        
+
         # now, fore every accel, if more than one action wants the same accel,
         # pick the action with the first priority or position, and try again the
         # other actions.
@@ -141,9 +141,9 @@ def addAccelerators(actions, used=[]):
 
 def getAccelerator(text):
     """Returns the accelerator (in lower case) contained in the text, if any.
-    
+
     An accelerator is a character preceded by an ampersand &.
-    
+
     """
     m = re.search(r'&(\w)', text.replace('&&', ''))
     if m:
@@ -191,11 +191,11 @@ def mixcolor(color1, color2, mix):
 @contextlib.contextmanager
 def busyCursor(cursor=Qt.WaitCursor, processEvents=True):
     """Performs the contained code using a busy cursor.
-    
+
     The default cursor used is Qt.WaitCursor.
     If processEvents is True (the default), QApplication.processEvents()
     will be called once before the contained code is executed.
-    
+
     """
     QApplication.setOverrideCursor(cursor)
     processEvents and QApplication.processEvents()
@@ -207,13 +207,13 @@ def busyCursor(cursor=Qt.WaitCursor, processEvents=True):
 
 def waitForSignal(signal, message="", timeout=0):
     """Waits (max timeout msecs if given) for a signal to be emitted.
-    
+
     It the waiting lasts more than 2 seconds, a progress dialog is displayed
     with the message.
-    
+
     Returns True if the signal was emitted.
     Return False if the wait timed out or the dialog was canceled by the user.
-    
+
     """
     loop = QEventLoop()
     dlg = QProgressDialog(minimum=0, maximum=0, labelText=message)

--- a/frescobaldi_app/recentfiles.py
+++ b/frescobaldi_app/recentfiles.py
@@ -43,7 +43,7 @@ def load():
     if _recentfiles is not None:
         return
     _recentfiles = []
-    
+
     urls = qsettings.get_url_list(QSettings(), "recent_files")
     for url in urls:
         if os.access(url.toLocalFile(), os.R_OK):
@@ -57,7 +57,7 @@ def save():
 def urls():
     load()
     return _recentfiles
-    
+
 def add(url):
     load()
     if url in _recentfiles:
@@ -69,4 +69,4 @@ def remove(url):
     load()
     if url in _recentfiles:
         _recentfiles.remove(url)
-        
+

--- a/frescobaldi_app/reformat.py
+++ b/frescobaldi_app/reformat.py
@@ -52,9 +52,9 @@ def reformat(cursor):
 
 def remove_trailing_whitespace(cursor):
     """Remove trailing whitespace from all lines in the selection.
-    
+
     If there is no selection, the whole document is used.
-    
+
     """
     ly.reformat.remove_trailing_whitespace(lydocument.cursor(cursor, select_all=True))
 

--- a/frescobaldi_app/remote/__init__.py
+++ b/frescobaldi_app/remote/__init__.py
@@ -51,9 +51,9 @@ def init():
     global _server
     if _server is not None:
         return
-    
+
     server = QLocalServer(None)
-    
+
     # find a free socket name to use
     for name in ids():
         if server.listen(name):
@@ -102,30 +102,30 @@ def ids(count=3):
 
 def generate_id():
     """Generate a name for the IPC socket.
-    
+
     The name is unique for the application, the user id and the DISPLAY
     on X11.
-    
+
     """
     name = [appinfo.name]
-    
+
     try:
         name.append(format(os.getuid()))
     except AttributeError:
         pass
-    
+
     display = os.environ.get("DISPLAY")
     if display:
         name.append(display.replace(':', '_').replace('/', '_'))
-    
+
     return '-'.join(name)
 
 
 def enabled():
     """Return whether remote support is enabled.
-    
+
     By default it is enabled.
-    
+
     """
     return QSettings().value('allow_remote', True, bool)
 

--- a/frescobaldi_app/remote/api.py
+++ b/frescobaldi_app/remote/api.py
@@ -39,7 +39,7 @@ class Remote(object):
     """Speak to the remote Frescobaldi."""
     def __init__(self, socket):
         self.socket = socket
-    
+
     def close(self):
         """Close and disconnect."""
         self.write(b'bye\n')
@@ -47,13 +47,13 @@ class Remote(object):
         self.socket.disconnectFromServer()
         if self.socket.state() == QLocalSocket.ConnectedState:
             self.socket.waitForDisconnected(5000)
-    
+
     def write(self, data):
         """Writes binary data."""
         while data:
             l = self.socket.write(data)
             data = data[l:]
-    
+
     def command_line(self, args, urls):
         """Let remote Frescobaldi handle a command line."""
         if urls:
@@ -76,12 +76,12 @@ class Incoming(object):
         self.encoding = None
         _incoming_handlers.append(self)
         socket.readyRead.connect(self.read)
-    
+
     def close(self):
         if self in _incoming_handlers:
             self.socket.deleteLater()
             _incoming_handlers.remove(self)
-    
+
     def read(self):
         """Read from the socket and let command() handle the commands."""
         self.data.extend(self.socket.readAll())
@@ -94,23 +94,23 @@ class Incoming(object):
         del self.data[:end]
         if self.socket.state() == QLocalSocket.UnconnectedState:
             self.close()
-    
+
     def command(self, command):
         """Perform one command."""
         command = command.split()
         cmd = command[0]
         args = command[1:]
-        
+
         win = app.activeWindow()
         if not win:
             import mainwindow
             win = mainwindow.MainWindow()
             win.show()
-        
+
         if cmd == b'open':
             url = QUrl.fromEncoded(args[0])
             win.openUrl(url, self.encoding)
-                
+
         elif cmd == b'encoding':
             self.encoding = str(args[0])
         elif cmd == b'activate_window':

--- a/frescobaldi_app/rest/__init__.py
+++ b/frescobaldi_app/rest/__init__.py
@@ -36,17 +36,17 @@ class Rest(plugin.MainWindowPlugin):
         ac.rest_fmrest2spacer.triggered.connect(self.fmrest2spacer)
         ac.rest_spacer2fmrest.triggered.connect(self.spacer2fmrest)
         ac.rest_restcomm2rest.triggered.connect(self.restcomm2rest)
-    
+
     def fmrest2spacer(self):
         from . import rest
         cursor = self.mainwindow().textCursor()
         rest.fmrest2spacer(cursor)
-    
+
     def spacer2fmrest(self):
         from . import rest
         cursor = self.mainwindow().textCursor()
         rest.spacer2fmrest(cursor)
-    
+
     def restcomm2rest(self):
         from . import rest
         cursor = self.mainwindow().textCursor()
@@ -59,7 +59,7 @@ class Actions(actioncollection.ActionCollection):
         self.rest_fmrest2spacer = QAction(parent)
         self.rest_spacer2fmrest = QAction(parent)
         self.rest_restcomm2rest = QAction(parent)
-        
+
     def translateUI(self):
         self.rest_fmrest2spacer.setText(_(
             "Replace full measure rests with spacer rests"))
@@ -76,4 +76,4 @@ class Actions(actioncollection.ActionCollection):
         self.rest_restcomm2rest.setToolTip(_(
             "Change all \\rest with r "
             "in this document or in the selection."))
-        
+

--- a/frescobaldi_app/resultfiles.py
+++ b/frescobaldi_app/resultfiles.py
@@ -41,7 +41,7 @@ def results(document):
 @app.jobStarted.connect
 def _init_basenames(document, job):
     results(document).saveDocumentInfo(job.start_time())
-    
+
 
 
 class Results(plugin.DocumentPlugin):
@@ -51,20 +51,20 @@ class Results(plugin.DocumentPlugin):
         self._basenames = None
         self._start_time = 0.0
         document.saved.connect(self.forgetDocumentInfo)
-        
+
     def saveDocumentInfo(self, start_time):
         """Takes over some vital information from a DocumentInfo instance.
-        
+
         This method is called as soon as a job is started.
-        
+
         The file a job is run on and the basenames expected to be created are saved.
         When the user saves a Document after a Job has run, this information is 'forgotten' again.
-        
+
         Otherwise the results of a Job would not be seen if the user starts a Job and then
         saves the Document while the job is still running.  The Job uses the scratcharea if the
         document was modified but saving it would result in DocumentInfo.jobinfo()[0] pointing
         to the real document instead.
-        
+
         """
         info = documentinfo.info(self.document())
         self._start_time = start_time
@@ -73,15 +73,15 @@ class Results(plugin.DocumentPlugin):
 
     def forgetDocumentInfo(self):
         """Called when the user saves a Document.
-        
+
         'Forgets' the basenames and job filename if set, but only if no job is currently running.
-        
+
         """
         if not jobmanager.is_running(self.document()):
             self._start_time = 0.0
             self._jobfile = None
             self._basenames = None
-            
+
     def jobfile(self):
         """Returns the file that is currently being, or will be, engraved."""
         if self._jobfile is None:
@@ -96,13 +96,13 @@ class Results(plugin.DocumentPlugin):
 
     def files(self, extension = '*', newer = True):
         """Returns a list of existing files matching our basenames and the given extension.
-        
+
         First the files basename + extension are returned,
         then basename + '-[0-9]+' + extension,
         then basename + '-.+' + extension.
-        
+
         If newer is True (the default), only files that are newer than the jobfile() are returned.
-        
+
         """
         jobfile = self.jobfile()
         if jobfile:
@@ -114,13 +114,13 @@ class Results(plugin.DocumentPlugin):
                     pass
             return list(files)
         return []
-    
+
     def files_lastjob(self, extension = '*'):
         """Like files(), but only returns files that were created by the last job.
-        
+
         If no job has yet run on the document, returns the same files as the
         files_uptodate() method.
-        
+
         """
         if self._start_time:
             files = util.files(self.basenames(), extension)
@@ -131,12 +131,12 @@ class Results(plugin.DocumentPlugin):
             return files
         else:
             return self.files(extension)
-    
+
     def is_newer(self, filename):
         """Return True if the given (generated) file is newer than the jobfile().
-        
+
         Also return True if the mtime of one of the files could not be read.
-        
+
         """
         jobfile = self.jobfile()
         if jobfile:
@@ -145,12 +145,12 @@ class Results(plugin.DocumentPlugin):
             except (OSError, IOError):
                 pass
         return True
-        
+
     def currentDirectory(self):
         """Returns the directory the document resides in.
-        
+
         Returns the temporary directory if that was used last.
-        
+
         """
         directory = os.path.dirname(self.jobfile())
         if os.path.isdir(directory):

--- a/frescobaldi_app/rhythm/__init__.py
+++ b/frescobaldi_app/rhythm/__init__.py
@@ -49,7 +49,7 @@ class Rhythm(plugin.MainWindowPlugin):
         ac.rhythm_apply.triggered.connect(self.rhythm_apply)
         ac.rhythm_copy.triggered.connect(self.rhythm_copy)
         ac.rhythm_paste.triggered.connect(self.rhythm_paste)
-        
+
     def updateSelection(self, selection):
         ac = self.actionCollection
         ac.rhythm_double.setEnabled(selection)
@@ -70,62 +70,62 @@ class Rhythm(plugin.MainWindowPlugin):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_double(cursor)
-        
+
     def rhythm_halve(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_halve(cursor)
-        
+
     def rhythm_dot(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_dot(cursor)
-        
+
     def rhythm_undot(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_undot(cursor)
-        
+
     def rhythm_remove_scaling(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_remove_scaling(cursor)
-        
+
     def rhythm_remove_fraction_scaling(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_remove_fraction_scaling(cursor)
-        
+
     def rhythm_remove(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_remove(cursor)
-        
+
     def rhythm_implicit(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_implicit(cursor)
-        
+
     def rhythm_implicit_per_line(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_implicit_per_line(cursor)
-        
+
     def rhythm_explicit(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_explicit(cursor)
-        
+
     def rhythm_apply(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_apply(cursor, self.mainwindow())
-        
+
     def rhythm_copy(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
         rhythm.rhythm_copy(cursor)
-        
+
     def rhythm_paste(self):
         cursor = self.mainwindow().textCursor()
         from . import rhythm
@@ -148,7 +148,7 @@ class Actions(actioncollection.ActionCollection):
         self.rhythm_apply = QAction(parent)
         self.rhythm_copy = QAction(parent)
         self.rhythm_paste = QAction(parent)
-    
+
     def translateUI(self):
         self.rhythm_double.setText(_("&Double durations"))
         self.rhythm_double.setToolTip(_(

--- a/frescobaldi_app/scorewiz/__init__.py
+++ b/frescobaldi_app/scorewiz/__init__.py
@@ -37,14 +37,14 @@ class ScoreWizard(plugin.MainWindowPlugin):
         actioncollectionmanager.manager(mainwindow).addActionCollection(ac)
         ac.scorewiz.triggered.connect(self.showDialog)
         self._dlg = None
-    
+
     def dialog(self):
         """Return the wizard dialog, creating it if necessary."""
         if self._dlg is None:
             from . import dialog
             self._dlg = dialog.ScoreWizardDialog(self.mainwindow())
         return self._dlg
-        
+
     def showDialog(self):
         self.dialog().show()
 
@@ -56,7 +56,7 @@ class Actions(actioncollection.ActionCollection):
         self.scorewiz.setIcon(icons.get("tools-score-wizard"))
         self.scorewiz.setShortcut(QKeySequence("Ctrl+Shift+N"))
         self.scorewiz.setMenuRole(QAction.NoRole)
-        
+
     def translateUI(self):
         self.scorewiz.setText(_("Score &Wizard..."))
 

--- a/frescobaldi_app/scorewiz/build.py
+++ b/frescobaldi_app/scorewiz/build.py
@@ -35,16 +35,16 @@ from . import parts
 
 class PartNode(object):
     """Represents an item with sub-items in the parts tree.
-    
+
     Sub-items of this items are are split out in two lists: the 'parts' and
     'groups' attributes.
-    
+
     Parts ('parts' attribute) are vertically stacked (instrumental parts or
     staff groups). Groups ('groups' attribute) are horizontally added (score,
     book, bookpart).
-    
+
     The Part (containing the widgets) is in the 'part' attribute.
-    
+
     """
     def __init__(self, item):
         """item is a PartItem (QTreeWidgetItem)."""
@@ -61,23 +61,23 @@ class PartNode(object):
 
 class PartData(object):
     r"""Represents what a Part wants to add to the LilyPond score.
-    
+
     A Part may append to the following instance attributes (which are lists):
-    
+
     includes:           (string) filename to be included
     codeblocks:         (ly.dom.LyNode) global blocks of code a part depends on
     assignments:        (ly.dom.Assignment) assignment of an expression to a
                         variable, most times the music stub for a part
     nodes:              (ly.dom.LyNode) the nodes a part adds to the parent \score
     afterblocks:        (ly.dom.LyNode) other blocks, appended ad the end
-    
+
     The num instance attribute is set to 0 by default but can be increased by
     the Builder, when there are more parts of the exact same type in the same
     score.
-    
+
     This is used by the builder afterwards to adjust identifiers and instrument
     names to this.
-    
+
     """
     def __init__(self, part, parent=None):
         """part is a parts._base.Part instance, parent may be another PartData."""
@@ -92,13 +92,13 @@ class PartData(object):
         self.assignments = []
         self.nodes = []
         self.afterblocks = []
-    
+
     def name(self):
         """Returns a name for this part data.
-        
+
         The name consists of the class name of the part with the value of the num
         attribute appended as a roman number.
-        
+
         """
         if self.num:
             return self._name + ly.util.int2roman(self.num)
@@ -106,20 +106,20 @@ class PartData(object):
 
     def assign(self, name=None):
         """Creates a ly.dom.Assignment.
-        
+
         name is a string name, if not given the class name is used with the
         first letter lowered.
-        
+
         A ly.dom.Reference is used as the name for the Assignment.
         The assignment is appended to our assignments and returned.
-        
+
         The Reference is in the name attribute of the assignment.
-        
+
         """
         a = ly.dom.Assignment(ly.dom.Reference(name or ly.util.mkid(self.name())))
         self.assignments.append(a)
         return a
-    
+
     def assignMusic(self, name=None, octave=0, transposition=None):
         """Creates a ly.dom.Assignment with a \\relative music stub."""
         a = self.assign(name)
@@ -145,21 +145,21 @@ class BlockData(object):
 
 class Builder(object):
     """Builds the LilyPond score from all user input in the score wizard.
-    
+
     Reads settings and other input from the dialog on construction.
     Does not need the dialog after that.
-    
+
     """
     def __init__(self, dialog):
         """Initializes ourselves from all user settings in the dialog."""
         self._includeFiles = []
         self.globalUsed = False
-        
+
         scoreProperties = dialog.settings.widget().scoreProperties
         generalPreferences = dialog.settings.widget().generalPreferences
         lilyPondPreferences = dialog.settings.widget().lilyPondPreferences
         instrumentNames = dialog.settings.widget().instrumentNames
-        
+
         # attributes the Part and Container types may read and we need later as well
         self.header = list(dialog.header.widget().headers())
         self.headerDict = dict(self.header)
@@ -177,7 +177,7 @@ class Builder(object):
         names = ['long', 'short', None]
         self.firstInstrumentName = names[instrumentNames.firstSystem.currentIndex()]
         self.otherInstrumentName = names[instrumentNames.otherSystems.currentIndex()]
-        
+
         # translator for instrument names
         self._ = _
         if instrumentNames.isChecked():
@@ -188,11 +188,11 @@ class Builder(object):
                 mofile = po.find(lang)
                 if mofile:
                     self._ = po.translator(po.mofile.MoFile(mofile))
-        
+
         # global score preferences
         self.scoreProperties = scoreProperties
         self.globalSection = scoreProperties.globalSection(self)
-        
+
         # printer that converts the ly.dom tree to text
         p = self._printer = ly.dom.Printer()
         p.indentString = "  " # will be re-indented anyway
@@ -204,36 +204,36 @@ class Builder(object):
         p.secondary_quote_right = quotes.secondary.right
         if self.pitchLanguage:
             p.language = self.pitchLanguage
-        
+
         # get the parts
         globalGroup = PartNode(dialog.parts.widget().rootPartItem())
-        
+
         # move parts down the tree to subgroups that have no parts
         assignparts(globalGroup)
-        
+
         # now prepare the different blocks
         self.usePrefix = needsPrefix(globalGroup)
         self.currentScore = 0
-        
+
         # make a part of the document (assignments, scores, backmatter) for
         # every group (book, bookpart or score) in the global group
         if globalGroup.parts:
             groups = [globalGroup]
         else:
             groups = globalGroup.groups
-        
+
         self.blocks = []
         for group in groups:
             block = BlockData()
             self.makeBlock(group, block.scores, block)
             self.blocks.append(block)
-    
+
     def makeBlock(self, group, node, block):
         """Recursively populates the Block with data from the group.
-        
+
         The group can contain parts and/or subgroups.
         ly.dom.LyNodes representing the LilyPond document are added to the node.
-        
+
         """
         if group.part:
             node = group.part.makeNode(node)
@@ -241,7 +241,7 @@ class Builder(object):
             # prefix for this block, used if necessary
             self.currentScore += 1
             prefix = 'score' + ly.util.int2letter(self.currentScore)
-            
+
             # is this a score and has it its own score properties?
             globalName = 'global'
             scoreProperties = self.scoreProperties
@@ -255,7 +255,7 @@ class Builder(object):
                     ly.dom.BlankLine(block.assignments)
             if globalName == 'global':
                 self.globalUsed = True
-            
+
             # add parts here, always in \score { }
             score = node if isinstance(node,ly.dom.Score) else ly.dom.Score(node)
             ly.dom.Layout(score)
@@ -270,33 +270,33 @@ class Builder(object):
                         scoreProperties.lyMidiTempo(ly.dom.Context('Score', midi))
             music = ly.dom.Simr()
             score.insert(0, music)
-            
+
             # a PartData subclass "knowing" the globalName and scoreProperties
             class _PartData(PartData): pass
             _PartData.globalName = globalName
             _PartData.scoreProperties = scoreProperties
-                
+
             # make the parts
             partData = self.makeParts(group.parts, _PartData)
-            
+
             # record the include files a part wants to add
             for p in partData:
                 for i in p.includes:
                     if i not in self._includeFiles:
                         self._includeFiles.append(i)
-            
+
             # collect all 'prefixable' assignments for this group
             assignments = []
             for p in partData:
                 assignments.extend(p.assignments)
-                
+
             # add the assignments to the block
             for p in partData:
                 for a in p.assignments:
                     block.assignments.append(a)
                     ly.dom.BlankLine(block.assignments)
                 block.backmatter.extend(p.afterblocks)
-                
+
             # make part assignments if there is more than one part that has assignments
             if sum(1 for p in partData if p.assignments) > 1:
                 def make(part, music):
@@ -312,27 +312,27 @@ class Builder(object):
             else:
                 def make(part, music):
                     music.extend(part.nodes)
-            
+
             def makeRecursive(parts, music):
                 for part in parts:
                     make(part, music)
                     if part.children:
                         makeRecursive(part.children, part.music)
-            
+
             parents = [p for p in partData if not p.isChild]
             makeRecursive(parents, music)
-            
+
             # add the prefix to the assignments if necessary
             if self.usePrefix:
                 for a in assignments:
                     a.name.name = ly.util.mkid(prefix, a.name.name)
-            
+
         for g in group.groups:
             self.makeBlock(g, node, block)
-    
+
     def makeParts(self, parts, partDataClass):
         """Lets the parts build the music stubs and assignments.
-        
+
         parts is a list of PartNode instances.
         partDataClass is a subclass or PartData containing some attributes:
             - globalName is either 'global' (for the global time/key signature
@@ -340,9 +340,9 @@ class Builder(object):
               own properties).
             - scoreProperties is the ScoreProperties instance currently in effect
               (the global one or a particular Score part's one).
-        
+
         Returns the list of PartData object for the parts.
-        
+
         """
         # number instances of the same type (Choir I and Choir II, etc.)
         data = {}
@@ -361,7 +361,7 @@ class Builder(object):
         # now build all the parts
         for group in allparts(parts):
             group.part.build(data[group], self)
-        
+
         # check for name collisions in assignment identifiers
         # add the part class name and a roman number if necessary
         refs = collections.defaultdict(list)
@@ -375,25 +375,25 @@ class Builder(object):
                 for ref, group in reflist:
                     # append the class name and number
                     ref.name = ly.util.mkid(ref.name, data[group].name())
-        
+
         # return all PartData instances
         return [data[group] for group in allparts(parts)]
-        
+
     def text(self, doc=None):
         """Return LilyPond formatted output. """
         return self.printer().indent(doc or self.document())
-        
+
     def printer(self):
         """Returns a ly.dom.Printer, that converts the ly.dom structure to LilyPond text. """
         return self._printer
-        
+
     def document(self):
         """Creates and returns a ly.dom tree representing the full LilyPond document."""
         doc = ly.dom.Document()
-        
+
         # version
         ly.dom.Version(self.lyVersionString, doc)
-        
+
         # language
         if self.pitchLanguage:
             if self.lyVersion >= (2, 13, 38):
@@ -407,7 +407,7 @@ class Builder(object):
             for filename in self._includeFiles:
                 ly.dom.Include(filename, doc)
             ly.dom.BlankLine(doc)
-            
+
         # general header
         h = ly.dom.Header()
         for name, value in self.header:
@@ -429,18 +429,18 @@ class Builder(object):
             ly.dom.BlankLine(doc)
 
         layout = ly.dom.Layout()
-        
+
         # remove bar numbers
         if self.removeBarNumbers:
             ly.dom.Line('\\remove "Bar_number_engraver"',
                 ly.dom.Context('Score', layout))
-        
+
         # smart neutral direction
         if self.smartNeutralDirection:
             ctxt_voice = ly.dom.Context('Voice', layout)
             ly.dom.Line('\\consists "Melody_engraver"', ctxt_voice)
             ly.dom.Line("\\override Stem #'neutral-direction = #'()", ctxt_voice)
-        
+
         if len(layout):
             doc.append(layout)
             ly.dom.BlankLine(doc)
@@ -451,7 +451,7 @@ class Builder(object):
             a.append(self.globalSection)
             doc.append(a)
             ly.dom.BlankLine(doc)
-        
+
         # add the main scores
         for block in self.blocks:
             doc.append(block.assignments)
@@ -469,10 +469,10 @@ class Builder(object):
 
     def setInstrumentNames(self, staff, longName, shortName):
         """Sets the instrument names to the staff (or group).
-        
+
         longName and shortName may either be a string or a ly.dom.LyNode object (markup)
         The settings in the score wizard are honored.
-        
+
         """
         if self.showInstrumentNames:
             staff.addInstrumentNameEngraverIfNecessary()
@@ -489,22 +489,22 @@ class Builder(object):
 
     def instrumentName(self, function, num=0):
         """Returns an instrument name.
-        
+
         The name is constructed by calling the 'function' with our translator as
         argument, and appending the number 'num' in roman literals, if num > 0.
-        
+
         """
         name = function(self._)
         if num:
             name += ' ' + ly.util.int2roman(num)
         return name
-    
+
     def setInstrumentNamesFromPart(self, node, part, data):
         """Sets the long and short instrument names for the node.
-        
+
         Calls part.title(translator) and part.short(translator) to get the
         names, appends roman literals if data.num > 0, and sets them on the node.
-        
+
         """
         longName = self.instrumentName(part.title, data.num)
         shortName = self.instrumentName(part.short, data.num)
@@ -513,11 +513,11 @@ class Builder(object):
 
 def assignparts(group):
     """Moves the parts to sub-groups that contain no parts.
-    
+
     If at least one subgroup uses the parts, the parent's parts are removed.
     This way a user can specify some parts and then multiple scores, and they will all
     use the same parts again.
-    
+
     """
     partsOfParentUsed = False
     for g in group.groups:
@@ -531,10 +531,10 @@ def assignparts(group):
 
 def itergroups(group):
     """Iterates over the group and its subgroups as an event list.
-    
+
     When a group is yielded, it means the group starts.
     When None is yielded, it means that the last started groups ends.
-    
+
     """
     yield group
     for g in group.groups:
@@ -545,9 +545,9 @@ def itergroups(group):
 
 def descendants(group):
     """Iterates over the descendants of a group (including the group itself).
-    
+
     First the group, then its children, then the grandchildren, etc.
-    
+
     """
     def _descendants(group):
         children = group.groups
@@ -564,10 +564,10 @@ def descendants(group):
 
 def needsPrefix(globalGroup):
     """Returns True if there are multiple scores in group with shared part types.
-    
+
     This means the music assignments will need a prefix (e.g. scoreAsoprano,
     scoreBsoprano, etc.)
-    
+
     """
     counter = collections.Counter()
     for group in itergroups(globalGroup):
@@ -582,4 +582,4 @@ def allparts(parts):
         yield group
         for group in allparts(group.parts):
             yield group
-        
+

--- a/frescobaldi_app/scorewiz/dialog.py
+++ b/frescobaldi_app/scorewiz/dialog.py
@@ -34,17 +34,17 @@ import ly.document
 
 
 class ScoreWizardDialog(QDialog):
-    
+
     pitchLanguageChanged = pyqtSignal(str)
-    
+
     def __init__(self, mainwindow):
         super(ScoreWizardDialog, self).__init__(mainwindow)
         self.addAction(mainwindow.actionCollection.help_whatsthis)
         self._pitchLanguage = None
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.tabs = QTabWidget()
         b = self.dialogButtons = QDialogButtonBox()
         b.setStandardButtons(
@@ -58,21 +58,21 @@ class ScoreWizardDialog(QDialog):
         self.previewButton.clicked.connect(self.showPreview)
         layout.addWidget(self.tabs)
         layout.addWidget(b)
-        
+
         self.header = Header(self)
         self.tabs.addTab(self.header, '')
         self.parts = Parts(self)
         self.tabs.addTab(self.parts, '')
         self.settings = Settings(self)
         self.tabs.addTab(self.settings, '')
-        
+
         self.tabs.setCurrentIndex(0)
         self.tabs.widget(0).widget() # activate it
         self.tabs.currentChanged.connect(self.slotCurrentChanged)
         qutil.saveDialogSize(self, "scorewiz/dialog/size")
         app.translateUI(self)
         self.accepted.connect(self.slotAccepted)
-    
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Score Setup Wizard")))
         for i in range(self.tabs.count()):
@@ -81,11 +81,11 @@ class ScoreWizardDialog(QDialog):
         self.dialogButtons.button(QDialogButtonBox.Reset).setToolTip(_(
             "Clears the current page of the Score Wizard."))
         self.previewButton.setText(_("Preview"))
-        
+
     def slotCurrentChanged(self, i):
         """Lazy-loads the tab's page if shown for the first time."""
         self.tabs.widget(i).widget()
-        
+
     def reset(self):
         self.tabs.currentWidget().widget().clear()
 
@@ -93,7 +93,7 @@ class ScoreWizardDialog(QDialog):
         if language != self._pitchLanguage:
             self._pitchLanguage = language
             self.pitchLanguageChanged.emit(language)
-    
+
     def pitchLanguage(self):
         if self._pitchLanguage is None:
             # load setting; saving occurs in .settings.py
@@ -116,7 +116,7 @@ class ScoreWizardDialog(QDialog):
         doc.setPlainText(lydoc.plaintext()) # write the text in it
         doc.setModified(False)              # make it "not modified"
         self.parent().setCurrentDocument(doc)
-    
+
     def showPreview(self):
         """Shows a preview."""
         # get the document and fill in some example music
@@ -134,15 +134,15 @@ class ScoreWizardDialog(QDialog):
 
 class Page(QWidget):
     """A Page in the tab widget.
-    
+
     Basically this is just a QWidget that loads the desired page
     as soon as the widget() is called for the first time.
-    
+
     """
     def __init__(self, dialog):
         super(Page, self).__init__(dialog)
         self._widget = None
-        
+
     def title(self):
         """Should return a title."""
 
@@ -157,7 +157,7 @@ class Page(QWidget):
 
     def createWidget(self, parent):
         """Should return the widget for this tab."""
-        
+
 
 class Header(Page):
     def title(self):
@@ -167,7 +167,7 @@ class Header(Page):
         from . import header
         return header.HeaderWidget(parent)
 
-        
+
 class Parts(Page):
     def title(self):
         return _("&Parts")
@@ -180,7 +180,7 @@ class Parts(Page):
 class Settings(Page):
     def title(self):
         return _("&Score settings")
-    
+
     def createWidget(self, parent):
         from . import settings
         return settings.SettingsWidget(parent)

--- a/frescobaldi_app/scorewiz/header.py
+++ b/frescobaldi_app/scorewiz/header.py
@@ -38,10 +38,10 @@ from . import __path__
 class HeaderWidget(QWidget):
     def __init__(self, parent):
         super(HeaderWidget, self).__init__(parent)
-        
+
         layout = QHBoxLayout()
         self.setLayout(layout)
-        
+
         # The html view with the score layout example
         t = self.htmlView = QTextBrowser()
         t.setOpenLinks(False)
@@ -49,22 +49,22 @@ class HeaderWidget(QWidget):
         t.setSearchPaths(__path__)
         t.setTextInteractionFlags(Qt.LinksAccessibleByMouse)
         t.setFocusPolicy(Qt.NoFocus)
-        
+
         # ensure that the full HTML example page is displayed
         t.setContentsMargins(2, 2, 2, 2)
         t.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         t.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         t.setMinimumSize(QSize(350, 350))
         layout.addWidget(t)
-        
+
         t.anchorClicked.connect(self.slotAnchorClicked)
-        
+
         grid = QGridLayout()
         layout.addLayout(grid)
-        
+
         grid.setVerticalSpacing(1)
         grid.setColumnMinimumWidth(1, 200)
-        
+
         self.labels = {}
         self.edits = {}
         for row, (name, desc) in enumerate(headers()):
@@ -77,11 +77,11 @@ class HeaderWidget(QWidget):
             self.edits[name] = e
             completionmodel.complete(e, "scorewiz/completion/header/"+name)
             e.completer().setCaseSensitivity(Qt.CaseInsensitive)
-        
+
         app.settingsChanged.connect(self.readSettings)
         self.readSettings()
         app.translateUI(self)
-        
+
     def translateUI(self):
         msg = _("Click to enter a value.")
         self.htmlView.setHtml(titles_html.format(
@@ -102,7 +102,7 @@ class HeaderWidget(QWidget):
         p = self.htmlView.palette()
         p.setColor(QPalette.Base, textformats.formatData('editor').baseColors['paper'])
         self.htmlView.setPalette(p)
-    
+
     def slotAnchorClicked(self, url):
         try:
             e = self.edits[url.toString()]
@@ -114,14 +114,14 @@ class HeaderWidget(QWidget):
         """Empties all text entries."""
         for edit in self.edits.values():
             edit.clear()
-    
+
     def headers(self):
         """Yields two-tuples (headername, entered text) for the headers that are non-empty."""
         for name, desc in headers():
             text = self.edits[name].text().strip()
             if text:
                 yield name, text
-            
+
 
 
 def headers():

--- a/frescobaldi_app/scorewiz/parts/__init__.py
+++ b/frescobaldi_app/scorewiz/parts/__init__.py
@@ -70,10 +70,10 @@ def model():
 
 class Model(QAbstractItemModel):
     """Provides the categories and the part types contained therein as a Model.
-    
+
     Simply accesses the global 'categories' variable.
     Don't instantiate directly but use the model() global function.
-    
+
     """
     def index(self, row, column, parent):
         if not parent.isValid():
@@ -81,22 +81,22 @@ class Model(QAbstractItemModel):
         elif parent.internalPointer() is None:
             return self.createIndex(row, column, categories[parent.row()])
         return QModelIndex()
-    
+
     def parent(self, index):
         if index.internalPointer() is None:
             return QModelIndex()
         return self.createIndex(categories.index(index.internalPointer()), 0)
-            
+
     def columnCount(self, parent):
         return 1
-    
+
     def rowCount(self, parent):
         if not parent.isValid():
             return len(categories)
         elif parent.internalPointer() is None:
             return len(categories[parent.row()].items)
         return 0
-    
+
     def data(self, index, role):
         if role == Qt.DisplayRole:
             if index.internalPointer() is None:

--- a/frescobaldi_app/scorewiz/parts/_base.py
+++ b/frescobaldi_app/scorewiz/parts/_base.py
@@ -44,24 +44,24 @@ class Base(object):
     @staticmethod
     def title(_=translate):
         """Should return a title.
-        
+
         If a translator is given, it is used instead of the builtin.
-        
+
         """
-    
+
     @staticmethod
     def short(_=translate):
         """Should return an abbreviated title.
-        
+
         If a translator is given, it is used instead of the builtin.
-        
+
         """
 
     def createWidgets(self, layout):
         """Should create widgets to adjust settings."""
         self.noSettingsLabel = QLabel()
         layout.addWidget(self.noSettingsLabel)
-        
+
     def translateWidgets(self):
         """Should set the text in the widgets when the language changes."""
         self.noSettingsLabel.setText('({0})'.format(_("No settings available.")))
@@ -69,7 +69,7 @@ class Base(object):
     def accepts(self):
         """Should return a tuple of classes this part item accepts as child items."""
         return ()
-    
+
     def build(self, data, builder):
         """Should populate the PartData (see build.py)."""
         data.nodes.append(ly.dom.Comment("Part {0}".format(self.__class__.__name__)))
@@ -84,7 +84,7 @@ class Container(Base):
     """Base class for "part" types that can contain others, like a Staff Group or Score, Book etc."""
     def accepts(self):
         return (Part, Container)
-    
+
 
 class Group(Container):
     """Base class for "part" types that are a group such as Book, BookPart and Score."""
@@ -119,10 +119,10 @@ class PianoStaffPart(Part):
         self.lowerVoicesLabel = QLabel()
         self.upperVoices = QSpinBox(minimum=1, maximum=4, value=1)
         self.lowerVoices = QSpinBox(minimum=1, maximum=4, value=1)
-        
+
         self.upperVoicesLabel.setBuddy(self.upperVoices)
         self.lowerVoicesLabel.setBuddy(self.lowerVoices)
-        
+
         layout.addWidget(self.label)
         grid = QGridLayout()
         grid.addWidget(self.upperVoicesLabel, 0, 0)
@@ -130,7 +130,7 @@ class PianoStaffPart(Part):
         grid.addWidget(self.lowerVoicesLabel, 1, 0)
         grid.addWidget(self.lowerVoices, 1, 1)
         layout.addLayout(grid)
-    
+
     def translateWidgets(self):
         self.label.setText('{0} <i>({1})</i>'.format(
             _("Adjust how many separate voices you want on each staff."),
@@ -138,7 +138,7 @@ class PianoStaffPart(Part):
               "like a fuge.")))
         self.upperVoicesLabel.setText(_("Right hand:"))
         self.lowerVoicesLabel.setText(_("Left hand:"))
-    
+
     def buildStaff(self, data, builder, name, octave, numVoices=1, node=None, clef=None):
         """Build a staff with the given number of voices and name."""
         staff = ly.dom.Staff(name, parent=node)
@@ -178,13 +178,13 @@ class ChordNames(object):
         self.chordStyle.setModel(listmodel.ListModel(chordNameStyles, self.chordStyle,
             display=listmodel.translate))
         self.guitarFrets = QCheckBox()
-        
+
         box = QHBoxLayout()
         box.addWidget(self.chordStyleLabel)
         box.addWidget(self.chordStyle)
         layout.addLayout(box)
         layout.addWidget(self.guitarFrets)
-        
+
     def translateWidgets(self):
         self.chordStyleLabel.setText(_("Chord style:"))
         self.guitarFrets.setText(_("Guitar fret diagrams"))

--- a/frescobaldi_app/scorewiz/parts/brass.py
+++ b/frescobaldi_app/scorewiz/parts/brass.py
@@ -28,13 +28,13 @@ from . import register
 
 class BrassPart(_base.SingleVoicePart):
     """Base class for brass types."""
-    
-    
+
+
 class HornF(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Horn in F")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Horn in F", "Hn.F.")
@@ -47,55 +47,55 @@ class TrumpetC(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Trumpet in C")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Trumpet in C", "Tr.C.")
 
     midiInstrument = 'trumpet'
-    
-    
+
+
 class TrumpetBb(TrumpetC):
     @staticmethod
     def title(_=_base.translate):
         return _("Trumpet in Bb")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Trumpet in Bb", "Tr.Bb.")
 
     transposition = (-1, 6, -1)
-    
-    
+
+
 class CornetBb(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Cornet in Bb")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Cornet in Bb", "Crt.Bb.")
 
     transposition = (-1, 6, -1)
-    
-   
+
+
 class Flugelhorn(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Flugelhorn")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Flugelhorn", "Fgh.")
 
     midiInstrument = 'trumpet'
-   
-    
+
+
 class Mellophone(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Mellophone")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Mellophone", "Mph.")
@@ -108,7 +108,7 @@ class Trombone(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Trombone")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Trombone", "Trb.")
@@ -116,13 +116,13 @@ class Trombone(BrassPart):
     midiInstrument = 'trombone'
     clef = 'bass'
     octave = -1
-    
-    
+
+
 class Baritone(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Baritone")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Baritone", "Bar.")
@@ -130,13 +130,13 @@ class Baritone(BrassPart):
     midiInstrument = 'trombone'
     clef = 'bass'
     octave = -1
-    
+
 
 class Euphonium(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Euphonium")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Euphonium", "Euph.")
@@ -144,30 +144,30 @@ class Euphonium(BrassPart):
     midiInstrument = 'trombone'
     clef = 'bass'
     octave = -1
-    
-    
+
+
 class Tuba(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Tuba")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Tuba", "Tb.")
 
     midiInstrument = 'tuba'
     transposition = (-2, 6, -1)
-    
+
 
 class BassTuba(BrassPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Bass Tuba")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Bass Tuba", "B.Tb.")
-    
+
     midiInstrument = 'tuba'
     clef = 'bass'
     octave = -1

--- a/frescobaldi_app/scorewiz/parts/containers.py
+++ b/frescobaldi_app/scorewiz/parts/containers.py
@@ -59,19 +59,19 @@ class StaffGroup(_base.Container):
             icon=lambda item: symbols.icon(item[1])))
         self.systemStart.setIconSize(QSize(64, 64))
         self.connectBarLines = QCheckBox(checked=True)
-        
+
         box = QHBoxLayout()
         box.addWidget(self.systemStartLabel)
         box.addWidget(self.systemStart)
         layout.addLayout(box)
         layout.addWidget(self.connectBarLines)
-    
+
     def translateWidgets(self):
         self.systemStartLabel.setText(_("Type:"))
         self.connectBarLines.setText(_("Connect Barlines"))
         self.connectBarLines.setToolTip(_("If checked, barlines are connected between the staves."))
         self.systemStart.model().update()
-    
+
     def build(self, data, builder):
         s = self.systemStart.currentIndex()
         b = self.connectBarLines.isChecked()
@@ -101,7 +101,7 @@ class Score(_base.Group, scoreproperties.ScoreProperties):
         self.opusLabel.setBuddy(self.opus)
         self.scoreProps = QGroupBox(checkable=True, checked=False)
         scoreproperties.ScoreProperties.createWidgets(self)
-        
+
         grid = QGridLayout()
         grid.addWidget(self.pieceLabel, 0 ,0)
         grid.addWidget(self.piece, 0, 1)
@@ -112,17 +112,17 @@ class Score(_base.Group, scoreproperties.ScoreProperties):
         layout = QVBoxLayout()
         self.scoreProps.setLayout(layout)
         scoreproperties.ScoreProperties.layoutWidgets(self, layout)
-        
+
         scorewiz = self.scoreProps.window()
         self.setPitchLanguage(scorewiz.pitchLanguage())
         scorewiz.pitchLanguageChanged.connect(self.setPitchLanguage)
-        
+
     def translateWidgets(self):
         self.pieceLabel.setText(_("Piece:"))
         self.opusLabel.setText(_("Opus:"))
         self.scoreProps.setTitle(_("Properties"))
         scoreproperties.ScoreProperties.translateWidgets(self)
-        
+
     def accepts(self):
         return (StaffGroup, _base.Part)
 
@@ -138,11 +138,11 @@ class Score(_base.Group, scoreproperties.ScoreProperties):
         if len(h):
             score.append(h)
         return score
-    
+
     def globalSection(self, builder):
         if self.scoreProps.isChecked():
             return scoreproperties.ScoreProperties.globalSection(self, builder)
-            
+
 
 
 class BookPart(_base.Group):
@@ -172,7 +172,7 @@ class Book(_base.Group):
         self.bookOutput = widgets.lineedit.LineEdit()
         self.bookOutputFileName = QRadioButton()
         self.bookOutputSuffix = QRadioButton(checked=True)
-        
+
         layout.addWidget(self.bookOutputInfo)
         grid = QGridLayout(spacing=0)
         grid.addWidget(self.bookOutputLabel, 0, 0)
@@ -180,7 +180,7 @@ class Book(_base.Group):
         grid.addWidget(self.bookOutputFileName, 1, 1)
         grid.addWidget(self.bookOutputSuffix, 1, 2)
         layout.addLayout(grid)
-    
+
     def translateWidgets(self):
         self.bookOutputInfo.setText(_(
             "<p>Here you can specify a filename or suffix (without extension) "

--- a/frescobaldi_app/scorewiz/parts/keyboard.py
+++ b/frescobaldi_app/scorewiz/parts/keyboard.py
@@ -39,11 +39,11 @@ class Piano(KeyboardPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Piano")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Piano", "Pno.")
-    
+
     midiInstrument = 'acoustic grand'
 
 
@@ -51,11 +51,11 @@ class Harpsichord(KeyboardPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Harpsichord")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Harpsichord", "Hs.")
-    
+
     midiInstrument = 'harpsichord'
 
 
@@ -63,11 +63,11 @@ class Clavichord(KeyboardPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Clavichord")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Clavichord", "Clv.")
-    
+
     midiInstrument = 'clav'
 
 
@@ -75,11 +75,11 @@ class Organ(KeyboardPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Organ")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Organ", "Org.")
-    
+
     midiInstrument = 'church organ'
 
     def createWidgets(self, layout):
@@ -90,13 +90,13 @@ class Organ(KeyboardPart):
         self.pedalVoicesLabel.setBuddy(self.pedalVoices)
         grid.addWidget(self.pedalVoicesLabel, 2, 0)
         grid.addWidget(self.pedalVoices)
-        
+
     def translateWidgets(self):
         super(Organ, self).translateWidgets()
         self.pedalVoicesLabel.setText(_("Pedal:"))
         self.pedalVoices.setToolTip(_(
             "Set to 0 to disable the pedal altogether."))
-    
+
     def build(self, data, builder):
         super(Organ, self).build(data, builder)
         if self.pedalVoices.value():
@@ -109,11 +109,11 @@ class Celesta(KeyboardPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Celesta")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Celesta", "Cel.")
-    
+
     midiInstrument = 'celesta'
 
 

--- a/frescobaldi_app/scorewiz/parts/percussion.py
+++ b/frescobaldi_app/scorewiz/parts/percussion.py
@@ -35,17 +35,17 @@ from . import register
 
 class PitchedPercussionPart(_base.SingleVoicePart):
     """Base class for pitched percussion types."""
-    
-    
+
+
 class Timpani(PitchedPercussionPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Timpani")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Timpani", "Tmp.")
-        
+
     midiInstrument = 'timpani'
     clef = 'bass'
     octave = -1
@@ -55,11 +55,11 @@ class Xylophone(PitchedPercussionPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Xylophone")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Xylophone", "Xyl.")
-        
+
     midiInstrument = 'xylophone'
 
 
@@ -67,17 +67,17 @@ class Marimba(_base.PianoStaffPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Marimba")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Marimba", "Mar.")
-    
+
     midiInstrument = 'marimba'
 
     def createWidgets(self, layout):
         super(Marimba, self).createWidgets(layout)
         self.lowerVoices.setMinimum(0)
-    
+
     def translateWidgets(self):
         self.upperVoicesLabel.setText(_("Upper staff:"))
         self.lowerVoicesLabel.setText(_("Lower staff:"))
@@ -95,11 +95,11 @@ class Vibraphone(Marimba):
     @staticmethod
     def title(_=_base.translate):
         return _("Vibraphone")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Vibraphone", "Vib.")
-        
+
     midiInstrument = 'vibraphone'
 
 
@@ -107,11 +107,11 @@ class TubularBells(PitchedPercussionPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Tubular bells")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Tubular bells", "Tub.")
-        
+
     midiInstrument = 'tubular bells'
 
 
@@ -119,11 +119,11 @@ class Glockenspiel(PitchedPercussionPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Glockenspiel")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Glockenspiel", "Gls.")
-        
+
     midiInstrument = 'glockenspiel'
 
 
@@ -131,18 +131,18 @@ class Carillon(_base.PianoStaffPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Carillon")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Carillon", "Car.")
-    
+
     midiInstrument = 'tubular bells' # anyone knows better?
-    
+
     def translateWidgets(self):
         super(Carillon, self).translateWidgets()
         self.upperVoicesLabel.setText(_("Manual staff:"))
         self.lowerVoicesLabel.setText(_("Pedal staff:"))
-    
+
     def build(self, data, builder):
         p = ly.dom.PianoStaff()
         builder.setInstrumentNamesFromPart(p, self, data)
@@ -157,11 +157,11 @@ class Drums(_base.Part):
     @staticmethod
     def title(_=_base.translate):
         return _("Drums")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Drums", "Dr.")
-        
+
     def createWidgets(self, layout):
         self.voicesLabel = QLabel()
         self.voices = QSpinBox(minimum=1, maximum=4, value=1)
@@ -169,7 +169,7 @@ class Drums(_base.Part):
         self.drumStyle = QComboBox()
         self.drumStyle.setModel(listmodel.ListModel(drumStyles, self.drumStyle, display=listmodel.translate))
         self.drumStems = QCheckBox()
-        
+
         box = QHBoxLayout()
         box.addWidget(self.voicesLabel)
         box.addWidget(self.voices)
@@ -179,19 +179,19 @@ class Drums(_base.Part):
         box.addWidget(self.drumStyle)
         layout.addLayout(box)
         layout.addWidget(self.drumStems)
-        
+
     def translateWidgets(self):
         self.voicesLabel.setText(_("Voices:"))
         self.drumStyleLabel.setText(_("Style:"))
         self.drumStems.setText(_("Remove stems"))
         self.drumStems.setToolTip(_("Remove the stems from the drum notes."))
         self.drumStyle.model().update()
-    
+
     def assignDrums(self, data, name = None):
         r"""Creates an empty name = \drummode assignment.
 
         Returns the assignment.
-        
+
         """
         a = data.assign(name)
         s = ly.dom.DrumMode(a)
@@ -233,7 +233,7 @@ drumStyles = (
     lambda: _("Bongos-style (2 lines)"),
     lambda: _("Percussion-style (1 line)"),
 )
-    
+
 
 
 register(

--- a/frescobaldi_app/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi_app/scorewiz/parts/plucked_strings.py
@@ -37,13 +37,13 @@ from . import register
 
 class TablaturePart(_base.Part):
     """Base class for tablature instrument part types."""
-    
+
     octave = 0
     clef = None
     transposition = None
     tunings = ()    # may contain a list of tunings.
     tabFormat = ''  # can contain a tablatureFormat value.
-    
+
     def createWidgets(self, layout):
         self.staffTypeLabel = QLabel()
         self.staffType = QComboBox()
@@ -58,7 +58,7 @@ class TablaturePart(_base.Part):
             self.createTuningWidgets(layout)
             self.staffType.activated.connect(self.slotTabEnable)
             self.slotTabEnable(0)
-        
+
     def createTuningWidgets(self, layout):
         self.tuningLabel = QLabel()
         self.tuning = QComboBox()
@@ -78,13 +78,13 @@ class TablaturePart(_base.Part):
         box.addWidget(self.tuningLabel)
         box.addWidget(self.tuning)
         layout.addWidget(self.customTuning)
-    
+
     def translateWidgets(self):
         self.staffTypeLabel.setText(_("Staff type:"))
         self.staffType.model().update()
         if self.tunings:
             self.translateTuningWidgets()
-    
+
     def translateTuningWidgets(self):
         self.tuningLabel.setText(_("Tuning:"))
         self.customTuning.setToolTip('<qt>' + _(
@@ -97,30 +97,30 @@ class TablaturePart(_base.Part):
         except AttributeError:
             pass # only in Qt 4.7+
         self.tuning.model().update()
-    
+
     def slotTabEnable(self, enable):
         """Called when the user changes the staff type.
-        
+
         Non-zero if the user wants a TabStaff.
-        
+
         """
         self.tuning.setEnabled(bool(enable))
         if enable:
             self.slotCustomTuningEnable(self.tuning.currentIndex())
         else:
             self.customTuning.setEnabled(False)
-    
+
     def slotCustomTuningEnable(self, index):
         self.customTuning.setEnabled(index > len(self.tunings))
-    
+
     def voiceCount(self):
         """Returns the number of voices.
-        
+
         Inherit to make this user-settable.
-        
+
         """
         return 1
-        
+
     def build(self, data, builder):
         # First make assignments for the voices we want to create
         numVoices = self.voiceCount()
@@ -135,10 +135,10 @@ class TablaturePart(_base.Part):
         else:
             order = 1, 2, 3, 4
             voices = [ly.util.mkid(data.name(), "voice") + ly.util.int2text(i) for i in order]
-        
+
         assignments = [data.assignMusic(name, self.octave, self.transposition)
                        for name in voices]
-        
+
         staffType = self.staffType.currentIndex()
         if staffType in (0, 2):
             # create a normal staff
@@ -152,7 +152,7 @@ class TablaturePart(_base.Part):
                 ly.dom.VoiceSeparator(mus)
             ly.dom.Identifier(assignments[-1].name, mus)
             builder.setMidiInstrument(staff, self.midiInstrument)
-        
+
         if staffType in (1, 2):
             # create a tab staff
             tabstaff = ly.dom.TabStaff()
@@ -167,7 +167,7 @@ class TablaturePart(_base.Part):
                     s = ly.dom.Seq(ly.dom.TabVoice(parent=sim))
                     ly.dom.Text('\\voice' + ly.util.int2text(num), s)
                     ly.dom.Identifier(a.name, s)
-        
+
         if staffType == 0:
             # only a normal staff
             p = staff
@@ -181,7 +181,7 @@ class TablaturePart(_base.Part):
             s = ly.dom.Sim(p)
             s.append(staff)
             s.append(tabstaff)
-        
+
         builder.setInstrumentNamesFromPart(p, self, data)
         data.nodes.append(p)
 
@@ -210,26 +210,26 @@ class Mandolin(TablaturePart):
     @staticmethod
     def title(_=_base.translate):
         return _("Mandolin")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Mandolin", "Mdl.")
-    
+
     midiInstrument = 'acoustic guitar (steel)'
     tunings = (
         ('mandolin-tuning', lambda: _("Mandolin tuning")),
     )
-    
+
 
 class Ukulele(TablaturePart):
     @staticmethod
     def title(_=_base.translate):
         return _("Ukulele")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Ukulele", "Uk.")
-    
+
     midiInstrument = 'acoustic guitar (steel)'
     tunings = (
         ('ukulele-tuning', lambda: _("Ukulele tuning")),
@@ -243,11 +243,11 @@ class Banjo(TablaturePart):
     @staticmethod
     def title(_=_base.translate):
         return _("Banjo")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Banjo", "Bj.")
-    
+
     midiInstrument = 'banjo'
     tabFormat = 'fret-number-tablature-format-banjo'
     tunings = (
@@ -257,16 +257,16 @@ class Banjo(TablaturePart):
         ('banjo-open-d-tuning', lambda: _("Open D-tuning (aDF#AD)")),
         ('banjo-open-dm-tuning', lambda: _("Open Dm-tuning (aDFAD)")),
     )
-    
+
     def createTuningWidgets(self, layout):
         super(Banjo, self).createTuningWidgets(layout)
         self.fourStrings = QCheckBox()
         layout.addWidget(self.fourStrings)
-        
+
     def translateTuningWidgets(self):
         super(Banjo, self).translateTuningWidgets()
         self.fourStrings.setText(_("Four strings (instead of five)"))
-    
+
     def setTunings(self, tab):
         i = self.tuning.currentIndex()
         if i > len(self.tunings) or not self.fourStrings.isChecked():
@@ -279,17 +279,17 @@ class Banjo(TablaturePart):
     def slotCustomTuningEnable(self, index):
         super(Banjo, self).slotCustomTuningEnable(index)
         self.fourStrings.setEnabled(index <= len(self.tunings))
-    
+
 
 class ClassicalGuitar(TablaturePart):
     @staticmethod
     def title(_=_base.translate):
         return _("Classical guitar")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Classical guitar", "Gt.")
-    
+
     midiInstrument = 'acoustic guitar (nylon)'
     clef = "treble_8"
     tunings = (
@@ -311,11 +311,11 @@ class ClassicalGuitar(TablaturePart):
         box.addWidget(self.voicesLabel)
         box.addWidget(self.voices)
         layout.addLayout(box)
-        
+
     def translateWidgets(self):
         super(ClassicalGuitar, self).translateWidgets()
         self.voicesLabel.setText(_("Voices:"))
-    
+
     def voiceCount(self):
         return self.voices.value()
 
@@ -324,11 +324,11 @@ class JazzGuitar(ClassicalGuitar):
     @staticmethod
     def title(_=_base.translate):
         return _("Jazz guitar")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Jazz guitar", "J.Gt.")
-    
+
     midiInstrument = 'electric guitar (jazz)'
 
 
@@ -336,7 +336,7 @@ class Bass(TablaturePart):
     @staticmethod
     def title(_=_base.translate):
         return _("Bass")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Bass", "Bs.") #FIXME
@@ -357,7 +357,7 @@ class ElectricBass(Bass):
     @staticmethod
     def title(_=_base.translate):
         return _("Electric bass")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Electric bass", "E.Bs.")
@@ -369,7 +369,7 @@ class Harp(_base.PianoStaffPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Harp")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Harp", "Hp.")
@@ -380,7 +380,7 @@ class Harp(_base.PianoStaffPart):
         super(Harp, self).translateWidgets()
         self.upperVoicesLabel.setText(_("Upper staff:"))
         self.lowerVoicesLabel.setText(_("Lower staff:"))
-    
+
     def build(self, data, builder):
         p = ly.dom.PianoStaff()
         builder.setInstrumentNamesFromPart(p, self, data)
@@ -390,7 +390,7 @@ class Harp(_base.PianoStaffPart):
         self.buildStaff(data, builder, 'lower', 0, self.lowerVoices.value(), s, "bass")
         data.nodes.append(p)
 
-        
+
 
 
 

--- a/frescobaldi_app/scorewiz/parts/special.py
+++ b/frescobaldi_app/scorewiz/parts/special.py
@@ -34,7 +34,7 @@ class Chords(_base.ChordNames, _base.Part):
     @staticmethod
     def title(_=_base.translate):
         return _("Chord names")
-    
+
 
 class BassFigures(_base.Part):
     @staticmethod
@@ -44,7 +44,7 @@ class BassFigures(_base.Part):
     def createWidgets(self, layout):
         self.extenderLines = QCheckBox()
         layout.addWidget(self.extenderLines)
-    
+
     def translateWidgets(self):
         self.extenderLines.setText(_("Use extender lines"))
 

--- a/frescobaldi_app/scorewiz/parts/strings.py
+++ b/frescobaldi_app/scorewiz/parts/strings.py
@@ -36,7 +36,7 @@ class Violin(StringPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Violin")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Violin", "Vl.")
@@ -48,11 +48,11 @@ class Viola(StringPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Viola")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Viola", "Vla.")
-    
+
     midiInstrument = 'viola'
     clef = 'alto'
     octave = 0
@@ -62,11 +62,11 @@ class Cello(StringPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Cello")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Cello", "Cl.")
-    
+
     midiInstrument = 'cello'
     clef = 'bass'
     octave = -1
@@ -76,11 +76,11 @@ class Contrabass(StringPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Contrabass")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Contrabass", "Cb.")
-    
+
     midiInstrument = 'contrabass'
     clef = 'bass'
     octave = -1
@@ -90,11 +90,11 @@ class BassoContinuo(Cello):
     @staticmethod
     def title(_=_base.translate):
         return _("Basso Continuo")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Basso Continuo", "B.c.")
-    
+
     def build(self, data, builder):
         super(BassoContinuo, self).build(data, builder)
         data.assignments[0].name.name = 'bcMusic'
@@ -108,7 +108,7 @@ class BassoContinuo(Cello):
         figbass = ly.dom.FiguredBass()
         ly.dom.Identifier(a.name, figbass)
         data.nodes.append(figbass)
-    
+
 
 register(
     lambda: _("Strings"),

--- a/frescobaldi_app/scorewiz/parts/vocal.py
+++ b/frescobaldi_app/scorewiz/parts/vocal.py
@@ -45,11 +45,11 @@ class VocalPart(_base.Part):
     def createWidgets(self, layout):
         self.createStanzaWidget(layout)
         self.createAmbitusWidget(layout)
-        
+
     def translateWidgets(self):
         self.translateStanzaWidget()
         self.translateAmbitusWidget()
-        
+
     def createStanzaWidget(self, layout):
         self.stanzas = QSpinBox(minimum=1, maximum=99, value=1)
         self.stanzasLabel = QLabel()
@@ -58,25 +58,25 @@ class VocalPart(_base.Part):
         box.addWidget(self.stanzasLabel)
         box.addWidget(self.stanzas)
         layout.addLayout(box)
-        
+
     def translateStanzaWidget(self):
         self.stanzasLabel.setText(_("Stanzas:"))
         self.stanzas.setToolTip(_("The number of stanzas."))
-    
+
     def createAmbitusWidget(self, layout):
         self.ambitus = QCheckBox()
         layout.addWidget(self.ambitus)
-        
+
     def translateAmbitusWidget(self):
         self.ambitus.setText(_("Ambitus"))
         self.ambitus.setToolTip(_(
             "Show the pitch range of the voice at the beginning of the staff."))
-    
+
     def assignLyrics(self, data, name, verse=0):
         """Creates an empty assignment for lyrics.
-        
+
         Returns the assignment.
-        
+
         """
         l = ly.dom.LyricMode()
         if verse:
@@ -87,13 +87,13 @@ class VocalPart(_base.Part):
         ly.dom.LineComment(_("Lyrics follow here."), l)
         ly.dom.BlankLine(l)
         return a
-    
+
     def addStanzas(self, data, node):
         """Add stanzas to the given (Voice) node.
-        
+
         The stanzas (as configured in self.stanzas.value()) are added
         using \\addlyrics.
-        
+
         """
         if self.stanzas.value() == 1:
             ly.dom.Identifier(self.assignLyrics(data, 'verse').name, ly.dom.AddLyrics(node))
@@ -106,7 +106,7 @@ class VocalSoloPart(VocalPart, _base.SingleVoicePart):
     """Base class for vocal solo parts."""
     octave = 1
     clef = None
-    
+
     def build(self, data, builder):
         super(VocalSoloPart, self).build(data, builder)
         stub = data.assignments[-1][0][-1]
@@ -122,7 +122,7 @@ class SopranoVoice(VocalSoloPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Soprano")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Soprano", "S.")
@@ -132,7 +132,7 @@ class MezzoSopranoVoice(VocalSoloPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Mezzo-soprano")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Mezzo-soprano", "Ms.")
@@ -142,11 +142,11 @@ class AltoVoice(VocalSoloPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Alto")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Alto", "A.")
-    
+
     octave = 0
 
 
@@ -154,7 +154,7 @@ class TenorVoice(VocalSoloPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Tenor")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Tenor", "T.")
@@ -167,7 +167,7 @@ class BassVoice(VocalSoloPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Bass")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Bass", "B.")
@@ -180,7 +180,7 @@ class LeadSheet(VocalPart, _base.ChordNames):
     @staticmethod
     def title(_=_base.translate):
         return _("Lead sheet")
-    
+
     def createWidgets(self, layout):
         self.label = QLabel(wordWrap=True)
         self.chords = QGroupBox(checkable=True, checked=True)
@@ -192,7 +192,7 @@ class LeadSheet(VocalPart, _base.ChordNames):
         self.accomp = QCheckBox()
         layout.addWidget(self.accomp)
         VocalPart.createWidgets(self, layout)
-    
+
     def translateWidgets(self):
         VocalPart.translateWidgets(self)
         _base.ChordNames.translateWidgets(self)
@@ -207,9 +207,9 @@ class LeadSheet(VocalPart, _base.ChordNames):
 
     def build(self, data, builder):
         """Create chord names, song and lyrics.
-        
+
         Optionally a second staff with a piano accompaniment.
-        
+
         """
         if self.chords.isChecked():
             _base.ChordNames.build(self, data, builder)
@@ -294,7 +294,7 @@ class Choir(VocalPart):
         self.lyrics.setCurrentIndex(0)
         self.pianoReduction = QCheckBox()
         self.rehearsalMidi = QCheckBox()
-        
+
         layout.addWidget(self.label)
         box = QHBoxLayout()
         layout.addLayout(box)
@@ -308,7 +308,7 @@ class Choir(VocalPart):
         self.createAmbitusWidget(layout)
         layout.addWidget(self.pianoReduction)
         layout.addWidget(self.rehearsalMidi)
-    
+
     def translateWidgets(self):
         self.translateStanzaWidget()
         self.translateAmbitusWidget()
@@ -336,7 +336,7 @@ class Choir(VocalPart):
         staves = re.sub('-+', '-', staves).strip('-')
         if not staves:
             return
-        
+
         splitStaves = staves.split('-')
         numStaves = len(splitStaves)
         staffCIDs = collections.defaultdict(int)    # number same-name staff Context-IDs
@@ -346,29 +346,29 @@ class Choir(VocalPart):
         lyrics = collections.defaultdict(list)      # lyrics grouped by stanza number
         pianoReduction = collections.defaultdict(list)
         rehearsalMidis = []
-        
+
         p = ly.dom.ChoirStaff()
         choir = ly.dom.Sim(p)
         data.nodes.append(p)
-        
+
         # print main instrumentName if there are more choirs, and we
         # have more than one staff.
         if numStaves > 1 and data.num:
             builder.setInstrumentNames(p,
                 builder.instrumentName(lambda _: _("Choir"), data.num),
                 builder.instrumentName(lambda _: _("abbreviation for Choir", "Ch."), data.num))
-        
+
         # get the preferred way of adding lyrics
         lyrAllSame, lyrEachSame, lyrEachDiff, lyrSpread = (
             self.lyrics.currentIndex() == i for i in range(4))
         lyrEach = lyrEachSame or lyrEachDiff
-        
+
         # stanzas to print (0 = don't print stanza number):
         if numStanzas == 1:
             allStanzas = [0]
         else:
             allStanzas = list(range(1, numStanzas + 1))
-        
+
         # Which stanzas to print where:
         if lyrSpread and numStanzas > 1 and numStaves > 2:
             spaces = numStaves - 1
@@ -380,7 +380,7 @@ class Choir(VocalPart):
                                 itertools.repeat(count, numStaves - rest)))
         else:
             stanzaGroups = itertools.repeat(allStanzas, numStaves)
-        
+
         # a function to set staff affinity (in LilyPond 2.13.4 and above):
         if builder.lyVersion >= (2, 13, 4):
             def setStaffAffinity(context, affinity):
@@ -389,7 +389,7 @@ class Choir(VocalPart):
         else:
             def setStaffAffinity(lyricsContext, affinity):
                 pass
-        
+
         # a function to make a column markup:
         if builder.lyVersion >= (2, 11, 57):
             columnCommand = 'center-column'
@@ -401,7 +401,7 @@ class Choir(VocalPart):
             for name in names:
                 ly.dom.QuotedString(name, column)
             return node
-        
+
         stavesLeft = numStaves
         for staff, stanzas in zip(splitStaves, stanzaGroups):
             # are we in the last staff?
@@ -413,7 +413,7 @@ class Choir(VocalPart):
             # Create the staff for the voices
             s = ly.dom.Staff(parent=choir)
             builder.setMidiInstrument(s, self.midiInstrument)
-            
+
             # Build a list of the voices in this staff.
             # Each entry is a tuple(name, num).
             # name is one of 'S', 'A', 'T', or 'B'
@@ -424,7 +424,7 @@ class Choir(VocalPart):
                 if staves.count(voice) > 1:
                     voiceCounter[voice] += 1
                 voices.append((voice, voiceCounter[voice]))
-            
+
             # Add the instrument names to the staff:
             if numVoices == 1:
                 voice, num = voices[0]
@@ -439,13 +439,13 @@ class Choir(VocalPart):
                 shortNames = makeColumnMarkup(
                     builder.instrumentName(voice2Voice[voice].short, num) for voice, num in voices)
                 builder.setInstrumentNames(s, longNames, shortNames)
-            
+
             # Make the { } or << >> holder for this staff's children.
             # If *all* staves have only one voice, addlyrics is used.
             # In that case, don't remove the braces.
             staffMusic = (ly.dom.Seq if lyrEach and maxNumVoices == 1 else
                           ly.dom.Seqr if numVoices == 1 else ly.dom.Simr)(s)
-            
+
             # Set the clef for this staff:
             if 'B' in staff:
                 ly.dom.Clef('bass', staffMusic)
@@ -465,14 +465,14 @@ class Choir(VocalPart):
                 order = 1, 3, 2, 4
             else:
                 order = range(1, numVoices + 1)
-            
+
             # What name would the staff get if we need to refer to it?
             # If a name (like 's' or 'sa') is already in use in this part,
             # just add a number ('ss2' or 'sa2', etc.)
             staffCIDs[staff] += 1
             cid = ly.dom.Reference(staff.lower() +
                 str(staffCIDs[staff] if staffCIDs[staff] > 1 else ""))
-            
+
             # Create voices and their lyrics:
             for (voice, num), voiceNum in zip(voices, order):
                 name = voice2id[voice]
@@ -480,7 +480,7 @@ class Choir(VocalPart):
                     name += ly.util.int2text(num)
                 a = data.assignMusic(name, voice2Voice[voice].octave)
                 lyrName = name + 'Verse' if lyrEachDiff else 'verse'
-            
+
                 # Use \addlyrics if all staves have exactly one voice.
                 if lyrEach and maxNumVoices == 1:
                     for verse in stanzas:
@@ -493,7 +493,7 @@ class Choir(VocalPart):
                     if voiceNum:
                         ly.dom.Text('\\voice' + ly.util.int2text(voiceNum), voiceMusic)
                     ly.dom.Identifier(a.name, voiceMusic)
-                    
+
                     if stanzas and (lyrEach or (voiceNum <= 1 and
                                     (stavesLeft or numStaves == 1))):
                         # Create the lyrics. If they should be above the staff,
@@ -519,10 +519,10 @@ class Choir(VocalPart):
                     if voiceNum > 1:
                         ly.dom.Line("\\override Ambitus #'X-offset = #{0}".format(
                                  (voiceNum - 1) * 2.0), ambitusContext)
-            
+
                 pianoReduction[voice].append(a.name)
                 rehearsalMidis.append((voice, num, a.name, lyrName))
-            
+
         # Assign the lyrics, so their definitions come after the note defs.
         # (These refs are used again below in the midi rehearsal routine.)
         refs = {}
@@ -537,17 +537,17 @@ class Choir(VocalPart):
             a = data.assign('pianoReduction')
             data.nodes.append(ly.dom.Identifier(a.name))
             piano = ly.dom.PianoStaff(parent=a)
-            
+
             sim = ly.dom.Sim(piano)
             rightStaff = ly.dom.Staff(parent=sim)
             leftStaff = ly.dom.Staff(parent=sim)
             right = ly.dom.Seq(rightStaff)
             left = ly.dom.Seq(leftStaff)
-            
+
             # Determine the ordering of voices in the staves
             upper = pianoReduction['S'] + pianoReduction['A']
             lower = pianoReduction['T'] + pianoReduction['B']
-            
+
             preferUpper = 1
             if not upper:
                 # Male choir
@@ -566,14 +566,14 @@ class Choir(VocalPart):
             # Otherwise accidentals can be confusing
             ly.dom.Line("#(set-accidental-style 'piano)", right)
             ly.dom.Line("#(set-accidental-style 'piano)", left)
-            
+
             # Move voices if unevenly spread
             if abs(len(upper) - len(lower)) > 1:
                 voices = upper + lower
                 half = (len(voices) + preferUpper) // 2
                 upper = voices[:half]
                 lower = voices[half:]
-            
+
             for staff, voices in (ly.dom.Simr(right), upper), (ly.dom.Simr(left), lower):
                 if voices:
                     for v in voices[:-1]:
@@ -585,30 +585,30 @@ class Choir(VocalPart):
             ly.dom.Line("fontSize = #-1", piano.getWith())
             ly.dom.Line("\\override StaffSymbol #'staff-space = #(magstep -1)",
                 piano.getWith())
-            
+
             # Nice to add Mark engravers
             ly.dom.Line('\\consists "Mark_engraver"', rightStaff.getWith())
             ly.dom.Line('\\consists "Metronome_mark_engraver"', rightStaff.getWith())
-            
+
             # Keep piano reduction out of the MIDI output
             if builder.midi:
                 ly.dom.Line('\\remove "Staff_performer"', rightStaff.getWith())
                 ly.dom.Line('\\remove "Staff_performer"', leftStaff.getWith())
-        
+
         # Create MIDI files if desired
         if self.rehearsalMidi.isChecked():
             a = data.assign('rehearsalMidi')
             rehearsalMidi = a.name
-            
+
             func = ly.dom.SchemeList(a)
             func.pre = '#\n(' # hack
             ly.dom.Text('define-music-function', func)
             ly.dom.Line('(parser location name midiInstrument lyrics) '
                  '(string? string? ly:music?)', func)
             choir = ly.dom.Sim(ly.dom.Command('unfoldRepeats', ly.dom.SchemeLily(func)))
-            
+
             data.afterblocks.append(ly.dom.Comment(_("Rehearsal MIDI files:")))
-            
+
             for voice, num, ref, lyrName in rehearsalMidis:
                 # Append voice to the rehearsalMidi function
                 name = voice2id[voice] + str(num or '')
@@ -616,9 +616,9 @@ class Choir(VocalPart):
                 if builder.lyVersion < (2, 18, 0):
                     ly.dom.Text('<>\\f', seq) # add one dynamic
                 ly.dom.Identifier(ref, seq) # add the reference to the voice
-                
+
                 book = ly.dom.Book()
-                
+
                 # Append score to the aftermath (stuff put below the main score)
                 suffix = "choir{0}-{1}".format(data.num, name) if data.num else name
                 if builder.lyVersion < (2, 12, 0):
@@ -629,7 +629,7 @@ class Choir(VocalPart):
                 data.afterblocks.append(book)
                 data.afterblocks.append(ly.dom.BlankLine())
                 score = ly.dom.Score(book)
-                
+
                 # TODO: make configurable
                 midiInstrument = voice2Midi[voice]
 
@@ -638,7 +638,7 @@ class Choir(VocalPart):
                 ly.dom.QuotedString(midiInstrument, cmd)
                 ly.dom.Identifier(refs[(lyrName, allStanzas[0])], cmd)
                 ly.dom.Midi(score)
-            
+
             ly.dom.Text("\\context Staff = $name", choir)
             seq = ly.dom.Seq(choir)
             ly.dom.Line("\\set Score.midiMinimumVolume = #0.5", seq)

--- a/frescobaldi_app/scorewiz/parts/woodwind.py
+++ b/frescobaldi_app/scorewiz/parts/woodwind.py
@@ -28,25 +28,25 @@ from . import register
 
 class WoodWindPart(_base.SingleVoicePart):
     """Base class for wood wind part types."""
-    
-    
+
+
 class Flute(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Flute")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Flute", "Fl.")
 
     midiInstrument = 'flute'
 
-    
+
 class Piccolo(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Piccolo")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Piccolo", "Pic.")
@@ -54,25 +54,25 @@ class Piccolo(WoodWindPart):
     midiInstrument = 'piccolo'
     transposition = (1, 0, 0)
 
-    
+
 class AltoFlute(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Alto Flute")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation Alto flute", "Afl.")
 
     midiInstrument = 'flute'
-    transposition = (-1, 4, 0) 	
+    transposition = (-1, 4, 0)
 
 
 class BassFlute(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Bass flute")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Bass flute", "Bfl.")
@@ -85,7 +85,7 @@ class Oboe(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Oboe")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Oboe", "Ob.")
@@ -97,7 +97,7 @@ class OboeDAmore(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Oboe d'amore")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Oboe d'amore", "Ob.d'am.")
@@ -110,7 +110,7 @@ class EnglishHorn(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("English horn")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for English horn", "Eng.h.")
@@ -123,7 +123,7 @@ class Bassoon(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Bassoon")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Bassoon", "Bn.")
@@ -137,7 +137,7 @@ class ContraBassoon(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Contrabassoon")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Contrabassoon", "C.Bn.")
@@ -152,7 +152,7 @@ class Clarinet(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Clarinet")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Clarinet", "Cl.")
@@ -160,38 +160,38 @@ class Clarinet(WoodWindPart):
     midiInstrument = 'clarinet'
     transposition = (-1, 6, -1)
 
-    
+
 class EflatClarinet(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("E-flat clarinet ")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for E-flat Clarinet", "Cl. in Eb")
 
     midiInstrument = 'clarinet'
     transposition = (0, 2, -1)
-    
-    
+
+
 class AClarinet(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("A clarinet ")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for A Clarinet", "Cl. in A")
 
     midiInstrument = 'clarinet'
     transposition = (-1, 5, 0)
-    
+
 
 class BassClarinet(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Bass clarinet")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Bass clarinet", "BCl.")
@@ -204,7 +204,7 @@ class C_MelodySax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("C-Melody Sax")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for C-Melody Sax", "C-Mel Sax")
@@ -216,11 +216,11 @@ class SopraninoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Sopranino Sax")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Sopranino Sax", "SiSx.")
-    
+
     midiInstrument = 'soprano sax'
     transposition = (0, 2, -1)    # es'
 
@@ -229,11 +229,11 @@ class SopranoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Soprano Sax")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Soprano Sax", "SoSx.")
-    
+
     midiInstrument = 'soprano sax'
     transposition = (-1, 6, -1)   # bes
 
@@ -242,11 +242,11 @@ class AltoSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Alto Sax")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Alto Sax", "ASx.")
-    
+
     midiInstrument = 'alto sax'
     transposition = (-1, 2, -1)   # es
 
@@ -255,11 +255,11 @@ class TenorSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Tenor Sax")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Tenor Sax", "TSx.")
-    
+
     midiInstrument = 'tenor sax'
     transposition = (-2, 6, -1)   # bes,
 
@@ -268,11 +268,11 @@ class BaritoneSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Baritone Sax")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Baritone Sax", "BSx.")
-    
+
     midiInstrument = 'baritone sax'
     transposition = (-2, 2, -1)   # es,
 
@@ -281,11 +281,11 @@ class BassSax(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Bass Sax")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Bass Sax", "BsSx.")
-    
+
     midiInstrument = 'baritone sax'
     transposition = (-3, 6, -1)   # bes,,
 
@@ -294,11 +294,11 @@ class SopraninoRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Sopranino recorder")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Sopranino recorder", "Si.rec.")
-    
+
     midiInstrument = 'recorder'
     transposition = (1, 0, 0)
 
@@ -306,11 +306,11 @@ class SopranoRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Soprano recorder")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Soprano recorder", "S.rec.")
-    
+
     midiInstrument = 'recorder'
     transposition = (1, 0, 0)
 
@@ -319,11 +319,11 @@ class AltoRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Alto recorder")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Alto recorder", "A.rec.")
-    
+
     midiInstrument = 'recorder'
 
 
@@ -331,11 +331,11 @@ class TenorRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Tenor recorder")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Tenor recorder", "T.rec.")
-    
+
     midiInstrument = 'recorder'
 
 
@@ -343,40 +343,40 @@ class BassRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Bass recorder")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Bass recorder", "B.rec.")
-    
+
     midiInstrument = 'recorder'
     transposition = (1, 0, 0)
     clef = 'bass'
     octave = -1
-    
-    
+
+
 class ContraBassRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Contra Bass recorder")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Contra Bass recorder", "Cb.rec.")
-    
+
     midiInstrument = 'recorder'
     clef = 'bass'
     octave = -1
-    
-    
+
+
 class SubContraBassRecorder(WoodWindPart):
     @staticmethod
     def title(_=_base.translate):
         return _("Subcontra Bass recorder")
-    
+
     @staticmethod
     def short(_=_base.translate):
         return _("abbreviation for Subcontra Bass recorder", "Scb.rec.")
-    
+
     midiInstrument = 'recorder'
     clef = 'bass'
     octave = -1

--- a/frescobaldi_app/scorewiz/preview.py
+++ b/frescobaldi_app/scorewiz/preview.py
@@ -41,10 +41,10 @@ def examplify(doc):
                     break
             stubs.append((g, a[-1]))
         else:
-            keysig = a.find_child(ly.dom.KeySignature) 
+            keysig = a.find_child(ly.dom.KeySignature)
             timesig = a.find_child(ly.dom.TimeSignature)
             partial = a.find_child(ly.dom.Partial)
-            
+
             # create a list of durations for the example notes.
             durations = []
             if partial:
@@ -57,10 +57,10 @@ def examplify(doc):
             durations += [(dur, 0)] * num
 
             globals[a.name] = (keysig, durations)
-    
+
     # other lyrics on each request
     lyrics = itertools.cycle('ha hi he ho hu'.split())
-    
+
     # fill assignment stubs with suitable example music input
     num = 10
     for g, stub in stubs:
@@ -69,13 +69,13 @@ def examplify(doc):
             num = len(durations)
         except KeyError:
             pass
-        
+
         def addItems(stub, generator):
             for dur, dots in durations:
                 node = next(generator)
                 node.append(ly.dom.Duration(dur, dots))
                 stub.append(node)
-        
+
         if isinstance(stub, ly.dom.LyricMode):
             stub.append(ly.dom.Text(' '.join(itertools.repeat(next(lyrics), num))))
         elif isinstance(stub, ly.dom.Relative):
@@ -104,14 +104,14 @@ def chordGen(startPitch):
         yield n
         for i in 1, 2, 3:
             yield ly.dom.TextDur("\\skip")
-        
+
 
 def figureGen():
     while True:
         for i in 5, 6, 3, 8, 7:
             for s in "<{0}>".format(i), "\\skip", "\\skip":
                 yield ly.dom.TextDur(s)
-            
+
 
 def drumGen():
     while True:

--- a/frescobaldi_app/scorewiz/score.py
+++ b/frescobaldi_app/scorewiz/score.py
@@ -37,7 +37,7 @@ from . import parts
 class ScorePartsWidget(QSplitter):
     def __init__(self, parent):
         super(ScorePartsWidget, self).__init__(parent)
-        
+
         self.typesLabel = QLabel()
         self.typesView = QTreeView(
             selectionMode=QTreeView.ExtendedSelection,
@@ -56,36 +56,36 @@ class ScorePartsWidget(QSplitter):
         self.upButton = QToolButton(icon = icons.get("go-up"))
         self.downButton = QToolButton(icon = icons.get("go-down"))
         self.partSettings = QStackedWidget()
-        
+
         w = QWidget()
         self.addWidget(w)
         layout = QVBoxLayout(spacing=0)
         w.setLayout(layout)
-        
+
         layout.addWidget(self.typesLabel)
         layout.addWidget(self.typesView)
         layout.addWidget(self.addButton)
-        
+
         w = QWidget()
         self.addWidget(w)
         layout = QVBoxLayout(spacing=0)
         w.setLayout(layout)
-        
+
         layout.addWidget(self.scoreLabel)
         layout.addWidget(self.scoreView)
-        
+
         box = QHBoxLayout(spacing=0)
         layout.addLayout(box)
-        
+
         box.addWidget(self.removeButton)
         box.addWidget(self.upButton)
         box.addWidget(self.downButton)
-        
+
         self.addWidget(self.partSettings)
 
         self.typesView.setModel(parts.model())
         app.translateUI(self)
-        
+
         # signal connections
         self.addButton.clicked.connect(self.slotAddButtonClicked)
         self.removeButton.clicked.connect(self.slotRemoveButtonClicked)
@@ -93,7 +93,7 @@ class ScorePartsWidget(QSplitter):
         self.scoreView.currentItemChanged.connect(self.slotCurrentItemChanged)
         self.upButton.clicked.connect(self.scoreView.moveSelectedChildrenUp)
         self.downButton.clicked.connect(self.scoreView.moveSelectedChildrenDown)
-        
+
     def translateUI(self):
         bold = "<b>{0}</b>".format
         self.typesLabel.setText(bold(_("Available parts:")))
@@ -105,7 +105,7 @@ class ScorePartsWidget(QSplitter):
 
     def slotDoubleClicked(self, index):
         self.addParts([index])
-        
+
     def slotAddButtonClicked(self):
         self.addParts(self.typesView.selectedIndexes())
 
@@ -126,14 +126,14 @@ class ScorePartsWidget(QSplitter):
                 else:
                     parent = self.scoreView
                 item = PartItem(parent, part, box)
-    
+
     def slotCurrentItemChanged(self, item):
         if isinstance(item, PartItem):
             self.partSettings.setCurrentWidget(item.box)
-    
+
     def slotRemoveButtonClicked(self):
         self.scoreView.removeSelectedItems()
-       
+
     def clear(self):
         """Called when the user clicks the clear button on this page."""
         self.scoreView.clear()
@@ -141,17 +141,17 @@ class ScorePartsWidget(QSplitter):
     def rootPartItem(self):
         """Returns the invisibleRootItem(), representing the tree of parts in the score view."""
         return self.scoreView.invisibleRootItem()
-        
+
 
 class PartItem(widgets.treewidget.TreeWidgetItem):
     """An item in the score tree widget."""
     def __init__(self, tree, part, box):
         """Initializes the item.
-        
+
         tree: is the score tree widget,
         part: is the Part instance that creates the widgets
         box: the QGroupBox that is created for this item in the stacked widget.
-        
+
         """
         super(PartItem, self).__init__(tree)
         self.part = part()
@@ -161,7 +161,7 @@ class PartItem(widgets.treewidget.TreeWidgetItem):
         self.part.createWidgets(layout)
         layout.addStretch(1)
         app.translateUI(self)
-        
+
         flags = (
             Qt.ItemIsSelectable |
             Qt.ItemIsDragEnabled |
@@ -170,12 +170,12 @@ class PartItem(widgets.treewidget.TreeWidgetItem):
         if issubclass(part, parts._base.Container):
             flags |= Qt.ItemIsDropEnabled
         self.setFlags(flags)
-        
+
     def translateUI(self):
         self.setText(0, self.part.title())
         self.box.setTitle(self.part.title())
         self.part.translateWidgets()
-        
+
     def cleanup(self):
         self.box.deleteLater()
 

--- a/frescobaldi_app/scorewiz/scoreproperties.py
+++ b/frescobaldi_app/scorewiz/scoreproperties.py
@@ -53,7 +53,7 @@ class ScoreProperties(object):
         self.createPickupWidget()
         self.createMetronomeWidget()
         self.createTempoWidget()
-        
+
     def layoutWidgets(self, layout):
         """Adds all widgets to a vertical layout."""
         self.layoutKeySignatureWidget(layout)
@@ -61,32 +61,32 @@ class ScoreProperties(object):
         self.layoutPickupWidget(layout)
         self.layoutMetronomeWidget(layout)
         self.layoutTempoWidget(layout)
-        
+
     def translateWidgets(self):
         self.translateKeySignatureWidget()
         self.translateTimeSignatureWidget()
         self.translatePickupWidget()
         self.tranlateMetronomeWidget()
         self.translateTempoWidget()
-    
+
     def ly(self, node, builder):
         """Adds appropriate LilyPond command nodes to the parent node.
-        
+
         Settings from the builder are used where that makes sense.
         All widgets must be present.
-        
+
         """
         self.lyKeySignature(node, builder)
         self.lyTimeSignature(node, builder)
         self.lyPickup(node, builder)
         self.lyTempo(node, builder)
-    
+
     def globalSection(self, builder):
         """Returns a sequential expression between { } containing the output of ly()."""
         seq = ly.dom.Seq()
         self.ly(seq, builder)
         return seq
-        
+
     # Key signature
     def createKeySignatureWidget(self):
         self.keySignatureLabel = QLabel()
@@ -95,11 +95,11 @@ class ScoreProperties(object):
         self.keyMode = QComboBox()
         self.keyMode.setModel(listmodel.ListModel(modes, self.keyMode, display=listmodel.translate_index(1)))
         self.keySignatureLabel.setBuddy(self.keyNote)
-        
+
     def translateKeySignatureWidget(self):
         self.keySignatureLabel.setText(_("Key signature:"))
         self.keyMode.model().update()
-    
+
     def layoutKeySignatureWidget(self, layout):
         """Adds our widgets to a layout, assuming it is a QVBoxLayout."""
         box = QHBoxLayout()
@@ -111,14 +111,14 @@ class ScoreProperties(object):
     def setPitchLanguage(self, language='nederlands'):
         self.keyNote.model()._data = keyNames[language or 'nederlands']
         self.keyNote.model().update()
-    
+
     def lyKeySignature(self, node, builder):
         """Adds the key signature to the ly.dom node parent."""
         note, alter = keys[self.keyNote.currentIndex()]
         alter = fractions.Fraction(alter, 2)
         mode = modes[self.keyMode.currentIndex()][0]
         ly.dom.KeySignature(note, alter, mode, node).after = 1
-        
+
     # Time signature
     def createTimeSignatureWidget(self):
         self.timeSignatureLabel = QLabel()
@@ -131,17 +131,17 @@ class ScoreProperties(object):
             icon=icons.get))
         self.timeSignature.setCompleter(None)
         self.timeSignatureLabel.setBuddy(self.timeSignature)
-    
+
     def translateTimeSignatureWidget(self):
         self.timeSignatureLabel.setText(_("Time signature:"))
-    
+
     def layoutTimeSignatureWidget(self, layout):
         """Adds our widgets to a layout, assuming it is a QVBoxLayout."""
         box = QHBoxLayout()
         box.addWidget(self.timeSignatureLabel)
         box.addWidget(self.timeSignature)
         layout.addLayout(box)
-    
+
     def lyTimeSignature(self, node, builder):
         """Adds the time signature to the ly.dom node parent."""
         sig = self.timeSignature.currentText().strip()
@@ -173,22 +173,22 @@ class ScoreProperties(object):
             icon = lambda item: symbols.icon('note_{0}'.format(item.replace('.', 'd'))) if item else None))
         self.pickup.view().setIconSize(QSize(22, 22))
         self.pickupLabel.setBuddy(self.pickup)
-        
+
     def translatePickupWidget(self):
         self.pickupLabel.setText(_("Pickup measure:"))
         self.pickup.model().update()
-        
+
     def layoutPickupWidget(self, layout):
         box = QHBoxLayout()
         box.addWidget(self.pickupLabel)
         box.addWidget(self.pickup)
         layout.addLayout(box)
-    
+
     def lyPickup(self, node, builder):
         if self.pickup.currentIndex() > 0:
             dur, dots = partialDurations[self.pickup.currentIndex() - 1]
             ly.dom.Partial(dur, dots, parent=node)
-    
+
     # Metronome value
     def createMetronomeWidget(self):
         self.metronomeLabel = QLabel()
@@ -210,7 +210,7 @@ class ScoreProperties(object):
         self.metronomeLabel.setBuddy(self.metronomeNote)
         self.metronomeRound = QCheckBox()
 
-    
+
     def layoutMetronomeWidget(self, layout):
         grid = QGridLayout()
         grid.addWidget(self.metronomeLabel, 0, 0)
@@ -224,14 +224,14 @@ class ScoreProperties(object):
 
         grid.addWidget(self.metronomeRound, 1, 1)
         layout.addLayout(grid)
-        
+
     def tranlateMetronomeWidget(self):
         self.metronomeLabel.setText(_("Metronome mark:"))
         self.metronomeRound.setText(_("Round tap tempo value"))
         self.metronomeRound.setToolTip(_(
             "Round the entered tap tempo to a common value."
             ))
-    
+
     def setMetronomeValue(self, bpm):
         """ Tap the tempo tap button """
         if  self.metronomeRound.isChecked():
@@ -278,19 +278,19 @@ class ScoreProperties(object):
     def lyMidiTempo(self, node):
         """Sets the configured tempo in the tempoWholesPerMinute variable."""
         node['tempoWholesPerMinute'] = ly.dom.Scheme(self.schemeMidiTempo())
-    
+
     def schemeMidiTempo(self):
         """Returns a string with the tempo like '(ly:make-moment 100 4)' from the settings."""
         base, mul = midiDurations[self.metronomeNote.currentIndex()]
         val = int(self.metronomeValue.currentText() or '60') * mul
         return "(ly:make-moment {0} {1})".format(val, base)
-    
+
     def lySimpleMidiTempo(self, node):
         r"""Return a simple \tempo x=y node for the currently set tempo."""
         dur = durations[self.metronomeNote.currentIndex()]
         val = self.metronomeValue.currentText() or '60'
         return ly.dom.Tempo(dur, val, node)
-        
+
 
 def metronomeValues():
     v, start = [], 40
@@ -314,7 +314,7 @@ timeSignaturePresets = (
 durations = ('16', '16.', '8', '8.', '4', '4.', '2', '2.', '1', '1.')
 midiDurations = ((16,1),(32,3),(8,1),(16,3),(4,1),(8,3),(2,1),(4,3),(1,1),(2,3))
 partialDurations = ((4,0),(4,1),(3,0),(3,1),(2,0),(2,1),(1,0),(1,1),(0,0),(0,1))
- 
+
 
 keyNames = {
     'nederlands': (

--- a/frescobaldi_app/scorewiz/settings.py
+++ b/frescobaldi_app/scorewiz/settings.py
@@ -39,17 +39,17 @@ class SettingsWidget(QWidget):
         super(SettingsWidget, self).__init__(parent)
         grid = QGridLayout()
         self.setLayout(grid)
-        
+
         self.scoreProperties = ScoreProperties(self)
         self.generalPreferences = GeneralPreferences(self)
         self.lilyPondPreferences = LilyPondPreferences(self)
         self.instrumentNames = InstrumentNames(self)
-        
+
         grid.addWidget(self.scoreProperties, 0, 0)
         grid.addWidget(self.generalPreferences, 0, 1)
         grid.addWidget(self.lilyPondPreferences, 1, 0)
         grid.addWidget(self.instrumentNames, 1, 1)
-    
+
     def clear(self):
         self.scoreProperties.tempo.clear()
         self.scoreProperties.keyNote.setCurrentIndex(0)
@@ -60,22 +60,22 @@ class SettingsWidget(QWidget):
 class ScoreProperties(QGroupBox, scoreproperties.ScoreProperties):
     def __init__(self, parent):
         super(ScoreProperties, self).__init__(parent)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.createWidgets()
         self.layoutWidgets(layout)
-        
+
         app.translateUI(self)
-        
+
         scorewiz = self.window()
         scorewiz.pitchLanguageChanged.connect(self.setPitchLanguage)
         self.setPitchLanguage(scorewiz.pitchLanguage())
 
         self.loadSettings()
         self.window().finished.connect(self.saveSettings)
-        
+
     def translateUI(self):
         self.translateWidgets()
         self.setTitle(_("Score properties"))
@@ -94,10 +94,10 @@ class ScoreProperties(QGroupBox, scoreproperties.ScoreProperties):
 class GeneralPreferences(QGroupBox):
     def __init__(self, parent):
         super(GeneralPreferences, self).__init__(parent)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.typq = QCheckBox()
         self.tagl = QCheckBox()
         self.barnum = QCheckBox()
@@ -109,24 +109,24 @@ class GeneralPreferences(QGroupBox):
         self.paper.addItems(paperSizes)
         self.paperLandscape = QCheckBox(enabled=False)
         self.paper.activated.connect(self.slotPaperChanged)
-        
+
         layout.addWidget(self.typq)
         layout.addWidget(self.tagl)
         layout.addWidget(self.barnum)
         layout.addWidget(self.neutdir)
         layout.addWidget(self.midi)
         layout.addWidget(self.metro)
-        
+
         box = QHBoxLayout(spacing=2)
         box.addWidget(self.paperSizeLabel)
         box.addWidget(self.paper)
         box.addWidget(self.paperLandscape)
         layout.addLayout(box)
         app.translateUI(self)
-        
+
         self.loadSettings()
         self.window().finished.connect(self.saveSettings)
-        
+
     def translateUI(self):
         self.setTitle(_("General preferences"))
         self.typq.setText(_("Use typographical quotes"))
@@ -154,14 +154,14 @@ class GeneralPreferences(QGroupBox):
         self.paperSizeLabel.setText(_("Paper size:"))
         self.paper.setItemText(0, _("Default"))
         self.paperLandscape.setText(_("Landscape"))
-  
+
     def slotPaperChanged(self, index):
         self.paperLandscape.setEnabled(bool(index))
-    
+
     def getPaperSize(self):
         """Returns the configured papersize or the empty string for default."""
         return paperSizes[self.paper.currentIndex()]
-    
+
     def loadSettings(self):
         s = QSettings()
         s.beginGroup('scorewiz/preferences')
@@ -189,14 +189,14 @@ class GeneralPreferences(QGroupBox):
         s.setValue('paper_size', paperSizes[self.paper.currentIndex()])
         s.setValue('paper_landscape', self.paperLandscape.isChecked())
 
-        
+
 class InstrumentNames(QGroupBox):
     def __init__(self, parent):
         super(InstrumentNames, self).__init__(parent, checkable=True, checked=True)
-        
+
         grid = QGridLayout()
         self.setLayout(grid)
-        
+
         self.firstSystemLabel = QLabel()
         self.firstSystem = QComboBox()
         self.firstSystemLabel.setBuddy(self.firstSystem)
@@ -213,7 +213,7 @@ class InstrumentNames(QGroupBox):
         self.otherSystems.setModel(listmodel.ListModel(
             (lambda: _("Long"), lambda: _("Short"), lambda: _("None")), self.otherSystems,
             display = listmodel.translate))
-        
+
         self._langs = l = ['','C']
         l.extend(sorted(po.available()))
         def display(lang):
@@ -223,7 +223,7 @@ class InstrumentNames(QGroupBox):
                 return _("Default")
             return language_names.languageName(lang, po.setup.current())
         self.language.setModel(listmodel.ListModel(l, self.language, display=display))
-        
+
         grid.addWidget(self.firstSystemLabel, 0, 0)
         grid.addWidget(self.firstSystem, 0, 1)
         grid.addWidget(self.otherSystemsLabel, 1, 0)
@@ -233,7 +233,7 @@ class InstrumentNames(QGroupBox):
         app.translateUI(self)
         self.loadSettings()
         self.window().finished.connect(self.saveSettings)
-        
+
     def translateUI(self):
         self.setTitle(_("Instrument names"))
         self.firstSystemLabel.setText(_("First system:"))
@@ -248,14 +248,14 @@ class InstrumentNames(QGroupBox):
         self.firstSystem.model().update()
         self.otherSystems.model().update()
         self.language.model().update()
-    
+
     def getLanguage(self):
         """Returns the language the user has set.
-        
+
         '' means:  default (use same translation as system)
         'C' means: English (untranslated)
         or a language code that is available in Frescobaldi's translation.
-        
+
         """
         return self._langs[self.language.currentIndex()]
 
@@ -271,7 +271,7 @@ class InstrumentNames(QGroupBox):
         self.otherSystems.setCurrentIndex(allow.index(other) if other in allow else 2)
         language = s.value('language', '', str)
         self.language.setCurrentIndex(self._langs.index(language) if language in self._langs else 0)
-    
+
     def saveSettings(self):
         s = QSettings()
         s.beginGroup('scorewiz/instrumentnames')
@@ -280,31 +280,31 @@ class InstrumentNames(QGroupBox):
         s.setValue('other', ('long', 'short', 'none')[self.otherSystems.currentIndex()])
         s.setValue('language', self._langs[self.language.currentIndex()])
 
-        
+
 class LilyPondPreferences(QGroupBox):
     def __init__(self, parent):
         super(LilyPondPreferences, self).__init__(parent)
-        
+
         grid = QGridLayout()
         self.setLayout(grid)
-        
+
         self.pitchLanguageLabel = QLabel()
         self.pitchLanguage = QComboBox()
         self.versionLabel = QLabel()
         self.version = QComboBox(editable=True)
-        
+
         self.pitchLanguage.addItem('')
         self.pitchLanguage.addItems([lang.title() for lang in sorted(scoreproperties.keyNames)])
         self.version.addItem(lilypondinfo.preferred().versionString())
         for v in ("2.18.0", "2.16.0", "2.14.0", "2.12.0"):
             if v != lilypondinfo.preferred().versionString():
                 self.version.addItem(v)
-        
+
         grid.addWidget(self.pitchLanguageLabel, 0, 0)
         grid.addWidget(self.pitchLanguage, 0, 1)
         grid.addWidget(self.versionLabel, 1, 0)
         grid.addWidget(self.version, 1, 1)
-        
+
         self.pitchLanguage.activated.connect(self.slotPitchLanguageChanged)
         app.translateUI(self)
         self.loadSettings()
@@ -326,7 +326,7 @@ class LilyPondPreferences(QGroupBox):
         else:
             language = self.pitchLanguage.currentText().lower()
         self.window().setPitchLanguage(language)
-        
+
     def loadSettings(self):
         language = self.window().pitchLanguage()
         languages = list(sorted(scoreproperties.keyNames))

--- a/frescobaldi_app/scratchdir.py
+++ b/frescobaldi_app/scratchdir.py
@@ -33,17 +33,17 @@ import plugin
 
 def scratchdir(document):
     return ScratchDir.instance(document)
-    
+
 
 def findDocument(filename):
     """Like app.findDocument(), but also takes a possible scratchdir into account.
-    
+
     If the filename happens to be the scratch-filename of a document, that
     document is returned. Otherwise, the document that really has the filename
     is returned.
-    
+
     Note that, unlike app.findDocument(), a filename is specified and not a url.
-    
+
     """
     for d in app.documents:
         if d.url().toLocalFile() == filename:
@@ -54,19 +54,19 @@ def findDocument(filename):
 
 
 class ScratchDir(plugin.DocumentPlugin):
-    
+
     def __init__(self, document):
         self._directory = None
-        
+
     def create(self):
         """Creates the local temporary directory."""
         if not self._directory:
             self._directory = util.tempdir()
-    
+
     def directory(self):
         """Returns the directory if a temporary area was created, else None."""
         return self._directory
-    
+
     def path(self):
         """Returns the path the saved document text would have if a temporary area was created, else None."""
         if self._directory:
@@ -76,13 +76,13 @@ class ScratchDir(plugin.DocumentPlugin):
             if not basename:
                 basename = 'document' + ly.lex.extensions[documentinfo.mode(self.document())]
             return os.path.join(self._directory, basename)
-            
+
     def saveDocument(self):
         """Writes the text of the document to our path()."""
         if not self._directory:
             self.create()
         with open(self.path(), 'wb') as f:
             f.write(self.document().encodedText())
-            
+
 
 

--- a/frescobaldi_app/search/__init__.py
+++ b/frescobaldi_app/search/__init__.py
@@ -52,20 +52,20 @@ class Search(plugin.MainWindowPlugin, QWidget):
         self._positionsDirty = True
         self._replace = False  # are we in replace mode?
         self._going = False    # are we moving the text cursor?
-        
+
         mainwindow.currentViewChanged.connect(self.viewChanged)
         mainwindow.actionCollection.edit_find_next.triggered.connect(self.findNext)
         mainwindow.actionCollection.edit_find_previous.triggered.connect(self.findPrevious)
-        
+
         # don't inherit looks from view
         self.setFont(QApplication.font())
         self.setPalette(QApplication.palette())
-        
+
         grid = QGridLayout(spacing=2)
         grid.setContentsMargins(4, 0, 4, 0)
         grid.setVerticalSpacing(0)
         self.setLayout(grid)
-        
+
         self.searchEntry = QLineEdit(textChanged=self.slotSearchChanged)
         self.searchLabel = QLabel()
         self.prevButton = QToolButton(autoRaise=True, focusPolicy=Qt.NoFocus, clicked=self.findPrevious)
@@ -81,7 +81,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
         self.hideAction.setShortcut(QKeySequence(Qt.Key_Escape))
         self.hideAction.setIcon(self.style().standardIcon(QStyle.SP_DialogCloseButton))
         self.closeButton.setDefaultAction(self.hideAction)
-        
+
         grid.addWidget(self.searchLabel, 0, 0)
         grid.addWidget(self.searchEntry, 0, 1)
         grid.addWidget(self.prevButton, 0, 2)
@@ -90,24 +90,24 @@ class Search(plugin.MainWindowPlugin, QWidget):
         grid.addWidget(self.regexCheck, 0, 5)
         grid.addWidget(self.countLabel, 0, 6)
         grid.addWidget(self.closeButton, 0, 7)
-        
+
         self.caseCheck.toggled.connect(self.slotSearchChanged)
         self.regexCheck.toggled.connect(self.slotSearchChanged)
-        
+
         self.replaceEntry = QLineEdit()
         self.replaceLabel = QLabel()
         self.replaceButton = QPushButton(clicked=self.slotReplace)
         self.replaceAllButton = QPushButton(clicked=self.slotReplaceAll)
-        
+
         grid.addWidget(self.replaceLabel, 1, 0)
         grid.addWidget(self.replaceEntry, 1, 1)
         grid.addWidget(self.replaceButton, 1, 4)
         grid.addWidget(self.replaceAllButton, 1, 5)
-        
+
         app.settingsChanged.connect(self.readSettings)
         self.readSettings()
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.searchLabel.setText(_("Search:"))
         self.prevButton.setToolTip(_("Find Previous"))
@@ -123,7 +123,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
         self.replaceButton.setToolTip(_("Replaces the next occurrence of the search term."))
         self.replaceAllButton.setText(_("&All"))
         self.replaceAllButton.setToolTip(_("Replaces all occurrences of the search term in the document or selection."))
-    
+
     def readSettings(self):
         data = textformats.formatData('editor')
         self.searchEntry.setFont(data.font)
@@ -131,11 +131,11 @@ class Search(plugin.MainWindowPlugin, QWidget):
         p = data.palette()
         self.searchEntry.setPalette(p)
         self.replaceEntry.setPalette(p)
-         
+
     def currentView(self):
         """Return the currently active View."""
         return self._currentView and self._currentView()
-    
+
     def setCurrentView(self, view):
         """Set the currently active View, called by showWidget()."""
         cur = self.currentView()
@@ -146,7 +146,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
             view.selectionChanged.connect(self.slotSelectionChanged)
             view.document().contentsChanged.connect(self.slotDocumentContentsChanged)
         self._currentView = weakref.ref(view) if view else None
-    
+
     def showWidget(self):
         """Show the search widget and connect with the active View."""
         if self.isVisible():
@@ -156,7 +156,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
         layout = gadgets.borderlayout.BorderLayout.get(view)
         layout.addWidget(self, gadgets.borderlayout.BOTTOM)
         self.show()
-        
+
     def hideWidget(self):
         """Hide the widget, but remain connected with the active View."""
         view = self.currentView()
@@ -165,14 +165,14 @@ class Search(plugin.MainWindowPlugin, QWidget):
             self.hide()
             layout = gadgets.borderlayout.BorderLayout.get(view)
             layout.removeWidget(self)
-    
+
     def viewChanged(self, new):
         """Called when the user switches to another View."""
         self.setParent(None)
         self.hideWidget()
         self.setCurrentView(new)
         self.markPositionsDirty()
-    
+
     def slotSelectionChanged(self):
         """Called when the user changes the selection."""
         if not self._going:
@@ -187,14 +187,14 @@ class Search(plugin.MainWindowPlugin, QWidget):
         if self.isVisible():
             self.updatePositions()
             self.highlightingOn()
-        
+
     def slotHide(self):
         """Called when the close button is clicked."""
         view = self.currentView()
         if view:
             self.hideWidget()
             view.setFocus()
-        
+
     def find(self):
         """Called by the main menu Find... command."""
         # hide replace stuff
@@ -223,7 +223,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
             self.searchEntry.selectAll()
             self.highlightingOn()
         self.searchEntry.setFocus()
-        
+
     def replace(self):
         """Called by the main menu Find and Replace... command."""
         # show replace stuff
@@ -241,7 +241,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
             self.updatePositions()
             self.highlightingOn()
         focus.setFocus()
-        
+
     def slotSearchChanged(self):
         """Called on every change in the search text entry."""
         self._going = True
@@ -270,19 +270,19 @@ class Search(plugin.MainWindowPlugin, QWidget):
             view = self.currentView()
         if view:
             viewhighlighter.highlighter(view).highlight("search", self._positions, 1)
-    
+
     def highlightingOff(self, view=None):
         """Hide the current search result positions."""
         if view is None:
             view = self.currentView()
         if view:
             viewhighlighter.highlighter(view).clear("search")
-            
+
     def markPositionsDirty(self):
         """Delete positions and mark them dirty, i.e. they need updating."""
         self._positions = []
         self._positionsDirty = True
-    
+
     def updatePositions(self):
         """Update the search result positions if necessary."""
         view = self.currentView()
@@ -321,7 +321,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
         self.prevButton.setEnabled(enabled)
         self.nextButton.setEnabled(enabled)
         self._positionsDirty = False
-        
+
     def findNext(self):
         """Called on menu Find Next."""
         self._going = True
@@ -347,7 +347,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
             index = bisect.bisect_left(positions, view.textCursor().position()) - 1
             self.gotoPosition(index)
         self._going = False
-    
+
     def gotoPosition(self, index):
         """Scrolls the current View to the position in the _positions list at index."""
         c = QTextCursor(self._positions[index])
@@ -374,7 +374,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
                 ev.accept()
                 return True
         return super(Search, self).event(ev)
-        
+
     def keyPressEvent(self, ev):
         """Catches Up and Down to jump between search results."""
         # if in search mode, Up and Down jump between search results
@@ -411,7 +411,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
             cursor.insertText(replace)
             cursor.setPosition(pos, QTextCursor.KeepAnchor)
         return ok
-        
+
     def slotReplace(self):
         """Called when the user clicks Replace."""
         view = self.currentView()
@@ -422,7 +422,7 @@ class Search(plugin.MainWindowPlugin, QWidget):
                 index = 0
             if self.doReplace(self._positions[index]):
                 self.findNext()
-    
+
     def slotReplaceAll(self):
         """Called when the user clicks Replace All."""
         view = self.currentView()

--- a/frescobaldi_app/sessions/__init__.py
+++ b/frescobaldi_app/sessions/__init__.py
@@ -43,15 +43,15 @@ def _saveLastUsedSession():
     s = QSettings()
     s.beginGroup("session")
     s.setValue("lastused", _currentSession or "")
-    
+
 def loadDefaultSession():
     """Load the session which should be started by default.
-    
+
     This can be:
     - no session,
     - last used session,
     - a specific session.
-    
+
     Returns the document that should be set active (if any).
     """
     s = QSettings()
@@ -69,9 +69,9 @@ def loadDefaultSession():
 
 def sessionGroup(name):
     """Returns the session settings group where settings can be stored for the named session.
-    
+
     If the group doesn't exist, it is created.
-    
+
     """
     session = app.settings("sessions")
     childGroups = session.childGroups()
@@ -92,13 +92,13 @@ def sessionNames():
     names = [session.value(group + "/name", "", str) for group in session.childGroups()]
     names.sort(key=util.naturalsort)
     return names
-    
+
 def loadSession(name):
     """Loads the given session (without closing other docs first).
-    
+
     Return the document that should become the active one.
     If None is returned, the session did not open any documents!
-    
+
     """
     session = sessionGroup(name)
     urls = qsettings.get_url_list(session, "urls")
@@ -145,10 +145,10 @@ def renameSession(old, new):
     session.setValue("name", new)
     if old == currentSession():
         setCurrentSession(new)
-    
+
 def currentSession():
     return _currentSession
-    
+
 def setCurrentSession(name):
     global _currentSession
     if name != _currentSession:
@@ -158,9 +158,9 @@ def setCurrentSession(name):
 
 def currentSessionGroup():
     """Returns the session settings at the current group is there is a current session.
-    
+
     If there is no current session, returns None.
-    
+
     """
     if _currentSession:
         return sessionGroup(_currentSession)

--- a/frescobaldi_app/sessions/dialog.py
+++ b/frescobaldi_app/sessions/dialog.py
@@ -27,8 +27,8 @@ import json
 
 from PyQt5.QtCore import Qt, QSettings, QUrl
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QCheckBox, QDialog, QDialogButtonBox, QFileDialog, 
-    QGridLayout, QGroupBox, QLabel, QListWidgetItem, QLineEdit, QMessageBox, 
+    QAbstractItemView, QCheckBox, QDialog, QDialogButtonBox, QFileDialog,
+    QGridLayout, QGroupBox, QLabel, QListWidgetItem, QLineEdit, QMessageBox,
     QPushButton, QVBoxLayout)
 
 import app
@@ -45,23 +45,23 @@ class SessionManagerDialog(QDialog):
         self.setWindowModality(Qt.WindowModal)
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.sessions = SessionList(self)
         layout.addWidget(self.sessions)
-        
+
         self.imp = QPushButton(self)
         self.exp = QPushButton(self)
         self.act = QPushButton(self)
         self.imp.clicked.connect(self.importSession)
         self.exp.clicked.connect(self.exportSession)
         self.act.clicked.connect(self.activateSession)
-        
+
         self.sessions.layout().addWidget(self.imp, 5, 1)
         self.sessions.layout().addWidget(self.exp, 6, 1)
         self.sessions.layout().addWidget(self.act, 7, 1)
-        
+
         layout.addWidget(widgets.Separator())
-        
+
         self.buttons = b = QDialogButtonBox(self)
         layout.addWidget(b)
         b.setStandardButtons(QDialogButtonBox.Close)
@@ -72,7 +72,7 @@ class SessionManagerDialog(QDialog):
         self.sessions.changed.connect(self.enableButtons)
         self.sessions.listBox.itemSelectionChanged.connect(self.enableButtons)
         self.enableButtons()
-        
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("Manage Sessions")))
         self.imp.setText(_("&Import..."))
@@ -81,13 +81,13 @@ class SessionManagerDialog(QDialog):
         self.exp.setToolTip(_("Opens a dialog to export a session to a file."))
         self.act.setText(_("&Activate"))
         self.act.setToolTip(_("Switches to the selected session."))
-    
+
     def enableButtons(self):
         """Called when the selection in the listedit changes."""
         enabled = bool(self.sessions.listBox.currentItem())
         self.act.setEnabled(enabled)
         self.exp.setEnabled(enabled)
-        
+
     def importSession(self):
         """Called when the user clicks Import."""
         filetypes = '{0} (*.json);;{1} (*)'.format(_("JSON Files"), _("All Files"))
@@ -106,7 +106,7 @@ class SessionManagerDialog(QDialog):
                 strerror = e.strerror,
                 errno = e.errno)
             QMessageBox.critical(self, app.caption(_("Error")), msg)
-        
+
     def exportSession(self):
         """Called when the user clicks Export."""
         itemname, jsondict = self.sessions.exportItem()
@@ -127,7 +127,7 @@ class SessionManagerDialog(QDialog):
                 strerror = e.strerror,
                 errno = e.errno)
             QMessageBox.critical(self, app.caption(_("Error")), msg)
-    
+
     def activateSession(self):
         """Called when the user clicks Activate."""
         item = self.sessions.listBox.currentItem()
@@ -161,7 +161,7 @@ class SessionList(widgets.listedit.ListEdit):
         if name:
             item.setText(name)
             return True
-            
+
     def importItem(self, data):
         """Implement importing a new session from a json data dict."""
         name = data['name']
@@ -178,12 +178,12 @@ class SessionList(widgets.listedit.ListEdit):
         names = sessions.sessionNames()
         if name in names:
             self.setCurrentRow(names.index(name))
-        
+
     def exportItem(self):
         """Implement exporting the currently selected session item to a dict.
-        
+
         Returns the dict, which can be dumped as a json data dictionary.
-        
+
         """
         jsondict = {}
         item = self.listBox.currentItem()
@@ -193,7 +193,7 @@ class SessionList(widgets.listedit.ListEdit):
                 urls = []
                 for u in s.value(key):
                     urls.append(u.toString())
-                jsondict[key] = urls 
+                jsondict[key] = urls
             else:
                 jsondict[key] = s.value(key)
         return (item.text(), jsondict)
@@ -203,50 +203,50 @@ class SessionEditor(QDialog):
     def __init__(self, parent=None):
         super(SessionEditor, self).__init__(parent)
         self.setWindowModality(Qt.WindowModal)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         grid = QGridLayout()
         layout.addLayout(grid)
-        
+
         self.name = QLineEdit()
         self.nameLabel = l = QLabel()
         l.setBuddy(self.name)
         grid.addWidget(l, 0, 0)
         grid.addWidget(self.name, 0, 1)
-        
+
         self.autosave = QCheckBox()
         grid.addWidget(self.autosave, 1, 1)
-        
+
         self.basedir = widgets.urlrequester.UrlRequester()
         self.basedirLabel = l = QLabel()
         l.setBuddy(self.basedir)
         grid.addWidget(l, 2, 0)
         grid.addWidget(self.basedir, 2, 1)
-        
+
         self.inclPaths = ip = QGroupBox(self, checkable=True, checked=False)
         ipLayout = QVBoxLayout()
         ip.setLayout(ipLayout)
-        
+
         self.replPaths = QCheckBox()
         ipLayout.addWidget(self.replPaths)
         self.replPaths.toggled.connect(self.toggleReplace)
-        
+
         self.include = widgets.listedit.FilePathEdit()
         self.include.listBox.setDragDropMode(QAbstractItemView.InternalMove)
         ipLayout.addWidget(self.include)
-        
+
         grid.addWidget(ip, 3, 1)
-        
+
         self.revt = QPushButton(self)
         self.clear = QPushButton(self)
         self.revt.clicked.connect(self.revertPaths)
         self.clear.clicked.connect(self.clearPaths)
-       
+
         self.include.layout().addWidget(self.revt, 5, 1)
         self.include.layout().addWidget(self.clear, 6, 1)
-        
+
         layout.addWidget(widgets.Separator())
         self.buttons = b = QDialogButtonBox(self)
         layout.addWidget(b)
@@ -255,7 +255,7 @@ class SessionEditor(QDialog):
         b.rejected.connect(self.reject)
         userguide.addButton(b, "sessions")
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.nameLabel.setText(_("Name:"))
         self.autosave.setText(_("Always save the list of documents in this session"))
@@ -267,7 +267,7 @@ class SessionEditor(QDialog):
         self.revt.setToolTip(_("Add and edit the path from LilyPond preferences."))
         self.clear.setText(_("Clear"))
         self.clear.setToolTip(_("Remove all paths."))
-    
+
     def load(self, name):
         settings = sessions.sessionGroup(name)
         self.autosave.setChecked(settings.value("autosave", True, bool))
@@ -279,19 +279,19 @@ class SessionEditor(QDialog):
             self.addDisabledGenPaths()
             self.revt.setEnabled(False)
         # more settings here
-        
+
     def fetchGenPaths(self):
         """Fetch paths from general preferences."""
         return qsettings.get_string_list(QSettings(),
             "lilypond_settings/include_path")
-            
+
     def addDisabledGenPaths(self):
         """Add global paths, but set as disabled."""
         genPaths = self.fetchGenPaths()
         for p in genPaths:
             i = QListWidgetItem(p, self.include.listBox)
             i.setFlags(Qt.NoItemFlags)
-            
+
     def toggleReplace(self):
         """Called when user changes setting for replace of global paths."""
         if self.replPaths.isChecked():
@@ -303,20 +303,20 @@ class SessionEditor(QDialog):
         else:
             self.addDisabledGenPaths()
             self.revt.setEnabled(False)
-            
+
     def revertPaths(self):
         """Add global paths (for edit)."""
         genPaths = self.fetchGenPaths()
         for p in genPaths:
             i = QListWidgetItem(p, self.include.listBox)
-        
+
     def clearPaths(self):
         """Remove all active paths."""
         items = self.include.items()
         for i in items:
             if i.flags() & Qt.ItemIsEnabled:
                 self.include.listBox.takeItem(self.include.listBox.row(i))
-        
+
     def save(self, name):
         settings = sessions.sessionGroup(name)
         settings.setValue("autosave", self.autosave.isChecked())
@@ -326,7 +326,7 @@ class SessionEditor(QDialog):
         path = [i.text() for i in self.include.items() if i.flags() & Qt.ItemIsEnabled]
         settings.setValue("include-path", path)
         # more settings here
-        
+
     def defaults(self):
         self.autosave.setChecked(True)
         self.basedir.setPath('')
@@ -335,7 +335,7 @@ class SessionEditor(QDialog):
         self.addDisabledGenPaths()
         self.revt.setEnabled(False)
         # more defaults here
-        
+
     def edit(self, name=None):
         self._originalName = name
         if name:
@@ -359,10 +359,10 @@ class SessionEditor(QDialog):
     def done(self, result):
         if not result or self.validate():
             super(SessionEditor, self).done(result)
-        
+
     def validate(self):
         """Checks if the input is acceptable.
-        
+
         If this method returns True, the dialog is accepted when OK is clicked.
         Otherwise a messagebox could be displayed, and the dialog will remain
         visible.
@@ -376,13 +376,13 @@ class SessionEditor(QDialog):
             if self._originalName:
                 self.name.setText(self._originalName)
             return False
-        
+
         elif name == '-':
             self.name.setFocus()
             QMessageBox.warning(self, app.caption(_("Warning")),
                 _("Please do not use the name '{name}'.".format(name="-")))
             return False
-        
+
         elif self._originalName != name and name in sessions.sessionNames():
             self.name.setFocus()
             box = QMessageBox(QMessageBox.Warning, app.caption(_("Warning")),
@@ -393,6 +393,6 @@ class SessionEditor(QDialog):
             result = box.exec_()
             if result != QMessageBox.Discard:
                 return False
-            
+
         return True
 

--- a/frescobaldi_app/sessions/manager.py
+++ b/frescobaldi_app/sessions/manager.py
@@ -41,15 +41,15 @@ def get(mainwindow):
 
 class SessionManager(plugin.MainWindowPlugin):
     """Per-MainWindow session manager.
-    
+
     Emits the saveSessionData(name) signal when a session wants to be saved.
     Connect to this if you only want the notification for the current MainWindow
     (the one the user initiated the action from).
-    
+
     Use app.saveSessionData(name) if you want to get the global notification.
-    
+
     """
-    
+
     # This signal is emitted when a session wants to save its data.
     saveSessionData = signals.Signal() # Session name
 
@@ -60,19 +60,19 @@ class SessionManager(plugin.MainWindowPlugin):
         ac.session_save.triggered.connect(self.saveSession)
         ac.session_manage.triggered.connect(self.manageSessions)
         ac.session_none.triggered.connect(self.noSession)
-    
+
     def newSession(self):
         from . import dialog
         name = dialog.SessionEditor(self.mainwindow()).edit()
         if name:
             sessions.setCurrentSession(name)
             self.saveCurrentSession()
-    
+
     def saveSession(self):
         if not sessions.currentSession():
             return self.newSession()
         self.saveCurrentSession()
-        
+
     def manageSessions(self):
         from . import dialog
         dialog.SessionManagerDialog(self.mainwindow()).exec_()
@@ -81,7 +81,7 @@ class SessionManager(plugin.MainWindowPlugin):
         if sessions.currentSession():
             self.saveCurrentSessionIfDesired()
             sessions.setCurrentSession(None)
-    
+
     def startSession(self, name):
         """Switches to the given session."""
         if name == sessions.currentSession():
@@ -92,7 +92,7 @@ class SessionManager(plugin.MainWindowPlugin):
                 self.mainwindow().setCurrentDocument(active)
             else:
                 self.mainwindow().cleanStart()
-        
+
     def saveCurrentSessionIfDesired(self):
         """Saves the current session if it is configured to save itself on exit."""
         cur = sessions.currentSession()
@@ -100,7 +100,7 @@ class SessionManager(plugin.MainWindowPlugin):
             s = sessions.sessionGroup(cur)
             if s.value("autosave", True, bool):
                 self.saveCurrentSession()
-    
+
     def saveCurrentSession(self):
         """Saves the current session."""
         cur = sessions.currentSession()
@@ -119,11 +119,11 @@ class SessionActions(actioncollection.ActionCollection):
         self.session_manage = QAction(parent)
         self.session_none = QAction(parent)
         self.session_none.setCheckable(True)
-        
+
         self.session_new.setIcon(icons.get('document-new'))
         self.session_save.setIcon(icons.get('document-save'))
         self.session_manage.setIcon(icons.get('view-choose'))
-        
+
     def translateUI(self):
         self.session_new.setText(_("New Session", "&New..."))
         self.session_save.setText(_("&Save"))

--- a/frescobaldi_app/sessions/menu.py
+++ b/frescobaldi_app/sessions/menu.py
@@ -49,10 +49,10 @@ class SessionMenu(QMenu):
         self.addAction(ac.session_none)
         self.addSeparator()
         self.aboutToShow.connect(self.populate)
-    
+
     def translateUI(self):
         self.setTitle(_('menu title', '&Session'))
-    
+
     def populate(self):
         ac = manager.get(self.parentWidget()).actionCollection
         ag = self._actionGroup

--- a/frescobaldi_app/sidebar/__init__.py
+++ b/frescobaldi_app/sidebar/__init__.py
@@ -49,25 +49,25 @@ class SideBarManager(plugin.MainWindowPlugin):
         # there is always one ViewSpace, initialize it
         self.manager().loadSettings()
         self.updateActions()
-    
+
     def manager(self, viewspace=None):
         """Returns the ViewSpaceSideBarManager for the (current) ViewSpace."""
         if viewspace is None:
             viewspace  = self.mainwindow().viewManager.activeViewSpace()
         return ViewSpaceSideBarManager.instance(viewspace)
-        
+
     def toggleLineNumbers(self):
         manager = self.manager()
         manager.setLineNumbersVisible(not manager.lineNumbersVisible())
         manager.saveSettings()
-    
+
     def toggleFolding(self):
         """Toggle folding in the current view."""
         viewspace = self.mainwindow().viewManager.activeViewSpace()
         manager = self.manager(viewspace)
         enable = not manager.foldingVisible()
         document = viewspace.document()
-        
+
         # do it for all managers that display our document
         for m in manager.instances():
             if m.viewSpace().document() is document:
@@ -79,35 +79,35 @@ class SideBarManager(plugin.MainWindowPlugin):
         # unfold the document if disabled
         if not enable:
             self.folder().unfold_all()
-    
+
     def folder(self):
         """Get the Folder for the current document."""
         import folding
         return folding.Folder.get(self.mainwindow().currentDocument())
-    
+
     def foldCurrent(self):
         """Fold current region."""
         self.folder().fold(self.mainwindow().textCursor().block())
-    
+
     def foldTop(self):
         """Fold current region to toplevel."""
         self.folder().fold(self.mainwindow().textCursor().block(), -1)
-    
+
     def unfoldCurrent(self):
         """Unfold current region."""
         block = self.mainwindow().textCursor().block()
         folder = self.folder()
         folder.ensure_visible(block)
-        folder.unfold(block)        
-    
+        folder.unfold(block)
+
     def foldAll(self):
         """Fold the whole document."""
         self.folder().fold_all()
-    
+
     def unfoldAll(self):
         """Unfold the whole document."""
         self.folder().unfold_all()
-        
+
     def updateActions(self):
         manager = self.manager()
         ac = self.actionCollection
@@ -119,7 +119,7 @@ class SideBarManager(plugin.MainWindowPlugin):
         ac.folding_unfold_current.setEnabled(folding)
         ac.folding_fold_all.setEnabled(folding)
         ac.folding_unfold_all.setEnabled(folding)
-    
+
     def newViewSpace(self, viewspace):
         viewmanager = viewspace.manager()
         if viewmanager and viewmanager.window() is self.mainwindow():
@@ -136,7 +136,7 @@ class ViewSpaceSideBarManager(plugin.ViewSpacePlugin):
         self._folding = False
         self._foldingarea = None
         viewspace.viewChanged.connect(self.updateView)
-        
+
     def loadSettings(self):
         """Loads the settings from config."""
         s = QSettings()
@@ -145,19 +145,19 @@ class ViewSpaceSideBarManager(plugin.ViewSpacePlugin):
         self.setLineNumbersVisible(line_numbers)
         folding = s.value("folding", self._folding, bool)
         self.setFoldingVisible(folding)
-    
+
     def saveSettings(self):
         """Saves the settings to config."""
         s = QSettings()
         s.beginGroup("sidebar")
         s.setValue("line_numbers", self.lineNumbersVisible())
         s.setValue("folding",self.foldingVisible())
-    
+
     def copySettings(self, other):
         """Takes over the settings from another viewspace's manager."""
         self.setLineNumbersVisible(other.lineNumbersVisible())
         self.setFoldingVisible(other.foldingVisible())
-        
+
     def setLineNumbersVisible(self, visible):
         """Set whether line numbers are to be shown."""
         if visible == self._line_numbers:
@@ -168,24 +168,24 @@ class ViewSpaceSideBarManager(plugin.ViewSpacePlugin):
     def lineNumbersVisible(self):
         """Returns whether line numbers are shown."""
         return self._line_numbers
-    
+
     def setFoldingVisible(self, visible):
         """Set whether folding indicators are to be shown."""
         if visible == self._folding:
             return
         self._folding = visible
         self.updateView()
-    
+
     def foldingVisible(self):
         """Return whether folding indicators are to be shown."""
         return self._folding
-    
+
     def updateView(self):
         """Adjust the sidebar in the current View in the sidebar."""
         view = self.viewSpace().activeView()
         if not view:
             return
-        
+
         def add(widget):
             """Adds a widget to the side of the view."""
             from gadgets import borderlayout
@@ -239,7 +239,7 @@ class Actions(actioncollection.ActionCollection):
         self.folding_unfold_current = QAction(parent)
         self.folding_fold_all = QAction(parent)
         self.folding_unfold_all = QAction(parent)
-        
+
     def translateUI(self):
         self.view_linenumbers.setText(_("&Line Numbers"))
         self.folding_enable.setText(_("&Enable Folding"))

--- a/frescobaldi_app/signals.py
+++ b/frescobaldi_app/signals.py
@@ -48,58 +48,58 @@ __all__ = ["Signal", "SignalContext"]
 
 class Signal(object):
     """A Signal can be emitted and receivers (slots) can be connected to it.
-    
+
     An example:
-    
+
     class MyObject(object):
-    
+
         somethingChanged = Signal()
-        
+
         def __init__(self):
             pass # etc
-            
+
         def doSomething(self):
             ... do things ...
             self.somethingChanged("Hi there!")     # emit the signal
-    
+
     def receiver(arg):
         print("Received message:", arg)
-    
-    
+
+
     >>> o = MyObject()
     >>> o.somethingChanged.connect(receiver)
     >>> o.doSomething()
     Received message: Hi there!
-    
+
     A Signal() can be used directly or as a class attribute, but can also be
     accessed as an attribute of an instance, in which case it creates a Signal
     instance for that instance.
 
     The signal is emitted by the emit() method or by simply invoking it.
-    
+
     It is currently not possible to enforce argument types that should be used
     when emitting the signal. But if called methods or functions expect fewer
     arguments than were given on emit(), the superfluous arguments are left out.
-    
+
     Methods or functions are connected using connect() and disconnected using
     disconnect(). It is no problem to call connect() or disconnect() more than
     once for the same function or method. Only one connection to the same method
     or function can exist.
-    
+
     """
-    
+
     def __init__(self, owner=None):
         """Creates the Signal.
-        
+
         If owner is given (must be a keyword argument) a weak reference to it is
         kept, and this allows a Signal to be connected to another Signal. When
         the owner dies, the connection is removed.
-        
+
         """
         self.listeners = []
         self._blocked = False
         self._owner = weakref.ref(owner) if owner else lambda: None
-        
+
     def __get__(self, instance, cls):
         """Called when accessing as a descriptor: returns another instance."""
         if instance is None:
@@ -112,67 +112,67 @@ class Signal(object):
             pass
         ret = self._instances[instance] = type(self)(owner=instance)
         return ret
-    
+
     def owner(self):
         """Returns the owner of this Signal, if any."""
         return self._owner()
-        
+
     def connect(self, slot, priority=0, owner=None):
         """Connects a method or function ('slot') to this Signal.
-        
+
         The priority argument determines the order the connected slots are
         called. A lower value calls the slot earlier.
         If owner is given, the connection will be removed if owner is garbage
         collected.
-        
+
         A slot that is already connected will not be connected twice.
-        
+
         If slot is an instance method (bound method), the Signal keeps no
         reference to the object the method belongs to. So if the object is
         garbage collected, the signal is automatically disconnected.
-        
+
         If slot is a (normal or lambda) function, the Signal will keep a
         reference to the function. If you want to have the function disconnected
         automatically when some object dies, you should provide that object
         through the owner argument. Be sure that the connected function does not
         keep a reference to that object in that case!
-        
+
         """
         key = self.makeListener(slot, owner)
         if key not in self.listeners:
             key.add(self, priority)
-            
+
     def disconnect(self, func):
         """Disconnects the method or function.
-        
+
         No exception is raised if there wasn't a connection.
-        
+
         """
         key = self.makeListener(func)
         try:
             self.listeners.remove(key)
         except ValueError:
             pass
-    
+
     def clear(self):
         """Removes all connected slots."""
         del self.listeners[:]
-    
+
     @contextlib.contextmanager
     def blocked(self):
         """Returns a contextmanager that suppresses the signal.
-        
+
         An example (continued from the class documentation):
-        
+
         >>> o = MyObject()
         >>> o.somethingChanged.connect(receiver)
         >>> with o.somethingChanged.blocked():
         ...     o.doSomething()
         (no output)
-        
+
         The doSomething() method will emit the signal but the connected slots
         will not be called.
-        
+
         """
         blocked, self._blocked = self._blocked, True
         try:
@@ -182,14 +182,14 @@ class Signal(object):
 
     def emit(self, *args, **kwargs):
         """Emits the signal.
-        
+
         Unless blocked, all slots will be called with the supplied arguments.
-        
+
         """
         if not self._blocked:
             for l in self.listeners[:]:
                 l.call(args, kwargs)
-    
+
     __call__ = emit
 
     def makeListener(self, func, owner=None):
@@ -205,18 +205,18 @@ class Signal(object):
 class SignalContext(Signal):
     """A Signal variant where the connected methods or functions should return
     a context manager.
-    
+
     You should use the SignalContext itself also as a context manager, e.g.:
-    
+
     sig = signals.SignalContext()
-    
+
     with sig(args):
         do_something()
-    
+
     This will first call all the connected methods or functions, and then
     enter all the returned context managers. When the context ends,
     all context managers will be exited.
-    
+
     """
     def emit(self, *args, **kwargs):
         if self._blocked:
@@ -224,7 +224,7 @@ class SignalContext(Signal):
         else:
             managers = [l.call(args, kwargs) for l in self.listeners]
         return self.signalcontextmanager(managers)
-    
+
     __call__ = emit
 
     @contextlib.contextmanager
@@ -262,7 +262,7 @@ class ListenerBase(object):
 
     def __lt__(self, other):
         return self.priority < other.priority
-    
+
     def add(self, signal, priority):
         self.priority = priority
         bisect.insort_right(signal.listeners, self)
@@ -272,7 +272,7 @@ class ListenerBase(object):
                 if self and signal:
                     signal.listeners.remove(self)
             self.obj = weakref.ref(self.obj, remove)
-        
+
         # determine the number of arguments allowed
         end = None
         try:
@@ -315,5 +315,5 @@ class FunctionListener(ListenerBase):
 
     def call(self, args, kwargs):
         return self.func(*args[self.argslice], **kwargs)
-        
+
 

--- a/frescobaldi_app/simplemarkdown.py
+++ b/frescobaldi_app/simplemarkdown.py
@@ -37,7 +37,7 @@ plain text paragraph
 1. ordered list
 
   * nested lists are possible
-  
+
     a paragraph without bullet item
 
 * compact item list
@@ -76,11 +76,11 @@ def chop_left(string, chars=None):
 
 def find_first(string, chars, start=0, end=None):
     """Return a tuple (char, pos) for the first occurrence of any of the chars.
-    
+
     If char is None, then pos is undefined and it means there is no occurrence.
     The start and end arguments can be used as in "".find, to restrict the
     search to a certain part of the string.
-    
+
     """
     pos = end
     char = None
@@ -106,9 +106,9 @@ def iter_split(text, separator):
 
 def iter_split2(text, separator, separator2):
     """Yield pairs of text outside and inside the separators.
-    
+
     This can be used to parse e.g. "text with [bracketed words] in it".
-    
+
     """
     while True:
         t = text.split(separator, 1)
@@ -131,9 +131,9 @@ def html(text):
 
 def html_inline(text):
     """Convenience function converting markdown text to HTML.
-    
+
     Only inline text is parsed, i.e. links, emphasized, code.
-    
+
     """
     p = Parser()
     o = p.output = HtmlOutput()
@@ -154,52 +154,52 @@ def tree(text):
 
 class Parser(object):
     """A basic Markdown-like parser.
-    
+
     Usage:
-    
+
     p = simplemarkdown.Parser()
     o = simplemarkdown.HtmlOutput() # or a different Output subclass instance
     text = "some markdown-formatted text"
     p.parse(text, o)
     o.html()
-    
+
     You can also set an Output instance directly and use other parsing methods:
-    
+
     p = simplemarkdown.Parser()
     p.output = simplemarkdown.HtmlOutput()
     p.parse_inline_text('text with *emphasized* words')
     p.output.html()
-    
+
     While parsing, the linenumber is available in the lineno attribute.
     The default implementation sets the line number on every call to
     parse_inline_lines.
-    
+
     """
     def __init__(self):
         self._lists = []
         self.output = Output()
         self.lineno = 1
-    
+
     ##
     # block level parsing
     ##
-    
+
     def parse(self, text, output=None, lineno=None):
         """Parse the text.
-        
+
         Calls the push and pop methods on the output object, if specified.
         The lineno, if given, sets the lineno attribute for the current line.
-        
+
         """
         self.parse_lines(text.splitlines(), output, lineno)
-    
+
     def parse_lines(self, lines, output=None, lineno=None):
         """Parse text line by line.
-        
+
         The lines may be a generator.
         Calls the push and pop methods on the output object, if specified.
         The lineno, if given, sets the lineno attribute for the current line.
-        
+
         """
         if output is not None:
             self.output = output
@@ -232,12 +232,12 @@ class Parser(object):
                 para.append(line)
         if para:
             self.parse_paragraph(para)
-    
+
     def parse_paragraph(self, lines):
         """Parse a list of one or more lines without blank lines in between.
-        
+
         Dispatches the lines to handle headings, lists or plain text paragraphs.
-        
+
         """
         indent = len(chop_left(lines[0]))
         if lines[0].lstrip().startswith('='):
@@ -256,20 +256,20 @@ class Parser(object):
             self.handle_lists(indent)
             with self.output('paragraph'):
                 self.parse_inline_lines(lines)
-    
+
     def special_paragraph(self, lines):
         """Called when a paragraph is not a heading or a list item.
-        
+
         If this method returns True, it is assumed to have handled the contents.
         This can be used to extend the paragraph-level parser to understand more
         types of paragraphs.
-        
+
         The default implementation does nothing and returns None, which causes
         the lines to be assumed to be a normal paragraph.
-        
+
         """
         pass
-    
+
     def is_ul_item(self, line):
         """Return True if the line is a unordered list prefix ("*")."""
         try:
@@ -285,11 +285,11 @@ class Parser(object):
             return prefix.endswith('.') and prefix[:-1].isdigit()
         except ValueError:
             return False
-    
+
     def is_dl_item(self, lines):
         """Return True lines are a description list item."""
         return len(lines) > 1 and lines[1].lstrip().startswith(': ')
-    
+
     def parse_heading(self, lines):
         """Parse a header text."""
         prefix = chop_left(lines[0], '= ')
@@ -297,14 +297,14 @@ class Parser(object):
         lines[0] = lines[0].strip('= ')
         with self.output('heading', heading_type):
             self.parse_inline_lines(lines)
-    
+
     def parse_ol(self, lines):
         """Parse ordered lists.
-        
+
         Every line of the supplied group of lines is checked for a number,
         if they are separate items, no paragraph tags are put around the list
         items.
-        
+
         """
         # split in list items
         items = self.split_list_items(lines, self.is_ol_item)
@@ -316,14 +316,14 @@ class Parser(object):
                         self.parse_inline_lines(item)
                 else:
                     self.parse_inline_lines(item)
-            
+
     def parse_ul(self, lines):
         """Parse unordered lists.
-        
+
         Every line of the supplied group of lines is checked for an asterisk,
         if they are separate items, no paragraph tags are put around the list
         items.
-        
+
         """
         items = self.split_list_items(lines, self.is_ul_item)
         paragraph_item = len(items) == 1
@@ -334,12 +334,12 @@ class Parser(object):
                         self.parse_inline_lines(item)
                 else:
                     self.parse_inline_lines(item)
-    
+
     def split_list_items(self, lines, pred):
         """Returns lists of lines that each represent a list item.
-        
+
         The pred function should return true for a line that has an item prefix.
-        
+
         """
         items = []
         item = []
@@ -353,7 +353,7 @@ class Parser(object):
         if item:
             items.append(item)
         return items
-        
+
     def parse_dl(self, lines):
         """Parse a definition list item."""
         definition = lines[0]
@@ -363,13 +363,13 @@ class Parser(object):
                 self.parse_inline_lines([definition])
             with self.output('definitionlist_item_definition'):
                 self.parse_inline_lines(lines[1:])
-    
+
     def handle_lists(self, indent, list_type=None):
         """Close ongoing lists or start new lists if needed.
-        
+
         If given, list_type should be 'orderedlist', 'unorderedlist', or
         'definitionlist'.
-        
+
         """
         if list_type and (not self._lists or self._lists[-1][1] < indent):
             self._lists.append((list_type, indent))
@@ -387,22 +387,22 @@ class Parser(object):
                         self._lists.append((list_type, indent))
                         self.output.push(list_type)
                 break
-            
+
     ##
     # inline level parsing
     ##
-    
+
     def parse_inline_lines(self, lines):
         """Parse plain text lines with possibly inline markup.
-        
+
         This implementation strip()s the lines, joins them with a newline
         and calls parse_inline_text() with the text string.
-        
+
         """
         lineno = self.lineno
         self.parse_inline_text('\n'.join(line.strip() for line in lines))
         self.lineno = lineno + len(lines)
-        
+
     def parse_inline_text(self, text):
         """Parse a continuous text block with possibly inline markup."""
         with self.output('inline'):
@@ -452,7 +452,7 @@ class Parser(object):
             while nest:
                 nest.pop()
                 self.output.pop()
-    
+
     def output_inline_text(self, text):
         """Append an 'inline_text' to the output."""
         self.output.append('inline_text', text)
@@ -460,9 +460,9 @@ class Parser(object):
 
 class Output(object):
     """Base class for output handler objects.
-    
+
     You should inherit from this class and implement the push() and pop() methods.
-    
+
     """
     @contextlib.contextmanager
     def __call__(self, name, *args):
@@ -472,16 +472,16 @@ class Output(object):
             yield
         finally:
             self.pop()
-    
+
     def append(self, name, *args):
         """Append a new node to the current node."""
         self.push(name, *args)
         self.pop()
-    
+
     def push(self, name, *args):
         """Append a new node to the current node and make it current."""
         pass
-    
+
     def pop(self):
         """Make the current node's parent the current node."""
         pass
@@ -489,7 +489,7 @@ class Output(object):
 
 class Tree(Output):
     """An Output that represents the tree structure of the parsed text."""
-    
+
     class Node(list):
         def __new__(cls, name, *args):
             n = list.__new__(cls)
@@ -499,38 +499,38 @@ class Tree(Output):
 
         def __init__(self, name, *args):
             list.__init__(self)
-        
+
         def __bool__(self):
             return True
-        
+
         def __repr__(self):
             return '<Node "{0}" {1} [{2}]>'.format(self.name, self.args, len(self))
 
         def __str__(self):
             return "{0} {1}".format(self.name, self.args)
-    
-    
+
+
     def __init__(self):
         self._root = self.Node('root')
         self._cursor = [self._root]
-    
+
     # build the tree
     def push(self, name, *args):
         """Append a Node to the current node, and make that the current Node."""
         node = self.Node(name, *args)
         self._cursor[-1].append(node)
         self._cursor.append(node)
-    
+
     def pop(self):
         """End the current Node and go back to the parent node."""
         if len(self._cursor) > 1:
             self._cursor.pop()
-    
+
     # query the tree
     def root(self):
         """Return the root (which is a plain Python list)."""
         return self._root
-    
+
     def dump(self, node=None, indent_start=0, indent_string='  '):
         """Show the node or the entire tree in a pretty-printed string."""
         def dump(n, indent):
@@ -543,9 +543,9 @@ class Tree(Output):
 
     def copy(self, output, node=None):
         """Copy the tree to the other output instance.
-        
+
         If node is not specified, the entire tree is copied.
-        
+
         """
         if node in (None, self._root):
             for n in self._root:
@@ -554,14 +554,14 @@ class Tree(Output):
             with output(node.name, *node.args):
                 for n in node:
                     self.copy(output, n)
-    
+
     def find(self, path, node=None):
         """Iter over the elements described by path.
-        
+
         Currently this just yields all elements with the specified name.
-        
+
         If node is not given, the entire tree is searched.
-        
+
         """
         if node is None:
             node = self._root
@@ -570,13 +570,13 @@ class Tree(Output):
                 yield n
             for n1 in self.find(path, n):
                 yield n1
-    
+
     def iter_tree(self, node=None):
         """Iter over all elements of the tree.
-        
+
         Every 'yield' is a list from the node's child up to the element itself.
         If node is not given, the root node is used.
-        
+
         """
         def iter_tree(node, cursor=[]):
             for n in node:
@@ -585,15 +585,15 @@ class Tree(Output):
                 for l in iter_tree(n, l):
                     yield l
         return iter_tree(node or self._root)
-    
+
     def iter_tree_find(self, path, node=None):
         """Iter over the elements described by path.
-        
+
         Currently this just yields all elements with the specified name.
         Every 'yield' is a list from the node's child up to the element itself.
-        
+
         If node is not given, the entire tree is searched.
-        
+
         """
         def iter_tree_find(node, cursor=[]):
             for n in node:
@@ -603,22 +603,22 @@ class Tree(Output):
                 for l in iter_tree_find(n, l):
                     yield l
         return iter_tree_find(node or self._root)
-    
+
     def text(self, node):
         """Convenience method to return plain text from the specified node.
-        
+
         This method concatenates all text, so it is only useful on inline parts
         of a document.
-        
+
         """
         return ''.join(e.args[0] for e in self.find('inline_text', node))
-        
+
     def html(self, node=None):
         """Convenience method to return HTML text from the specified node.
-        
+
         If node is not given, the entire document is returned as HTML text.
         This method uses the HtmlOutput class to create the HTML text.
-        
+
         """
         o = HtmlOutput()
         self.copy(o, node)
@@ -627,38 +627,38 @@ class Tree(Output):
 
 class HtmlOutput(Output):
     """Converts output to HTML.
-    
+
     A heading type 1 gets converted to H1 by default, but you can set the
     heading_offset attribute to a value > 0 to make heading 1 output H2,
     heading 2 -> H3 etc.
-    
+
     """
     heading_offset = 0
-    
+
     def __init__(self):
         self._html = []
         self._tags = []
-    
+
     def push(self, name, *args):
         getattr(self, name + '_start')(*args)
         self._tags.append((name, args))
-        
+
     def pop(self):
         name, args = self._tags.pop()
         getattr(self, name + '_end')(*args)
-        
+
     def html(self):
         return ''.join(self._html)
-    
+
     def html_escape(self, text):
         """Escapes &, < and >."""
         return html_escape(text)
-    
+
     def tag(self, name, attrs=None):
         """Add a tag. Use a name like '/p' to write a close tag.
-        
+
         attrs may be a dictionary of attributes.
-        
+
         """
         if attrs:
             a = ''.join(' {0}="{1}"'.format(
@@ -667,14 +667,14 @@ class HtmlOutput(Output):
         else:
             a = ''
         self._html.append('<{0}{1}>'.format(name, a))
-    
+
     def nl(self):
         """Add a newline."""
         self._html.append('\n')
-    
+
     def text(self, text):
         self._html.append(self.html_escape(text))
-    
+
     ##
     # block level handlers
     ##
@@ -683,54 +683,54 @@ class HtmlOutput(Output):
         self.tag('code')
         self.tag('pre')
         self.text(code)
-    
+
     def code_end(self, code, specifier=None):
         self.tag('/pre')
         self.tag('/code')
         self.nl()
-    
+
     def heading_start(self, heading_type):
         h = min(self.heading_offset + heading_type, 6)
         self.tag('h{0}'.format(h))
-    
+
     def heading_end(self, heading_type):
         h = min(self.heading_offset + heading_type, 6)
         self.tag('/h{0}'.format(h))
         self.nl()
-        
+
     def paragraph_start(self):
         if self._tags and self._tags[-1][0] == "definitionlist":
             self.tag('dd')
         self.tag('p')
-    
+
     def paragraph_end(self):
         self.tag('/p')
         if self._tags and self._tags[-1][0] == "definitionlist":
             self.tag('/dd')
         self.nl()
-    
+
     def orderedlist_start(self):
         self.tag('ol')
         self.nl()
-    
+
     def orderedlist_item_start(self):
         self.tag('li')
-    
+
     def orderedlist_item_end(self):
         self.tag('/li')
         self.nl()
-    
+
     def orderedlist_end(self):
         self.tag('/ol')
         self.nl()
-    
+
     def unorderedlist_start(self):
         self.tag('ul')
         self.nl()
-    
+
     def unorderedlist_item_start(self):
         self.tag('li')
-    
+
     def unorderedlist_item_end(self):
         self.tag('/li')
         self.nl()
@@ -738,31 +738,31 @@ class HtmlOutput(Output):
     def unorderedlist_end(self):
         self.tag('/ul')
         self.nl()
-    
+
     def definitionlist_start(self):
         self.tag('dl')
         self.nl()
-        
+
     def definitionlist_item_term_start(self):
         self.tag('dt')
-        
+
     def definitionlist_item_term_end(self):
         self.tag('/dt')
         self.nl()
-        
+
     def definitionlist_item_definition_start(self):
         self.tag('dd')
-        
+
     def definitionlist_item_definition_end(self):
         self.tag('/dd')
         self.nl()
-        
+
     def definitionlist_item_start(self):
         pass
-        
+
     def definitionlist_item_end(self):
         pass
-        
+
     def definitionlist_end(self):
         self.tag('/dl')
         self.nl()
@@ -774,29 +774,29 @@ class HtmlOutput(Output):
     def inline_start(self):
         """Called when a block of inline text is parsed."""
         pass
-        
+
     def inline_end(self):
-        """Called at the end of parsing a block of inline text.""" 
+        """Called at the end of parsing a block of inline text."""
         pass
-    
+
     def inline_code_start(self):
         self.tag('code')
-    
+
     def inline_code_end(self):
         self.tag('/code')
-    
+
     def inline_emphasis_start(self):
         self.tag('em')
-    
+
     def inline_emphasis_end(self):
         self.tag('/em')
-    
+
     def link_start(self, url):
         self.tag('a', {'href': url})
-    
+
     def link_end(self, url):
         self.tag('/a')
-    
+
     def inline_text_start(self, text):
         self.text(text)
 

--- a/frescobaldi_app/simplestate.py
+++ b/frescobaldi_app/simplestate.py
@@ -47,7 +47,7 @@ def state(state):
     def append(name):
         if not names or names[-1] != name:
             names.append(name)
-    
+
     for p in state.state:
         name = parserClasses.get(p.__class__)
         if name:
@@ -59,9 +59,9 @@ def state(state):
                 if isinstance(p, c):
                     append(name)
                     break
-    
+
     return names
-    
+
 
 parserClasses = {
     # lilypond
@@ -84,11 +84,11 @@ parserClasses = {
     ly.lex.lilypond.ParseMarkup: "markup",
     ly.lex.lilypond.ParseOverride: "override",
     ly.lex.lilypond.ParseString: "string",
-    
+
     # scheme
     ly.lex.scheme.ParseScheme: "scheme",
     ly.lex.scheme.ParseString: "string",
-    
+
     # html
     ly.lex.html.ParseAttr: "htmlattribute",
     ly.lex.html.ParseStringSQ: "single-quoted-string",
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     @lilypond
     \relative c' {
       c d e-\markup {
-      
+
     """
     s = ly.lex.guessState(text)
     list(s.tokens(text))

--- a/frescobaldi_app/snippet/builtin.py
+++ b/frescobaldi_app/snippet/builtin.py
@@ -263,7 +263,7 @@ r"""-*- menu: blocks; name: repunf; selection: strip;
 'relative': T(_("Relative Music"),
 r"""-*- name: rel;
 \relative c$CURSOR'$ANCHOR {
-""" '   $SELECTION' r"""  
+""" '   $SELECTION' r"""
 }"""),
 
 
@@ -473,7 +473,7 @@ def main():
             break
     else:
         s = 'lilypond'
-    
+
     def html(text):
         if text:
             text = text.replace('<!-- ', '')
@@ -481,7 +481,7 @@ def main():
             text = text.replace('<!--', '')
             text = text.replace('-->', '')
             return text
-    
+
     def lilypond(text):
         if text.lstrip().startswith('%{'):
             if text.lstrip().startswith('%{ '):
@@ -496,10 +496,10 @@ def main():
                 text = cursor.selection().toPlainText()
             text = re.compile(r'^(\s*)%+ ?', re.M).sub(r'\1', text)
         return text
-    
+
     def scheme(text):
         return re.compile(r'^(\s*);+', re.M).sub(r'\1', text)
-    
+
     if s == 'lilypond':
         text = lilypond(text)
     elif s == 'html':
@@ -547,7 +547,7 @@ if dlg.exec_():
 
 'last_note': T(_("Last note or chord"),
 r"""-*- python; menu: music; symbol: note_ellipsis;
-# This snippet reads back the last entered note or chord and 
+# This snippet reads back the last entered note or chord and
 # inserts it again. It removes the octave mark from a note of the first
 # note of a chord if the music is in relative mode.
 
@@ -669,7 +669,7 @@ global = {
 chordNames = \chordmode {
   \global
   c1
-  
+
 }
 
 melody = \relative c'' {
@@ -679,8 +679,8 @@ melody = \relative c'' {
 }
 
 words = \lyricmode {
-  
-  
+
+
 }
 
 \score {
@@ -713,43 +713,43 @@ global = {
 soprano = \relative c'' {
   \global
   $CURSORc4
-  
+
 }
 
 alto = \relative c' {
   \global
   c4
-  
+
 }
 
 tenor = \relative c' {
   \global
   c4
-  
+
 }
 
 bass = \relative c {
   \global
   c4
-  
+
 }
 
 verseOne = \lyricmode {
   \set stanza = "1."
   hi
-  
+
 }
 
 verseTwo = \lyricmode {
   \set stanza = "2."
   ha
-  
+
 }
 
 verseThree = \lyricmode {
   \set stanza = "3."
   ho
-  
+
 }
 
 \score {

--- a/frescobaldi_app/snippet/completer.py
+++ b/frescobaldi_app/snippet/completer.py
@@ -41,22 +41,22 @@ class Completer(widgets.completer.Completer):
         self.setParent(textedit) # otherwise PyQt5 loses us
         app.settingsChanged.connect(self.readSettings)
         self.readSettings()
-    
+
     def readSettings(self):
         self.popup().setFont(textformats.formatData('editor').font)
         self.popup().setPalette(textformats.formatData('editor').palette())
- 
+
     def completionCursor(self):
         cursor = self.textCursor()
-        
+
         if self.popup().isVisible() and self._pos < cursor.position():
             cursor.setPosition(self._pos, cursor.KeepAnchor)
             return cursor
-        
+
         # alter the model
         pos = cursor.position()
         text = cursor.document().toPlainText()
-        
+
         # skip '-*- ' lines declaring variables, and check if it is python
         python = False
         block = cursor.document().firstBlock()
@@ -70,7 +70,7 @@ class Completer(widgets.completer.Completer):
             if not block.isValid():
                 break
             start = block.position()
-        
+
         # determine the word set to complete on
         if python:
             pattern = r'\w+'

--- a/frescobaldi_app/snippet/edit.py
+++ b/frescobaldi_app/snippet/edit.py
@@ -53,42 +53,42 @@ from . import completer
 
 class Edit(QDialog):
     """Dialog for editing a snippet. It is used for one edit.
-    
+
     Use None as the name to create a new snippet. In that case, text
     is set as a default in the text edit.
-    
+
     """
     def __init__(self, widget, name, text=""):
         super(Edit, self).__init__(widget)
-        
+
         self._name = name
 
         layout = QVBoxLayout()
         self.setLayout(layout)
-        
+
         self.topLabel = QLabel()
         self.text = QTextEdit(cursorWidth=2, acceptRichText=False)
         self.titleLabel = QLabel()
         self.titleEntry = QLineEdit()
         self.shortcutLabel = QLabel()
         self.shortcutButton = ShortcutButton(clicked=self.editShortcuts)
-        
+
         layout.addWidget(self.topLabel)
         layout.addWidget(self.text)
-        
+
         grid = QGridLayout()
         layout.addLayout(grid)
-        
+
         grid.addWidget(self.titleLabel, 0, 0)
         grid.addWidget(self.titleEntry, 0, 1)
         grid.addWidget(self.shortcutLabel, 1, 0)
         grid.addWidget(self.shortcutButton, 1, 1)
-        
+
         layout.addWidget(widgets.Separator())
-        
+
         b = QDialogButtonBox(accepted=self.accept, rejected=self.reject)
         layout.addWidget(b)
-        
+
         buttons = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         if name and name in builtin.builtin_snippets:
             b.setStandardButtons(buttons | QDialogButtonBox.RestoreDefaults)
@@ -96,7 +96,7 @@ class Edit(QDialog):
         else:
             b.setStandardButtons(buttons)
         userguide.addButton(b, "snippet_editor")
-        
+
         # PyQt5.10 en sip4.14.5 delete the Highlighter, even though it is
         # constructed with a parent, that's why we save it in an unused attribute.
         self._highlighter = highlight.Highlighter(self.text.document())
@@ -105,7 +105,7 @@ class Edit(QDialog):
         self.text.installEventFilter(cursorkeys.handler)
         wordboundary.handler.install_textedit(self.text)
         completer.Completer(self.text)
-        
+
         if name:
             self.titleEntry.setText(snippets.title(name, False) or '')
             self.text.setPlainText(snippets.text(name))
@@ -114,14 +114,14 @@ class Edit(QDialog):
         else:
             self.text.setPlainText(text)
             self.setShortcuts(None)
-        
+
         app.translateUI(self)
-        
+
         self.readSettings()
         app.settingsChanged.connect(self.readSettings)
         qutil.saveDialogSize(self, "snippettool/editor/size", QSize(400, 300))
         self.show()
-        
+
     def translateUI(self):
         title = _("Edit Snippet") if self._name else _("New Snippet")
         self.setWindowTitle(app.caption(title))
@@ -129,7 +129,7 @@ class Edit(QDialog):
         self.titleLabel.setText(_("Title:"))
         self.shortcutLabel.setText(_("Shortcut:"))
         self.shortcutButton.updateText()
-    
+
     def done(self, result):
         if result:
             if not self.text.toPlainText():
@@ -156,10 +156,10 @@ class Edit(QDialog):
 
     def shortcuts(self):
         return self.shortcutButton.shortcuts()
-    
+
     def setShortcuts(self, shortcuts):
         self.shortcutButton.setShortcuts(shortcuts)
-        
+
     def editShortcuts(self):
         from widgets import shortcuteditdialog
         ac = self.parent().parent().snippetActions
@@ -173,14 +173,14 @@ class Edit(QDialog):
             default = None
             text = self.titleEntry.text() or _("Untitled")
         action.setText(text.replace('&', '&&'))
-        
+
         cb = self.actionManager().findShortcutConflict
         skip = (self.parent().parent().snippetActions, self._name)
         dlg = shortcuteditdialog.ShortcutEditDialog(self, cb, skip)
-        
+
         if dlg.editAction(action, default):
             self.setShortcuts(action.shortcuts())
-    
+
     def saveSnippet(self):
         index = model.model().saveSnippet(self._name,
             self.text.toPlainText(), self.titleEntry.text())
@@ -211,14 +211,14 @@ class ShortcutButton(QPushButton):
         super(ShortcutButton, self).__init__(**args)
         self.setIcon(icons.get("preferences-desktop-keyboard-shortcuts"))
         self._shortcuts = []
-        
+
     def shortcuts(self):
         return self._shortcuts
-    
+
     def setShortcuts(self, shortcuts):
         self._shortcuts = shortcuts or []
         self.updateText()
-        
+
     def updateText(self):
         if not self._shortcuts:
             self.setText(_("None"))
@@ -235,7 +235,7 @@ class Matcher(gadgets.matcher.Matcher):
         super(Matcher, self).__init__(edit)
         self.readSettings()
         app.settingsChanged.connect(self.readSettings)
-    
+
     def readSettings(self):
         self.format = QTextCharFormat()
         self.format.setBackground(textformats.formatData('editor').baseColors['match'])

--- a/frescobaldi_app/snippet/expand.py
+++ b/frescobaldi_app/snippet/expand.py
@@ -18,7 +18,7 @@
 # See http://www.gnu.org/licenses/ for more information.
 
 """
-Expand variables like $DATE, $LILYPOND_VERSION etc. in snippets. 
+Expand variables like $DATE, $LILYPOND_VERSION etc. in snippets.
 """
 
 
@@ -31,29 +31,29 @@ import lilypondinfo
 
 def _(docstring):
     """Returns a decorator.
-    
+
     The decorator gives a function a doc() method, returning the translated docstring.
     The untranslated docstring will be added as __doc__ to the function.
-    
+
     builtins._ is expected to be the translation function.
-    
+
     We use the underscore as function name so xgettext picks up the strings
     to be translated.
-    
+
     """
     def deco(f):
         f.__doc__ = docstring
         f.doc = lambda: builtins._(docstring)
         return f
     return deco
-    
+
 
 def documentation(cls):
     """Yields tuples documenting the methods of the specified class.
-    
+
     The tuples are: (function_name, docstring). The docstrings are translated.
     The tuples are sorted on function_name.
-    
+
     """
     for name, meth in sorted(cls.__dict__.items()):
         if name.startswith('_'):
@@ -65,13 +65,13 @@ ANCHOR, CURSOR, SELECTION = constants = 1, 2, 3 # just some constants
 
 class Expander(object):
     """Expands variables.
-    
+
     The methods return text or other events (currently simply integer constants).
-    
+
     """
     def __init__(self, cursor):
         self.cursor = cursor
-    
+
     @_("The current date in YYYY-MM-DD format.")
     def DATE(self):
         return time.strftime('%Y-%m-%d')
@@ -83,15 +83,15 @@ class Expander(object):
     @_("The version of Frescobaldi.")
     def FRESCOBALDI_VERSION(self):
         return appinfo.version
-    
+
     @_("The URL of the current document.")
     def URL(self):
         return self.cursor.document().url().toString()
-    
+
     @_("The full local filename of the current document.")
     def FILE_NAME(self):
         return self.cursor.document().url().toLocalFile()
-    
+
     @_("The name of the current document.")
     def DOCUMENT_NAME(self):
         return self.cursor.document().documentName()
@@ -99,11 +99,11 @@ class Expander(object):
     @_("Moves the text cursor here after insert.")
     def CURSOR(self):
         return CURSOR
-        
+
     @_("Selects text from here to the position given using the <code>$CURSOR</code> variable")
     def ANCHOR(self):
         return ANCHOR
-    
+
     @_("The selected text if available. If not, the text cursor is moved here.")
     def SELECTION(self):
         return SELECTION if self.cursor.hasSelection() else CURSOR

--- a/frescobaldi_app/snippet/highlight.py
+++ b/frescobaldi_app/snippet/highlight.py
@@ -35,32 +35,32 @@ from . import snippets
 
 
 class Highlighter(QSyntaxHighlighter):
-    
+
     def __init__(self, document):
         super(Highlighter, self).__init__(document)
         self.python = None
         self._fridge = slexer.Fridge()
         self.readSettings()
         app.settingsChanged.connect(self.readSettingsAgain)
-        
+
     def readSettings(self):
         self._styles = textformats.formatData('editor').defaultStyles
-        
+
     def readSettingsAgain(self):
         self.readSettings()
         self.rehighlight()
-        
+
     def setPython(self, python):
         """Force Python or generic snippet highlighting.
-        
+
         Use True for Python, False for Snippet, or None to let the highlighter
         decide based on the variable lines.
-        
+
         """
         if self.python is not python:
             self.python = python
             self.rehighlight()
-    
+
     def highlightBlock(self, text):
         prev = self.previousBlockState()
         python = self.python if self.python is not None else prev == -2
@@ -125,7 +125,7 @@ class StringEscape(Escape):
 
 class Expansion(Escape):
     rx = snippets._expansions_re.pattern
-    
+
 # Python types:
 
 class PyKeyword(Keyword):

--- a/frescobaldi_app/snippet/import_export.py
+++ b/frescobaldi_app/snippet/import_export.py
@@ -50,21 +50,21 @@ def save(names, filename):
     root.text = '\n\n'
     root.tail = '\n'
     d = ET.ElementTree(root)
-    
+
     comment = ET.Comment(_comment.format(appinfo=appinfo))
     comment.tail = '\n\n'
     root.append(comment)
-    
+
     for name in names:
         snippet = ET.Element('snippet')
         snippet.set('id', name)
         snippet.text = '\n'
         snippet.tail = '\n\n'
-        
+
         title = ET.Element('title')
         title.text = snippets.title(name, False)
         title.tail = '\n'
-        
+
         shortcuts = ET.Element('shortcuts')
         ss = model.shortcuts(name)
         if ss:
@@ -75,11 +75,11 @@ def save(names, filename):
                 shortcut.tail = '\n'
                 shortcuts.append(shortcut)
         shortcuts.tail = '\n'
-        
+
         body = ET.Element('body')
         body.text = snippets.text(name)
         body.tail = '\n'
-        
+
         snippet.append(title)
         snippet.append(shortcuts)
         snippet.append(body)
@@ -89,12 +89,12 @@ def save(names, filename):
 
 def load(filename, widget):
     """Loads snippets from a file, displaying them in a list.
-    
+
     The user can then choose:
     - overwrite builtin snippets or not
     - overwrite own snippets with same title or not
     - select and view snippets contents.
-    
+
     """
     try:
         d = ET.parse(filename)
@@ -114,42 +114,42 @@ def load(filename, widget):
     tree = QTreeWidget(headerHidden=True, rootIsDecorated=False)
     dlg.setMainWidget(tree)
     userguide.addButton(dlg.buttonBox(), "snippet_import_export")
-    
+
     allnames = frozenset(snippets.names())
     builtins = frozenset(builtin.builtin_snippets)
     titles = dict((snippets.title(n), n) for n in allnames if n not in builtins)
-    
+
     new = QTreeWidgetItem(tree, [_("New Snippets")])
     updated = QTreeWidgetItem(tree, [_("Updated Snippets")])
     unchanged = QTreeWidgetItem(tree, [_("Unchanged Snippets")])
-    
+
     new.setFlags(Qt.ItemIsEnabled)
     updated.setFlags(Qt.ItemIsEnabled)
     unchanged.setFlags(Qt.ItemIsEnabled)
-    
+
     new.setExpanded(True)
     updated.setExpanded(True)
-    
+
     items = []
     for snip in elements:
         item = QTreeWidgetItem()
-        
+
         item.body = snip.find('body').text
         item.title = snip.find('title').text
         item.shortcuts = list(e.text for e in snip.findall('shortcuts/shortcut'))
-        
+
         title = item.title or snippets.maketitle(snippets.parse(item.body).text)
         item.setText(0, title)
-        
+
         name = snip.get('id')
         name = name if name in builtins else None
-        
-        
+
+
         # determine if new, updated or unchanged
         if not name:
             name = titles.get(title)
         item.name = name
-        
+
         if not name or name not in allnames:
             new.addChild(item)
             items.append(item)
@@ -158,7 +158,7 @@ def load(filename, widget):
         elif name:
             if (item.body != snippets.text(name)
                 or title != snippets.title(name)
-                or (item.shortcuts and item.shortcuts != 
+                or (item.shortcuts and item.shortcuts !=
                     [s.toString() for s in model.shortcuts(name) or ()])):
                 updated.addChild(item)
                 items.append(item)
@@ -174,15 +174,15 @@ def load(filename, widget):
         if i.childCount():
             i.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
             i.setCheckState(0, Qt.Checked)
-    
+
     def changed(item):
         if item in (new, updated):
             for i in range(item.childCount()):
                 c = item.child(i)
                 c.setCheckState(0, item.checkState(0))
-            
+
     tree.itemChanged.connect(changed)
-    
+
     importShortcuts = QTreeWidgetItem([_("Import Keyboard Shortcuts")])
     if items:
         tree.addTopLevelItem(importShortcuts)
@@ -192,7 +192,7 @@ def load(filename, widget):
     else:
         dlg.setMessage(_("There are no new or updated snippets in the file."))
         unchanged.setExpanded(True)
-    
+
     tree.setWhatsThis(_(
         "<p>Here the snippets from {filename} are displayed.</p>\n"
         "<p>If there are new or updated snippets, you can select or deselect "
@@ -200,7 +200,7 @@ def load(filename, widget):
         "Then click OK to import all the selected snippets.</p>\n"
         "<p>Existing, unchanged snippets can't be imported.</p>\n"
         ).format(filename=os.path.basename(filename)))
-        
+
     qutil.saveDialogSize(dlg, "snippettool/import/size", QSize(400, 300))
     if not dlg.exec_() or not items:
         return
@@ -218,12 +218,12 @@ def load(filename, widget):
 
 _comment = """
   Created by {appinfo.appname} {appinfo.version}.
-  
+
   Every snippet is represented by:
     title:      title text
     shortcuts:  list of shortcut elements, every shortcut is a key sequence
     body:       the snippet text
-  
+
   The snippet id attribute can be the name of a builtin snippet or a random
   name like 'n123456'. In the latter case, the title is used to determine
   whether a snippet is new or updated.

--- a/frescobaldi_app/snippet/insert.py
+++ b/frescobaldi_app/snippet/insert.py
@@ -40,16 +40,16 @@ def insert(name, view):
     """Insert named snippet into the view."""
     text, variables = snippets.get(name)
     cursor = view.textCursor()
-    
+
     selection = variables.get('selection', '')
     if 'yes' in selection and not cursor.hasSelection():
         return
     if 'strip' in selection:
         cursortools.strip_selection(cursor)
-    
+
     pos = cursor.selectionStart()
     with cursortools.compress_undo(cursor):
-        
+
         # insert the snippet, might return a new cursor
         if 'python' in variables:
             new = insert_python(text, cursor, name, view)
@@ -57,18 +57,18 @@ def insert(name, view):
             new = insert_macro(text, view)
         else:
             new = insert_snippet(text, cursor, variables)
-        
+
     # QTextBlocks the snippet starts and ends
     block = cursor.document().findBlock(pos)
     last = cursor.block()
-    
+
     # re-indent if not explicitly suppressed by a 'indent: no' variable
     if last != block and 'no' not in variables.get('indent', ''):
         c = QTextCursor(last)
         c.setPosition(block.position(), QTextCursor.KeepAnchor)
         with cursortools.compress_undo(c, True):
             indent.re_indent(c, True)
-    
+
     if not new and 'keep' in selection:
         end = cursor.position()
         cursor.setPosition(pos)
@@ -78,15 +78,15 @@ def insert(name, view):
 
 def insert_snippet(text, cursor, variables):
     """Inserts a normal text snippet.
-    
+
     After the insert, the cursor points to the end of the inserted snippet.
-    
+
     If this function returns a cursor it must be set as the cursor for the view
     after the snippet has been inserted.
-    
+
     """
     exp_base = expand.Expander(cursor)
-    
+
     evs = [] # make a list of events, either text or a constant
     for text, key in snippets.expand(text):
         if text:
@@ -98,7 +98,7 @@ def insert_snippet(text, cursor, variables):
             func = getattr(exp_base, key, None)
             if func:
                 evs.append(func())
-    
+
     selectionUsed = expand.SELECTION in evs
     # do the padding if 'selection: strip;' is used
     if selectionUsed and 'strip' in variables.get('selection', ''):
@@ -139,17 +139,17 @@ def insert_snippet(text, cursor, variables):
 
 def insert_python(text, cursor, name, view):
     """Regards the text as Python code, and exec it.
-    
+
     name and view are given in case an exception occurs.
-    
+
     The following variables are available:
-    
+
     - text: contains selection or '', set it to insert new text
     - state: contains simplestate for the cursor position
     - cursor: the QTextCursor
 
     After the insert, the cursor points to the end of the inserted snippet.
-    
+
     """
     namespace = {
         'cursor': QTextCursor(cursor),
@@ -194,13 +194,13 @@ def insert_python(text, cursor, name, view):
 
 
 def insert_macro(text, view):
-    """The macro snippet is a sequence of commands which are either 
+    """The macro snippet is a sequence of commands which are either
     Frescobaldi actions or other snippets.
     """
     import re
     import actioncollectionmanager
     from . import model
-    
+
     avail_snippets = {}
     for n in model.model().names():
         varname = snippets.get(n).variables.get('name')
@@ -238,9 +238,9 @@ def state(cursor):
 
 def handle_exception(name, view):
     """Called when a snippet raises a Python exception.
-    
+
     Shows the error message and offers the option to edit the offending snippet.
-    
+
     """
     import sys, traceback
     exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -256,7 +256,7 @@ def handle_exception(name, view):
     dlg.setEscapeButton(QMessageBox.Cancel)
     if dlg.exec_() != QMessageBox.Ok:
         return
-    
+
     # determine line number
     if exc_type is SyntaxError:
         lineno = exc_value.lineno
@@ -264,7 +264,7 @@ def handle_exception(name, view):
         lineno = tb[0][1]
     else:
         lineno = None
-    
+
     import panelmanager
     from . import edit
     widget = panelmanager.manager(view.window()).snippettool.widget()

--- a/frescobaldi_app/snippet/menu.py
+++ b/frescobaldi_app/snippet/menu.py
@@ -50,14 +50,14 @@ class SnippetMenuBase(QMenu):
         self.aboutToHide.connect(self.clearMenu, Qt.QueuedConnection)
         self.triggered.connect(self.slotTriggered)
         app.translateUI(self)
-        
+
     def mainwindow(self):
         return self.parent().window()
-    
+
     def tool(self):
         """Returns the snippets tool."""
         return panelmanager.manager(self.mainwindow()).snippettool
-    
+
     def populate(self):
         """Populates the menu with snippet actions."""
         self.clearMenu() # on some systems aboutToHide does not fire...
@@ -77,23 +77,23 @@ class SnippetMenuBase(QMenu):
                 self.insertAction(last, action)
             self.insertSeparator(last)
         qutil.addAccelerators(self.actions())
-        
+
     def insertBeforeAction(self):
         """Should return an action to insert out stuff before, or None."""
         return None
-    
+
     def snippetGroup(self, variables):
         """Should a group name if the snippet is to appear in the menu."""
-    
+
     def visitAction(self, action, variables):
         """May change the action depending on variables."""
-        
+
     def clearMenu(self):
         """Should delete the inserted actions."""
         for a in self.actions():
             self.removeAction(a)
             a.deleteLater()
-    
+
     def slotTriggered(self, action):
         """Called when an action is triggered."""
         name = action.objectName()
@@ -112,20 +112,20 @@ class SnippetMenu(SnippetMenuBase):
     def __init__(self, parent=None):
         super(SnippetMenu, self).__init__(parent)
         self.addAction(self.tool().actionCollection.snippettool_activate)
-        
+
     def translateUI(self):
         self.setTitle(_("menu title", "Sn&ippets"))
-    
+
     def insertBeforeAction(self):
         return self.actions()[-1]
-    
+
     def snippetGroup(self, variables):
         return variables.get('menu')
-    
+
     def visitAction(self, action, variables):
         if 'yes' in variables.get('selection', ''):
             action.setEnabled(self.mainwindow().hasSelection())
-    
+
     def clearMenu(self):
         """Deletes the actions on menu hide, excepts the "Snippets..." action."""
         for a in self.actions()[:-1]:
@@ -137,16 +137,16 @@ class TemplateMenu(SnippetMenuBase):
     def __init__(self, parent=None):
         super(TemplateMenu, self).__init__(parent)
         self.addAction(self.tool().actionCollection.templates_manage)
-        
+
     def translateUI(self):
         self.setTitle(_("New from &Template"))
-    
+
     def insertBeforeAction(self):
         return self.actions()[-1]
-    
+
     def snippetGroup(self, variables):
         return variables.get('template')
-    
+
     def applySnippet(self, name):
         d = app.openUrl(QUrl())
         self.mainwindow().setCurrentDocument(d)
@@ -158,7 +158,7 @@ class TemplateMenu(SnippetMenuBase):
         if 'template-run' in snippets.get(name).variables:
             import engrave
             engrave.engraver(self.mainwindow()).engrave('preview', d)
-    
+
     def clearMenu(self):
         """Deletes the actions on menu hide, except "Manage templates..."."""
         for a in self.actions()[:-1]:

--- a/frescobaldi_app/snippet/model.py
+++ b/frescobaldi_app/snippet/model.py
@@ -50,7 +50,7 @@ class SnippetModel(QAbstractItemModel):
         self.load()
         app.settingsChanged.connect(self.slotSettingsChanged)
         app.languageChanged.connect(self.slotLanguageChanged)
-        
+
     # methods needed to be a well-behaved model
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         if role == Qt.DisplayRole and orientation == Qt.Horizontal:
@@ -60,19 +60,19 @@ class SnippetModel(QAbstractItemModel):
                 return _("Description")
             else:
                 return _("Shortcut")
-    
+
     def index(self, row, column, parent=None):
         return self.createIndex(row, column)
-    
+
     def parent(self, index):
         return QModelIndex()
-    
+
     def columnCount(self, parent=QModelIndex()):
         return 3 if not parent.isValid() else 0
-    
+
     def rowCount(self, parent=QModelIndex()):
         return len(self._names) if not parent.isValid() else 0
-    
+
     def data(self, index, role=Qt.DisplayRole):
         name = self.name(index)
         if role == Qt.DisplayRole:
@@ -84,26 +84,26 @@ class SnippetModel(QAbstractItemModel):
                 return shortcut(name)
         elif role == Qt.DecorationRole and index.column() == 1:
             return snippets.icon(name)
-    
+
     # slots
     def slotSettingsChanged(self):
         """Called when settings change, e.g. when keyboard shortcuts are altered."""
         self.load()
-        
+
     def slotLanguageChanged(self):
         """Called when the user changes the language."""
         self.headerDataChanged.emit(Qt.Horizontal, 0, 2)
-        
+
     def load(self):
         self.beginResetModel()
         self._names = sorted(snippets.names(), key=snippets.title)
         self.endResetModel()
-    
+
     # interface for getting/altering snippets
     def names(self):
         """Returns the internal list of snippet names in title order. Do not alter!"""
         return self._names
-        
+
     def name(self, index):
         """The internal snippet id for the given QModelIndex."""
         return self._names[index.row()]
@@ -118,19 +118,19 @@ class SnippetModel(QAbstractItemModel):
         finally:
             self.endRemoveRows()
             return True
-        
+
     def saveSnippet(self, name, text, title):
         """Store a snippet.
-        
+
         If name is None or does not exist in names(), a new snippet is created.
         Returns the QModelIndex the snippet was stored at.
-        
+
         Title may be None.
-        
+
         """
         # first, get the old titles list
         titles = list(snippets.title(n) for n in self._names)
-        
+
         oldrow = None
         if name is None:
             name = snippets.name(self._names)
@@ -144,7 +144,7 @@ class SnippetModel(QAbstractItemModel):
         # if oldrow is not None, it is the row to be removed.
         title = snippets.title(name)
         i = bisect.bisect_right(titles, title)
-        
+
         if oldrow is None:
             # just insert new snippet
             self.beginInsertRows(QModelIndex(), i, i )

--- a/frescobaldi_app/snippet/restore.py
+++ b/frescobaldi_app/snippet/restore.py
@@ -44,18 +44,18 @@ class RestoreDialog(widgets.dialog.Dialog):
         userguide.addButton(self.buttonBox(), "snippets")
         self.tree = QTreeWidget(headerHidden=True, rootIsDecorated=False)
         self.setMainWidget(self.tree)
-        
+
         self.deletedItem = QTreeWidgetItem(self.tree)
         self.deletedItem.setFlags(Qt.ItemIsUserCheckable)
         self.changedItem = QTreeWidgetItem(self.tree)
         self.changedItem.setFlags(Qt.ItemIsUserCheckable)
         self.tree.itemChanged.connect(self.slotItemChanged)
-        
+
         app.translateUI(self)
         app.languageChanged.connect(self.populate)
         self.accepted.connect(self.updateSnippets)
         qutil.saveDialogSize(self, "snippettool/restoredialog/size")
-    
+
     def translateUI(self):
         self.setWindowTitle(
             app.caption(_("dialog title", "Restore Built-in Snippets")))
@@ -66,7 +66,7 @@ class RestoreDialog(widgets.dialog.Dialog):
         self.button("ok").setText(_("Restore Checked Snippets"))
         self.deletedItem.setText(0, _("Deleted Snippets"))
         self.changedItem.setText(0, _("Changed Snippets"))
-        
+
     def populate(self):
         """Puts the deleted/changed snippets in the tree."""
         self.deletedItem.takeChildren()
@@ -75,12 +75,12 @@ class RestoreDialog(widgets.dialog.Dialog):
         self.changedItem.takeChildren()
         self.changedItem.setExpanded(True)
         self.changedItem.setCheckState(0, Qt.Unchecked)
-        
+
         builtins = list(builtin.builtin_snippets)
         builtins.sort(key = snippets.title)
-        
+
         names = frozenset(snippets.names())
-        
+
         for name in builtins:
             if name in names:
                 if snippets.isoriginal(name):
@@ -88,23 +88,23 @@ class RestoreDialog(widgets.dialog.Dialog):
                 parent = self.changedItem
             else:
                 parent = self.deletedItem
-            
+
             item = QTreeWidgetItem(parent)
             item.name = name
             item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
             item.setCheckState(0, Qt.Unchecked)
             item.setText(0, snippets.title(name))
-        
+
         self.deletedItem.setDisabled(self.deletedItem.childCount() == 0)
         self.changedItem.setDisabled(self.changedItem.childCount() == 0)
         self.checkOkButton()
-    
+
     def slotItemChanged(self, item):
         if item in (self.deletedItem, self.changedItem):
             for i in range(item.childCount()):
                 item.child(i).setCheckState(0, item.checkState(0))
         self.checkOkButton()
-        
+
     def checkedSnippets(self):
         """Yields the names of the checked snippets."""
         for parent in (self.deletedItem, self.changedItem):
@@ -112,7 +112,7 @@ class RestoreDialog(widgets.dialog.Dialog):
                 child = parent.child(i)
                 if child.checkState(0) == Qt.Checked:
                     yield child.name
-    
+
     def updateSnippets(self):
         """Restores the checked snippets."""
         collection = self.parent().parent().snippetActions

--- a/frescobaldi_app/snippet/snippets.py
+++ b/frescobaldi_app/snippet/snippets.py
@@ -86,10 +86,10 @@ def names():
 
 def title(name, fallback=True):
     """Returns the title of the specified snippet or the empty string.
-    
+
     If fallback, returns a shortened display of the text if no title is
     available.
-    
+
     """
     s = settings()
     title = s.value(name+"/title")
@@ -139,35 +139,35 @@ def maketitle(text):
         return lines[start]
     else:
         return lines[start] + " ... " + lines[end]
-    
+
 
 @memoize
 def get(name):
     """Returns a tuple (text, variables) for the specified name.
-    
+
     Equivalent to parse(text(name)). See parse().
-    
+
     """
     return parse(text(name))
 
 
 def parse(text):
     """Parses a piece of text and returns a named tuple (text, variables).
-    
+
     text is the template text, with lines starting with '-*- ' removed.
     variables is a dictionary containing variables read from lines starting
     with '-*- '.
-    
+
     The syntax is as follows:
-    
+
     -*- name: value; name1: value2; (etc)
-    
+
     Names without value are also possible:
-    
+
     -*- name;
-    
+
     In that case the value is set to True.
-    
+
     """
     lines = text.split('\n')
     start = 0
@@ -200,9 +200,9 @@ def delete(name):
 
 def name(names):
     """Returns a name to be used for a new snippet..
-    
+
     names is a list of strings for which the newly returned name will be unique.
-    
+
     """
     while True:
         u = "n{0:06.0f}".format(random.random()*1000000)
@@ -242,16 +242,16 @@ def isoriginal(name):
 
 def expand(text):
     r"""Yields tuples (text, expansion) for text.
-    
+
     Parses text for expressions like '$VAR_NAME', '${other text}' or '$$'.
-    
+
     An expansion starts with a '$' and is an uppercase word (which can have
     single underscores in the middle), or other text between braces (which may
     contain a right brace escaped: '\}', those are already unescaped by this
     function).
 
     One of (text, expansion) may be an empty string.
-    
+
     """
     pos = 0
     for m in _expansions_re.finditer(text):

--- a/frescobaldi_app/snippet/template.py
+++ b/frescobaldi_app/snippet/template.py
@@ -52,22 +52,22 @@ class TemplateDialog(widgets.dialog.TextDialog):
         layout.addWidget(e)
         layout.addWidget(c)
         e.setFocus()
-    
+
     def lineEdit(self):
         """Return the QLineEdit widget."""
         return self._lineEdit or self.mainWidget()
-    
+
     def runCheck(self):
         """Return the Run LilyPond checkbox."""
         return self._runCheck
 
 
 def save(mainwindow):
-    
+
     titles = dict((snippets.title(name), name)
                   for name in model.model().names()
                   if 'template' in snippets.get(name).variables)
-    
+
     # would it make sense to run LilyPond after creating a document from this
     # template?
     cursor = mainwindow.textCursor()
@@ -81,15 +81,15 @@ def save(mainwindow):
     c = QCompleter(sorted(titles), dlg.lineEdit())
     dlg.lineEdit().setCompleter(c)
     dlg.runCheck().setChecked(template_run)
-    
+
     result = dlg.exec_()
     dlg.deleteLater()
     if not result:
         return # cancelled
-    
+
     title = dlg.text()
     template_run = dlg.runCheck().isChecked()
-    
+
     if title in titles:
         if QMessageBox.critical(mainwindow,
             _("Overwrite Template?"),
@@ -100,15 +100,15 @@ def save(mainwindow):
         name = titles[title]
     else:
         name = None
-    
+
     # get the text and insert cursor position or selection
     text = cursor.document().toPlainText()
-    
+
     repls = [(cursor.position(), '${CURSOR}')]
     if cursor.hasSelection():
         repls.append((cursor.anchor(), '${ANCHOR}'))
         repls.sort()
-        
+
     result = []
     prev = 0
     for pos, what in repls:
@@ -117,13 +117,13 @@ def save(mainwindow):
         prev = pos
     result.append(text[prev:].replace('$', '$$'))
     text = ''.join(result)
-    
+
     # add header line, if desired enable autorun
     headerline = '-*- template; indent: no;'
     if template_run:
         headerline += ' template-run;'
     text = headerline + '\n' + text
-    
+
     # save the new snippet
     model.model().saveSnippet(name, text, title)
 

--- a/frescobaldi_app/snippet/tool.py
+++ b/frescobaldi_app/snippet/tool.py
@@ -52,11 +52,11 @@ class SnippetTool(panel.Panel):
         mainwindow.addDockWidget(Qt.BottomDockWidgetArea, self)
         mainwindow.selectionStateChanged.connect(self.updateActions)
         self.updateActions()
-        
+
     def translateUI(self):
         self.setWindowTitle(_("Snippets"))
         self.toggleViewAction().setText(_("&Snippets"))
-        
+
     def createWidget(self):
         from . import widget
         return widget.Widget(self)
@@ -68,20 +68,20 @@ class SnippetTool(panel.Panel):
         self.mainwindow().currentView().ensureCursorVisible()
         self.widget().searchEntry.setFocus()
         self.widget().searchEntry.selectAll()
-    
+
     def updateActions(self):
         self.actionCollection.copy_to_snippet.setEnabled(self.mainwindow().hasSelection())
-    
+
     def saveAsTemplate(self):
         from . import template
         template.save(self.mainwindow())
-    
+
     def copyToSnippet(self):
         text = self.mainwindow().textCursor().selection().toPlainText()
         text = '-*- menu;\n' + text
         from . import edit
         edit.Edit(self.widget(), None, text)
-    
+
     def manageTemplates(self):
         super(SnippetTool, self).activate()
         if self.isFloating():
@@ -111,7 +111,7 @@ class SnippetActions(actioncollection.ShortcutCollection):
     def __init__(self, tool):
         super(SnippetActions, self).__init__(tool.mainwindow().centralWidget())
         self.tool = weakref.ref(tool)
-    
+
     def createDefaultShortcuts(self):
         self.setDefaultShortcuts('voice1', [QKeySequence('Alt+1')])
         self.setDefaultShortcuts('voice2', [QKeySequence('Alt+2')])
@@ -135,19 +135,19 @@ class SnippetActions(actioncollection.ShortcutCollection):
         self.setDefaultShortcuts('double', [QKeySequence('Ctrl+D')])
         self.setDefaultShortcuts('comment', [QKeySequence('Ctrl+Alt+C, Ctrl+Alt+C')])
         self.setDefaultShortcuts('uncomment', [QKeySequence('Ctrl+Alt+C, Ctrl+Alt+U')])
-        
+
     def realAction(self, name):
         from . import actions, model
         if name in model.model().names():
             return actions.action(name, None, self)
-    
+
     def triggerAction(self, name):
         from . import insert, model
         if name in model.model().names():
             view = self.tool().mainwindow().currentView()
             if view.hasFocus() or self.tool().widget().searchEntry.hasFocus():
                 insert.insert(name, view)
-            
+
     def title(self):
         return _("Snippets")
 

--- a/frescobaldi_app/snippet/widget.py
+++ b/frescobaldi_app/snippet/widget.py
@@ -47,22 +47,22 @@ from . import highlight
 class Widget(QWidget):
     def __init__(self, panel):
         super(Widget, self).__init__(panel)
-        
+
         layout = QVBoxLayout()
         self.setLayout(layout)
         layout.setSpacing(0)
-        
+
         self.searchEntry = SearchLineEdit()
         self.treeView = QTreeView(contextMenuPolicy=Qt.CustomContextMenu)
         self.textView = QTextBrowser()
-        
+
         applyButton = QToolButton(autoRaise=True)
         editButton = QToolButton(autoRaise=True)
         addButton = QToolButton(autoRaise=True)
         self.menuButton = QPushButton(flat=True)
         menu = QMenu(self.menuButton)
         self.menuButton.setMenu(menu)
-        
+
         splitter = QSplitter(Qt.Vertical)
         top = QHBoxLayout()
         layout.addLayout(top)
@@ -71,14 +71,14 @@ class Widget(QWidget):
         layout.addWidget(splitter)
         splitter.setSizes([200, 100])
         splitter.setCollapsible(0, False)
-        
+
         top.addWidget(self.searchEntry)
         top.addWidget(applyButton)
         top.addSpacing(10)
         top.addWidget(addButton)
         top.addWidget(editButton)
         top.addWidget(self.menuButton)
-        
+
         # action generator for actions added to search entry
         def act(slot, icon=None):
             a = QAction(self, triggered=slot)
@@ -86,64 +86,64 @@ class Widget(QWidget):
             a.setShortcutContext(Qt.WidgetWithChildrenShortcut)
             icon and a.setIcon(icons.get(icon))
             return a
-        
+
         # hide if ESC pressed in lineedit
         a = act(self.slotEscapePressed)
         a.setShortcut(QKeySequence(Qt.Key_Escape))
-        
+
         # import action
         a = self.importAction = act(self.slotImport, 'document-open')
         menu.addAction(a)
-        
+
         # export action
         a = self.exportAction = act(self.slotExport, 'document-save-as')
         menu.addAction(a)
-        
+
         # apply button
         a = self.applyAction = act(self.slotApply, 'edit-paste')
         applyButton.setDefaultAction(a)
         menu.addSeparator()
         menu.addAction(a)
-        
+
         # add button
         a = self.addAction_ = act(self.slotAdd, 'list-add')
         a.setShortcut(QKeySequence(Qt.Key_Insert))
         addButton.setDefaultAction(a)
         menu.addSeparator()
         menu.addAction(a)
-        
+
         # edit button
         a = self.editAction = act(self.slotEdit, 'document-edit')
         a.setShortcut(QKeySequence(Qt.Key_F2))
         editButton.setDefaultAction(a)
         menu.addAction(a)
-        
+
         # set shortcut action
         a = self.shortcutAction = act(self.slotShortcut, 'preferences-desktop-keyboard-shortcuts')
         menu.addAction(a)
-        
+
         # delete action
         a = self.deleteAction = act(self.slotDelete, 'list-remove')
         a.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_Delete))
         menu.addAction(a)
-        
+
         # restore action
         a = self.restoreAction = act(self.slotRestore)
         menu.addSeparator()
         menu.addAction(a)
-        
+
         # help button
         a = self.helpAction = act(self.slotHelp, 'help-contents')
         menu.addSeparator()
         menu.addAction(a)
-        
+
         self.treeView.setSelectionBehavior(QTreeView.SelectRows)
         self.treeView.setSelectionMode(QTreeView.ExtendedSelection)
         self.treeView.setRootIsDecorated(False)
         self.treeView.setAllColumnsShowFocus(True)
         self.treeView.setModel(model.model())
         self.treeView.setCurrentIndex(QModelIndex())
-        
+
         # signals
         self.searchEntry.returnPressed.connect(self.slotReturnPressed)
         self.searchEntry.textChanged.connect(self.updateFilter)
@@ -151,10 +151,10 @@ class Widget(QWidget):
         self.treeView.customContextMenuRequested.connect(self.showContextMenu)
         self.treeView.selectionModel().currentChanged.connect(self.updateText)
         self.treeView.model().dataChanged.connect(self.updateFilter)
-        
+
         # highlight text
         self.highlighter = highlight.Highlighter(self.textView.document())
-        
+
         # complete on snippet variables
         self.searchEntry.setCompleter(QCompleter([
             ':icon', ':indent', ':menu', ':name', ':python', ':selection',
@@ -172,11 +172,11 @@ class Widget(QWidget):
                 ev.accept()
                 from . import import_export
                 import_export.load(filename, self)
-        
+
     def dragEnterEvent(self, ev):
         if not ev.source() and ev.mimeData().hasUrls():
             ev.accept()
-        
+
     def translateUI(self):
         try:
             self.searchEntry.setPlaceholderText(_("Search..."))
@@ -219,10 +219,10 @@ class Widget(QWidget):
             _("E.g. entering {menu} will show all snippets that are displayed "
               "in the insert menu.").format(menu="<code>:menu</code>"),
             ))))
-    
+
     def sizeHint(self):
         return self.parent().mainwindow().size() / 4
-        
+
     def readSettings(self):
         data = textformats.formatData('editor')
         self.textView.setFont(data.font)
@@ -231,7 +231,7 @@ class Widget(QWidget):
     def showContextMenu(self, pos):
         """Called when the user right-clicks the tree view."""
         self.menuButton.menu().popup(self.treeView.viewport().mapToGlobal(pos))
-    
+
     def slotReturnPressed(self):
         """Called when the user presses Return in the search entry. Applies current snippet."""
         name = self.currentSnippet()
@@ -245,22 +245,22 @@ class Widget(QWidget):
         """Called when the user presses ESC in the search entry. Hides the panel."""
         self.parent().hide()
         self.parent().mainwindow().currentView().setFocus()
-    
+
     def slotDoubleClicked(self, index):
         name = self.treeView.model().name(index)
         view = self.parent().mainwindow().currentView()
         insert.insert(name, view)
-        
+
     def slotAdd(self):
         """Called when the user wants to add a new snippet."""
         edit.Edit(self, None)
-        
+
     def slotEdit(self):
         """Called when the user wants to edit a snippet."""
         name = self.currentSnippet()
         if name:
             edit.Edit(self, name)
-        
+
     def slotShortcut(self):
         """Called when the user selects the Configure Shortcut action."""
         from widgets import shortcuteditdialog
@@ -272,12 +272,12 @@ class Widget(QWidget):
             mgr = actioncollectionmanager.manager(self.parent().mainwindow())
             cb = mgr.findShortcutConflict
             dlg = shortcuteditdialog.ShortcutEditDialog(self, cb, (collection, name))
-            
+
             if dlg.editAction(action, default):
                 mgr.removeShortcuts(action.shortcuts())
                 collection.setShortcuts(name, action.shortcuts())
                 self.treeView.update()
-            
+
     def slotDelete(self):
         """Called when the user wants to delete the selected rows."""
         rows = sorted(set(i.row() for i in self.treeView.selectedIndexes()), reverse=True)
@@ -287,14 +287,14 @@ class Widget(QWidget):
                 self.parent().snippetActions.setShortcuts(name, [])
                 self.treeView.model().removeRow(row)
             self.updateFilter()
-    
+
     def slotApply(self):
         """Called when the user clicks the apply button. Applies current snippet."""
         name = self.currentSnippet()
         if name:
             view = self.parent().mainwindow().currentView()
             insert.insert(name, view)
-    
+
     def slotImport(self):
         """Called when the user activates the import action."""
         filetypes = "{0} (*.xml);;{1} (*)".format(_("XML Files"), _("All Files"))
@@ -304,7 +304,7 @@ class Widget(QWidget):
         if filename:
             from . import import_export
             import_export.load(filename, self)
-        
+
     def slotExport(self):
         """Called when the user activates the export action."""
         allrows = [row for row in range(model.model().rowCount())
@@ -313,7 +313,7 @@ class Widget(QWidget):
                                 if i.column() == 0 and i.row() in allrows]
         names = self.treeView.model().names()
         names = [names[row] for row in selectedrows or allrows]
-        
+
         filetypes = "{0} (*.xml);;{1} (*)".format(_("XML Files"), _("All Files"))
         n = len(names)
         caption = app.caption(_("dialog title",
@@ -327,7 +327,7 @@ class Widget(QWidget):
                 QMessageBox.critical(self, _("Error"), _(
                     "Can't write to destination:\n\n{url}\n\n{error}").format(
                     url=filename, error=e.strerror))
-        
+
     def slotRestore(self):
         """Called when the user activates the Restore action."""
         from . import restore
@@ -336,11 +336,11 @@ class Widget(QWidget):
         dlg.populate()
         dlg.show()
         dlg.finished.connect(dlg.deleteLater)
-        
+
     def slotHelp(self):
         """Called when the user clicks the small help button."""
         userguide.show("snippets")
-        
+
     def currentSnippet(self):
         """Returns the name of the current snippet if it is visible."""
         row = self.treeView.currentIndex().row()
@@ -376,7 +376,7 @@ class Widget(QWidget):
                 hide = True
             self.treeView.setRowHidden(row, QModelIndex(), hide)
         self.updateText()
-            
+
     def updateText(self):
         """Called when the current snippet changes."""
         name = self.currentSnippet()
@@ -385,16 +385,16 @@ class Widget(QWidget):
             s = snippets.get(name)
             self.highlighter.setPython('python' in s.variables)
             self.textView.setPlainText(s.text)
-        
+
     def updateColumnSizes(self):
         self.treeView.resizeColumnToContents(0)
         self.treeView.resizeColumnToContents(1)
-        
+
 
 class SearchLineEdit(widgets.lineedit.LineEdit):
     def __init__(self, *args):
         super(SearchLineEdit, self).__init__(*args)
-    
+
     def event(self, ev):
         if ev.type() == QEvent.KeyPress and any(ev.matches(key) for key in (
             QKeySequence.MoveToNextLine, QKeySequence.SelectNextLine,

--- a/frescobaldi_app/splashscreen/__init__.py
+++ b/frescobaldi_app/splashscreen/__init__.py
@@ -29,7 +29,7 @@ import app
 import appinfo
 
 def show():
-    
+
     message = "{0}  {1} ".format(appinfo.appname, appinfo.version)
     pixmap = QPixmap(os.path.join(__path__[0], 'splash3.png'))
     if QApplication.desktop().screenGeometry().height() < 640:
@@ -48,7 +48,7 @@ def show():
     splash.showMessage(message, Qt.AlignRight | Qt.AlignTop, Qt.white)
     splash.show()
     QApplication.processEvents()
-    
+
     def hide():
         splash.deleteLater()
         app.appStarted.disconnect(hide)

--- a/frescobaldi_app/svgview/__init__.py
+++ b/frescobaldi_app/svgview/__init__.py
@@ -20,7 +20,7 @@
 """
 The SVG preview panel.
 
-This previews a SVG-file with initial editing abilities. 
+This previews a SVG-file with initial editing abilities.
 
 """
 
@@ -42,30 +42,30 @@ class SvgViewPanel(panel.Panel):
         self.hide()
         self.toggleViewAction().setShortcut(QKeySequence("Meta+Alt+G"))
         mainwindow.addDockWidget(Qt.RightDockWidgetArea, self)
-        
+
         ac = self.actionCollection = Actions(self)
         actioncollectionmanager.manager(mainwindow).addActionCollection(ac)
         ac.svg_zoom_in.triggered.connect(self.zoomIn)
         ac.svg_zoom_out.triggered.connect(self.zoomOut)
         ac.svg_zoom_original.triggered.connect(self.zoomOriginal)
-        
+
     def translateUI(self):
         self.setWindowTitle(_("window title", "SVG View"))
         self.toggleViewAction().setText(_("SV&G View"))
-        
+
     def createWidget(self):
         from . import widget
         w = widget.SvgView(self)
         return w
-    
+
     def zoomIn(self):
         self.activate()
         self.widget().view.zoomIn()
-        
+
     def zoomOut(self):
         self.activate()
         self.widget().view.zoomOut()
-        
+
     def zoomOriginal(self):
         self.activate()
         self.widget().view.zoomOriginal()
@@ -77,11 +77,11 @@ class Actions(actioncollection.ActionCollection):
         self.svg_zoom_in = QAction(panel)
         self.svg_zoom_out = QAction(panel)
         self.svg_zoom_original = QAction(panel)
-        
+
         self.svg_zoom_in.setIcon(icons.get('zoom-in'))
         self.svg_zoom_out.setIcon(icons.get('zoom-out'))
         self.svg_zoom_original.setIcon(icons.get('zoom-original'))
-        
+
     def translateUI(self):
         self.svg_zoom_in.setText(_("Zoom &In"))
         self.svg_zoom_out.setText(_("Zoom &Out"))

--- a/frescobaldi_app/svgview/svgfiles.py
+++ b/frescobaldi_app/svgview/svgfiles.py
@@ -40,20 +40,20 @@ class SvgFiles(plugin.DocumentPlugin):
         self.current = 0
         document.loaded.connect(self.invalidate, -100)
         jobmanager.manager(document).finished.connect(self.invalidate, -100)
-    
+
     def invalidate(self):
         self._files = None
-        
+
     def update(self):
         files = resultfiles.results(self.document()).files('.svg*')
         self._files = files
         if files and self.current >= len(files):
             self.current = len(files) - 1
         return bool(files)
-    
+
     def __bool__(self):
         return bool(self._files)
-    
+
     def model(self):
         """Returns a model for a combobox."""
         if self._files is None:

--- a/frescobaldi_app/svgview/view.py
+++ b/frescobaldi_app/svgview/view.py
@@ -64,9 +64,9 @@ class View(QWebView):
     cursor = pyqtSignal(QTextCursor)
     selectedObject = pyqtSignal(str)
     selectedUrl = pyqtSignal(QTextCursor)
-    
+
     defaulturl = QUrl.fromLocalFile(os.path.join(__path__[0], 'background.html'))
-    
+
     def __init__(self, parent):
         super(View, self).__init__(parent)
         self._highlightFormat = QTextCharFormat()
@@ -76,28 +76,28 @@ class View(QWebView):
         app.settingsChanged.connect(self.readSettings)
         self.readSettings()
         self.load(self.defaulturl)
-    
+
     def cleanupForClose(self):
         """Called when our mainwindow is about to close.
-        
+
         Disconnects the loadFinished signal to prevent a RuntimeError
         about the QWebView already being deleted.
-        
+
         """
         self.loadFinished.disconnect(self.svgLoaded)
-    
+
     def mainwindow(self):
         return self.parent().mainwindow()
-        
+
     def currentSVG(self):
         return self.parent().getCurrent()
 
     def document(self, filename, load=False):
         """Get the document with the specified filename.
-        
+
         If load is True, the document is loaded if it wasn't already.
         Also takes scratchdir into account for unnamed or non-local documents.
-        
+
         """
         doc = scratchdir.findDocument(filename)
         if not doc and load:
@@ -111,18 +111,18 @@ class View(QWebView):
             frame.evaluateJavaScript(getJsScript('pointandclick.js'))
             #for now only editable in dev (git) or when the user explicitly allows experimental features
             if vcs.app_is_git_controlled() or QSettings().value("experimental-features", False, bool):
-                frame.evaluateJavaScript(getJsScript('editsvg.js')) 
-            
+                frame.evaluateJavaScript(getJsScript('editsvg.js'))
+
     def evalSave(self):
         frame = self.page().mainFrame()
         # to enable useful save of SVG edits to file uncomment the line below
         # frame.evaluateJavaScript(getJsScript('cleansvg.js'))
         frame.evaluateJavaScript(getJsScript('savesvg.js'))
-    
+
     def clear(self):
         """Empty the View."""
         self.load(self.defaulturl)
-    
+
     def dragElement(self, url):
         t = textedit.link(url)
         # Only process textedit links
@@ -136,14 +136,14 @@ class View(QWebView):
             p = b.position() + t.column
             cursor.setPosition(p)
         self.emitCursor(cursor)
-    
+
     def doObjectDragged(self, offsX, offsY):
         """announce extra-offsets an element has been dragged to"""
         self.objectDragged.emit(offsX, offsY)
-    
+
     def doObjectDragging(self, offsX, offsY):
         """announce extra-offsets while dragging an element"""
-        self.objectDragging.emit(offsX, offsY)    
+        self.objectDragging.emit(offsX, offsY)
 
     def doObjectStartDragging(self, offsX, offsY):
         """announce extra-offsets when starting to drag an element"""
@@ -151,7 +151,7 @@ class View(QWebView):
 
     def doTextEdit(self, url, setCursor = False):
         """Process a textedit link and either highlight
-           the corresponding source code or set the 
+           the corresponding source code or set the
            cursor to it.
         """
         t = textedit.link(url)
@@ -181,16 +181,16 @@ class View(QWebView):
                 mainwindow.activateWindow()
                 mainwindow.currentView().setFocus()
         return True
-    
+
     def emitCursor(self, cursor):
-        self.cursor.emit(cursor)    
-    
+        self.cursor.emit(cursor)
+
     def readSettings(self):
         """Reads the settings from the user's preferences."""
         color = textformats.formatData('editor').baseColors['selectionbackground']
         color.setAlpha(128)
         self._highlightFormat.setBackground(color)
-    
+
     def saveSVG(self, svg_string):
         """Pass string from JavaScript and save to current SVG page."""
         with open(self.currentSVG(), 'wb') as f:
@@ -203,13 +203,13 @@ class View(QWebView):
 
     def zoomIn(self):
         self.setZoomFactor(self.zoomFactor() * 1.1)
-        
+
     def zoomOut(self):
         self.setZoomFactor(self.zoomFactor() / 1.1)
-        
+
     def zoomOriginal(self):
         self.setZoomFactor(1.0)
-    
+
     def setZoomFactor(self, value):
         changed = self.zoomFactor() != value
         super(View, self).setZoomFactor(value)
@@ -219,9 +219,9 @@ class View(QWebView):
 
 class JSLink(QObject):
     """functions to be called from JavaScript
-    
+
     using addToJavaScriptWindowObject
-    
+
     """
     def __init__(self, view):
         super(JSLink, self).__init__()
@@ -229,7 +229,7 @@ class JSLink(QObject):
 
     @pyqtSlot(str)
     def click(self, url):
-        """set cursor in source by clicked textedit link""" 
+        """set cursor in source by clicked textedit link"""
         if not self.view.doTextEdit(url, True):
             import helpers
             helpers.openUrl(QUrl(url))
@@ -238,7 +238,7 @@ class JSLink(QObject):
     def dragged(self, offX, offY):
         """announce extra-offsets an element has been dragged to"""
         self.view.doObjectDragged(offX, offY)
-        
+
     @pyqtSlot(str)
     def draggedObject(self, JSON_string):
         # leave the following commented code as an idea how to proceed from here
@@ -247,7 +247,7 @@ class JSLink(QObject):
         #js = json.JSONDecoder()
         #print(js.decode(JSON_string))
         pass
-        
+
     @pyqtSlot(str)
     def dragElement(self, url):
         self.view.dragElement(url)
@@ -256,23 +256,23 @@ class JSLink(QObject):
     def dragging(self, offX, offY):
         """announce extra-offsets while dragging an element"""
         self.view.doObjectDragging(offX, offY)
-        
-    @pyqtSlot(str)       
+
+    @pyqtSlot(str)
     def hover(self, url):
         """actions when user set mouse over link"""
         self.view.doTextEdit(url, False)
-    
-    @pyqtSlot(str)       
+
+    @pyqtSlot(str)
     def leave(self, url):
         """actions when user moves mouse off link"""
         self.view.unHighlight()
-        
-    @pyqtSlot(str)       
+
+    @pyqtSlot(str)
     def pyLog(self, txt):
         """Temporary function. Print to Python console."""
         print(txt)
-    
-    @pyqtSlot(str)       
+
+    @pyqtSlot(str)
     def saveSVG(self, svg_string):
         """Pass string from JavaScript and save to current SVG page."""
         self.view.saveSVG(svg_string)

--- a/frescobaldi_app/svgview/widget.py
+++ b/frescobaldi_app/svgview/widget.py
@@ -40,22 +40,22 @@ from . import svgfiles
 class SvgView(QWidget):
     def __init__(self, dockwidget):
         super(SvgView, self).__init__(dockwidget)
-        
+
         self._document = None
         self._setting_zoom = False
-        
+
         self.view = view.View(self)
-        
+
         self.pageLabel = QLabel()
         self.pageCombo = QComboBox(sizeAdjustPolicy=QComboBox.AdjustToContents)
-		
+
         layout = QVBoxLayout(spacing=0)
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
         hbox = QHBoxLayout(spacing=0)
         hbox.addWidget(self.pageLabel)
         hbox.addWidget(self.pageCombo)
-        
+
         self.zoomInButton = QToolButton(autoRaise=True)
         self.zoomOutButton = QToolButton(autoRaise=True)
         self.zoomOriginalButton = QToolButton(autoRaise=True)
@@ -68,19 +68,19 @@ class SvgView(QWidget):
         hbox.addWidget(self.zoomNumber)
         hbox.addWidget(self.zoomOutButton)
         hbox.addWidget(self.zoomOriginalButton)
-        
+
         self.resetButton = QPushButton("reload", self)
         self.resetButton.clicked.connect(self.reLoadDoc)
         hbox.addWidget(self.resetButton)
-        
+
         self.saveButton = QPushButton("save edits", self)
         self.saveButton.clicked.connect(self.callSave)
         hbox.addWidget(self.saveButton)
-        
+
         hbox.addStretch(1)
         layout.addLayout(hbox)
         layout.addWidget(self.view)
-        
+
         app.jobFinished.connect(self.initSvg)
         app.documentClosed.connect(self.slotDocumentClosed)
         app.documentLoaded.connect(self.initSvg)
@@ -93,13 +93,13 @@ class SvgView(QWidget):
         if doc:
             self.initSvg(doc)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.pageLabel.setText(_("Page:"))
-        
+
     def mainwindow(self):
-        return self.parent().mainwindow()       
-        
+        return self.parent().mainwindow()
+
     def initSvg(self, doc):
         """Opens first page of score after compilation"""
         if doc == self.mainwindow().currentDocument():
@@ -111,29 +111,29 @@ class SvgView(QWidget):
                     self.pageCombo.setModel(model)
                     self.pageCombo.setCurrentIndex(files.current)
                 self.view.load(files.url(files.current))
-                
+
     def reLoadDoc(self):
         """Reloads current document."""
         if self._document:
             self.initSvg(self._document)
-            
+
     def callSave(self):
         """Call save function"""
         self.view.evalSave()
-		
+
     def getCurrent(self):
         files = svgfiles.SvgFiles.instance(self._document)
         return files.filename(files.current)
-			
+
     def slotZoomNumberChanged(self, value):
         self._setting_zoom = True
         self.view.setZoomFactor(value / 100.0)
         self._setting_zoom = False
-    
+
     def slotViewZoomChanged(self):
         if not self._setting_zoom:
             self.zoomNumber.setValue(int(self.view.zoomFactor() * 100))
-    
+
     def changePage(self, page_index):
         """change page of score"""
         doc = self._document
@@ -143,7 +143,7 @@ class SvgView(QWidget):
                 files.current = page_index
                 svg = files.url(page_index)
                 self.view.load(svg)
-		
+
     def slotDocumentClosed(self, doc):
         if doc == self._document:
             self._document = None

--- a/frescobaldi_app/symbols/__init__.py
+++ b/frescobaldi_app/symbols/__init__.py
@@ -48,9 +48,9 @@ def icon(name):
 
 def pixmap(name, size, mode, state):
     """Returns a (possibly cached) pixmap of the name and size with the default text color.
-    
+
     The state argument is ignored for now.
-    
+
     """
     if mode == QIcon.Selected:
         color = QApplication.palette().highlightedText().color()
@@ -80,12 +80,12 @@ class Engine(QIconEngine):
     def __init__(self, name):
         super(Engine, self).__init__()
         self._name = name
-        
+
     def pixmap(self, size, mode, state):
         return pixmap(self._name, size, mode, state)
-        
+
     def paint(self, painter, rect, mode, state):
         p = self.pixmap(rect.size(), mode, state)
         painter.drawPixmap(rect, p)
-        
+
 

--- a/frescobaldi_app/tabbar.py
+++ b/frescobaldi_app/tabbar.py
@@ -36,25 +36,25 @@ import util
 
 class TabBar(QTabBar):
     """The tabbar above the editor window."""
-    
+
     currentDocumentChanged = pyqtSignal(document.Document)
-    
+
     def __init__(self, parent=None):
         super(TabBar, self).__init__(parent)
-        
+
         self.setFocusPolicy(Qt.NoFocus)
         self.setMovable(True)      # TODO: make configurable
         self.setExpanding(False)
         self.setUsesScrollButtons(True)
         self.setElideMode(Qt.ElideNone)
-        
+
         mainwin = self.window()
         self.docs = []
         for doc in app.documents:
             self.addDocument(doc)
             if doc is mainwin.currentDocument():
                 self.setCurrentDocument(doc)
-        
+
         app.documentCreated.connect(self.addDocument)
         app.documentClosed.connect(self.removeDocument)
         app.documentUrlChanged.connect(self.setDocumentStatus)
@@ -68,15 +68,15 @@ class TabBar(QTabBar):
         self.tabMoved.connect(self.slotTabMoved)
         self.tabCloseRequested.connect(self.slotTabCloseRequested)
         self.readSettings()
-    
+
     def readSettings(self):
         """Called on init, and when the user changes the settings."""
         s = QSettings()
         self.setTabsClosable(s.value("tabs_closable", True, bool))
-    
+
     def documents(self):
         return list(self.docs)
-        
+
     def addDocument(self, doc):
         if doc not in self.docs:
             self.docs.append(doc)
@@ -107,7 +107,7 @@ class TabBar(QTabBar):
                 tooltip = None
             self.setTabToolTip(index, tooltip)
             self.setTabIcon(index, documenticon.icon(doc, self.window()))
-    
+
     def setCurrentDocument(self, doc):
         """ Raise the tab belonging to this document."""
         if doc in self.docs:
@@ -119,29 +119,29 @@ class TabBar(QTabBar):
     def slotCurrentChanged(self, index):
         """ Called when the user clicks a tab. """
         self.currentDocumentChanged.emit(self.docs[index])
-    
+
     def slotTabCloseRequested(self, index):
         """ Called when the user clicks the close button. """
         self.window().closeDocument(self.docs[index])
-    
+
     def slotTabMoved(self, index_from, index_to):
         """ Called when the user moved a tab. """
         doc = self.docs.pop(index_from)
         self.docs.insert(index_to, doc)
-        
+
     def nextDocument(self):
         """ Switches to the next document. """
         index = self.currentIndex() + 1
         if index == self.count():
             index = 0
         self.setCurrentIndex(index)
-        
+
     def previousDocument(self):
         index = self.currentIndex() - 1
         if index < 0:
             index = self.count() - 1
         self.setCurrentIndex(index)
-    
+
     def contextMenuEvent(self, ev):
         index = self.tabAt(ev.pos())
         if index >= 0:

--- a/frescobaldi_app/textedit.py
+++ b/frescobaldi_app/textedit.py
@@ -36,14 +36,14 @@ Link = collections.namedtuple("Link", "filename line column")
 
 def link(url):
     """Return Link(filename, line, column) for the specified `textedit:` url.
-    
+
     Link is a named tuple (filename, line, column).
     If the url is not a valid textedit url, None is returned.
-    
+
     The url should be specified as a normal Python string (unicode in Python 2,
     str in Python 3); the filename is percent-decoded and converted in the
     correct filesystem encoding if necessary.
-    
+
     """
     m = textedit_match(url)
     if m:
@@ -51,9 +51,9 @@ def link(url):
 
 def readurl(match):
     """Return Link(filename, line, col) for the match object resulting from textedit_match.
-    
+
     Link is a named tuple (filename, line, column).
-    
+
     """
     return Link(readfilename(match), int(match.group(2)), int(match.group(3)))
 

--- a/frescobaldi_app/textformats.py
+++ b/frescobaldi_app/textformats.py
@@ -53,7 +53,7 @@ def _resetFormatData():
 app.settingsChanged.connect(_resetFormatData, -100) # before all others
 _resetFormatData()
 
-    
+
 class TextFormatData(object):
     """Encapsulates all settings in the Fonts & Colors page for a scheme."""
     def __init__(self, scheme):
@@ -64,17 +64,17 @@ class TextFormatData(object):
         self.allStyles = {}
         self._inherits = {}
         self.load(scheme)
-        
+
     def load(self, scheme):
         """Load the settings for the scheme. Called on init."""
         s = QSettings()
         s.beginGroup("fontscolors/" + scheme)
-        
+
         # load font
         defaultfont = "Lucida Console" if os.name == "nt" else "monospace"
         self.font = QFont(s.value("fontfamily", defaultfont, str))
         self.font.setPointSizeF(s.value("fontsize", 10.0, float))
-        
+
         # load base colors
         s.beginGroup("basecolors")
         for name in baseColors:
@@ -83,7 +83,7 @@ class TextFormatData(object):
             else:
                 self.baseColors[name] = baseColorDefaults[name]()
         s.endGroup()
-        
+
         # get the list of supported styles from ly.colorize
         all_styles = ly.colorize.default_mapping()
         default_styles = set()
@@ -93,9 +93,9 @@ class TextFormatData(object):
                 if style.base:
                     default_styles.add(style.base)
                     d[style.name] = style.base
-        
+
         default_scheme = ly.colorize.default_scheme
-        
+
         # load default styles
         s.beginGroup("defaultstyles")
         for name in default_styles:
@@ -107,7 +107,7 @@ class TextFormatData(object):
             self.loadTextFormat(f, s)
             s.endGroup()
         s.endGroup()
-        
+
         # load specific styles
         s.beginGroup("allstyles")
         for group, styles in all_styles:
@@ -123,20 +123,20 @@ class TextFormatData(object):
                 s.endGroup()
             s.endGroup()
         s.endGroup()
-        
+
     def save(self, scheme):
         """Save the settings to the scheme."""
         s = QSettings()
         s.beginGroup("fontscolors/" + scheme)
-        
+
         # save font
         s.setValue("fontfamily", self.font.family())
         s.setValue("fontsize", self.font.pointSizeF())
-        
+
         # save base colors
         for name in baseColors:
             s.setValue("basecolors/"+name, self.baseColors[name].name())
-        
+
         # save default styles
         s.beginGroup("defaultstyles")
         for name in defaultStyles:
@@ -144,7 +144,7 @@ class TextFormatData(object):
             self.saveTextFormat(self.defaultStyles[name], s)
             s.endGroup()
         s.endGroup()
-        
+
         # save all specific styles
         s.beginGroup("allstyles")
         for group, styles in ly.colorize.default_mapping():
@@ -162,12 +162,12 @@ class TextFormatData(object):
         f = QTextCharFormat(self.defaultStyles[inherit]) if inherit else QTextCharFormat()
         f.merge(self.allStyles[group][name])
         return f
-    
+
     def css_scheme(self):
         """Return a dictionary of css dictionaries representing this scheme.
-        
+
         This can be fed to the ly.colorize.format_stylesheet() function.
-        
+
         """
         scheme = {}
         # base/default styles
@@ -180,7 +180,7 @@ class TextFormatData(object):
             for name, fmt in styles.items():
                 d[name] = fmt2css(fmt)
         return scheme
-    
+
     def palette(self):
         """Return a basic palette with text, background, selection and selection background filled in."""
         p = QApplication.palette()
@@ -189,7 +189,7 @@ class TextFormatData(object):
         p.setColor(QPalette.HighlightedText, self.baseColors['selectiontext'])
         p.setColor(QPalette.Highlight, self.baseColors['selectionbackground'])
         return p
-        
+
     def saveTextFormat(self, fmt, settings):
         """(Internal) Store one QTextCharFormat in the QSettings instance."""
         if fmt.hasProperty(QTextFormat.FontWeight):
@@ -216,7 +216,7 @@ class TextFormatData(object):
             settings.setValue('underlineColor', fmt.underlineColor().name())
         else:
             settings.remove('underlineColor')
-        
+
     def loadTextFormat(self, fmt, settings):
         """(Internal) Merge values from the QSettings instance into the QTextCharFormat."""
         if settings.contains('bold'):

--- a/frescobaldi_app/tokeniter.py
+++ b/frescobaldi_app/tokeniter.py
@@ -69,23 +69,23 @@ def state_end(block):
 
 def update(block):
     """Retokenize the given block, saving the tokens in the UserData.
-    
+
     You only need to call this if you immediately need the new tokens again,
     e.g. for more manipulations in the same moment. The tokens will
     automatically be updated when Qt re-enters the event loop.
-    
+
     """
     highlighter.highlighter(block.document()).rehighlightBlock(block)
 
 
 def cursor(block, token, start=0, end=None):
     """Returns a QTextCursor for the given token in the given block.
-    
+
     If start is given the cursor will start at position start in the token
     (from the beginning of the token). Start defaults to 0.
     If end is given, the cursor will end at that position in the token (from
     the beginning of the token). End defaults to the length of the token.
-    
+
     """
     if end is None:
         end = len(token)
@@ -97,10 +97,10 @@ def cursor(block, token, start=0, end=None):
 
 def find(text, tokens):
     """Finds text in tokens.
-    
+
     Consumes the tokens iterable until a token with text text is found.
     Returns the found token or None.
-    
+
     """
     if isinstance(tokens, (tuple, list)):
         try:
@@ -115,11 +115,11 @@ def find(text, tokens):
 
 def index(cursor):
     """Returns the index of the token at the cursor (right or overlapping).
-    
+
     The index can range from 0 (if there are no tokens or the cursor is in the
     first token) to the total count of tokens in the cursor's block (if the
     cursor is at the very end of the block).
-    
+
     """
     block = cursortools.block(cursor)
     tokens_ = tokens(block)
@@ -141,11 +141,11 @@ Partition = collections.namedtuple('Partition', 'left middle right')
 
 def partition(cursor):
     """Returns a named three-tuple (left, middle, right).
-    
+
     left is a tuple of tokens left to the cursor.
     middle is the token that overlaps the cursor at both sides (or None).
     right is a tuple of tokens right to the cursor.
-    
+
     """
     block = cursortools.block(cursor)
     t = tokens(block)

--- a/frescobaldi_app/unicode_blocks.py
+++ b/frescobaldi_app/unicode_blocks.py
@@ -73,7 +73,7 @@ block_data = """\
 # Note:   When comparing block names, casing, whitespace, hyphens,
 #         and underbars are ignored.
 #         For example, "Latin Extended-A" and "latin extended a" are equivalent.
-#         For more information on the comparison of property values, 
+#         For more information on the comparison of property values,
 #            see UAX #44: http://www.unicode.org/reports/tr44/
 #
 #  All code points not explicitly listed for Block

--- a/frescobaldi_app/userguide/__init__.py
+++ b/frescobaldi_app/userguide/__init__.py
@@ -25,9 +25,9 @@ The Frescobaldi User Manual.
 
 def show(name=None):
     """Display the help browser and the specified help page.
-    
+
     If no name is given, just display the browser.
-    
+
     """
     global _browser
     try:
@@ -39,10 +39,10 @@ def show(name=None):
 
 def addButton(box, name):
     """Adds a Help button to the specified QDialogButtonBox.
-    
+
     When clicked or F1 (the system standard help key) is pressed,
     the specified help page is opened.
-    
+
     """
     from PyQt5.QtGui import QKeySequence
     from PyQt5.QtWidgets import QDialogButtonBox

--- a/frescobaldi_app/userguide/browser.py
+++ b/frescobaldi_app/userguide/browser.py
@@ -44,10 +44,10 @@ class Window(QMainWindow):
     def __init__(self):
         super(Window, self).__init__()
         self.setAttribute(Qt.WA_QuitOnClose, False)
-        
+
         self.browser = Browser(self)
         self.setCentralWidget(self.browser)
-        
+
         self._toolbar = tb = self.addToolBar('')
         self._back = tb.addAction(icons.get('go-previous'), '')
         self._forw = tb.addAction(icons.get('go-next'), '')
@@ -59,22 +59,22 @@ class Window(QMainWindow):
         self._home.triggered.connect(self.home)
         self._toc.triggered.connect(self.toc)
         self._print.triggered.connect(self.print_)
-        
+
         self.browser.sourceChanged.connect(self.slotSourceChanged)
         self.browser.historyChanged.connect(self.slotHistoryChanged)
         app.translateUI(self)
         self.loadSettings()
-    
+
     def closeEvent(self, ev):
         self.saveSettings()
         super(Window, self).closeEvent(ev)
-        
+
     def loadSettings(self):
         self.resize(QSettings().value("helpbrowser/size", QSize(400, 300), QSize))
-    
+
     def saveSettings(self):
         QSettings().setValue("helpbrowser/size", self.size())
-    
+
     def translateUI(self):
         self.setCaption()
         self._toolbar.setWindowTitle(_("Toolbar"))
@@ -83,10 +83,10 @@ class Window(QMainWindow):
         self._home.setText(_("Start"))
         self._toc.setText(_("Contents"))
         self._print.setText(_("Print"))
-        
+
     def slotSourceChanged(self):
         self.setCaption()
-    
+
     def setCaption(self):
         title = self.browser.documentTitle() or _("Help")
         self.setWindowTitle(app.caption(title) + " " + _("Help"))
@@ -94,13 +94,13 @@ class Window(QMainWindow):
     def slotHistoryChanged(self):
         self._back.setEnabled(self.browser.isBackwardAvailable())
         self._forw.setEnabled(self.browser.isForwardAvailable())
-    
+
     def home(self):
         self.displayPage('index')
-        
+
     def toc(self):
         self.displayPage('toc')
-    
+
     def displayPage(self, name=None):
         """Opens the help browser showing the specified help page."""
         if name:
@@ -108,7 +108,7 @@ class Window(QMainWindow):
         self.show()
         self.activateWindow()
         self.raise_()
-    
+
     def print_(self):
         printer = QPrinter()
         dlg = QPrintDialog(printer, self)
@@ -129,21 +129,21 @@ class Browser(QTextBrowser):
         app.settingsChanged.connect(self.reload, 1)
         self.anchorClicked.connect(self.slotAnchorClicked)
         self.setOpenLinks(False)
-        
+
     def slotAnchorClicked(self, url):
         url = self.source().resolved(url)
         if url.scheme() == "help":
             self.setSource(url)
         else:
             helpers.openUrl(url)
-        
+
     def loadResource(self, type, url):
         if type == QTextDocument.HtmlResource:
             return util.Formatter().html(url.path())
         elif type == QTextDocument.ImageResource:
             url = QUrl.fromLocalFile(os.path.join(__path__[0], url.path()))
         return super(Browser, self).loadResource(type, url)
-    
+
     def keyPressEvent(self, ev):
         if ev.key() == Qt.Key_Escape and int(ev.modifiers()) == 0:
             self.window().close()

--- a/frescobaldi_app/userguide/export.py
+++ b/frescobaldi_app/userguide/export.py
@@ -34,13 +34,13 @@ class Exporter(object):
     """Export userguide pages to other formats or destinations."""
     def __init__(self):
         self._pages = []
-    
+
     def add_page(self, name):
         """Add a help page. Return True if the page was not already added."""
         if name not in self._pages:
             self._pages.append(name)
             return True
-    
+
     def add_recursive(self, name):
         """Add a help page and its child pages recursively."""
         def add(name):
@@ -48,15 +48,15 @@ class Exporter(object):
                 for c in util.cache.children(name):
                     add(c)
         add(name)
-    
+
     def replace_links(self, text):
         """Alter links in the text to other help pages.
-        
+
         Calls replace_link() for every match of a HTML <a href...> construct.
-        
+
         """
         return re.sub(r'<a href="([^"])">', self.replace_link, re.I)
-    
+
     def replace_link(self, match):
         url = match.group(1)
         if '/' in url:

--- a/frescobaldi_app/userguide/page.py
+++ b/frescobaldi_app/userguide/page.py
@@ -41,7 +41,7 @@ class Page(object):
         self._name = None
         if name:
             self.load(name)
-    
+
     def load(self, name):
         """Parse and translate the named document."""
         self._name = name
@@ -51,20 +51,20 @@ class Page(object):
             doc, attrs = read.document('404')
         attrs.setdefault('VARS', []).append('userguide_page md `{0}`'.format(name))
         self.parse_text(doc, attrs)
-        
+
     def parse_text(self, text, attrs=None):
         """Parse and translate the document."""
         self._attrs = attrs or {}
         t = self._tree = simplemarkdown.Tree()
         read.Parser().parse(text, t)
-    
+
     def is_popup(self):
         """Return True if the helppage should be displayed as a popup."""
         try:
             return 'popup' in self._attrs['PROPERTIES']
         except KeyError:
             return False
-    
+
     def title(self):
         """Return the title"""
         if self._title is None:
@@ -73,7 +73,7 @@ class Page(object):
                 self._title = self._tree.text(heading)
                 break
         return self._title
-    
+
     def body(self):
         """Return the HTML body."""
         if self._body is None:
@@ -85,25 +85,25 @@ class Page(object):
             html = html.replace('<p></p>', '')
             self._body = html
         return self._body
-        
+
     def children(self):
         """Return the list of names of child documents."""
         return self._attrs.get("SUBDOCS") or []
-    
+
     def seealso(self):
         """Return the list of names of "see also" documents."""
         return self._attrs.get("SEEALSO") or []
-    
+
 
 class HtmlOutput(simplemarkdown.HtmlOutput):
     """Colorizes LilyPond source and replaces {variables}.
-    
+
     Put a Resolver instance in the resolver attribute before populating
     the output.
-    
+
     """
     heading_offset = 1
-    
+
     def code_start(self, code, specifier=None):
         if specifier == "lilypond":
             import highlight2html
@@ -112,13 +112,13 @@ class HtmlOutput(simplemarkdown.HtmlOutput):
             self.tag('code')
             self.tag('pre')
             self.text(code)
-    
+
     def code_end(self, code, specifier=None):
         if specifier != "lilypond":
             self.tag('/pre')
             self.tag('/code')
         self.nl()
-    
+
     def inline_text_start(self, text):
         text = self.html_escape(text)
         text = self.resolver.format(text)   # replace {variables} ...
@@ -129,10 +129,10 @@ class Resolver(object):
     """Resolves variables in help documents."""
     def __init__(self, variables=None):
         """Initialize with a list of variables from the #VARS section.
-        
+
         Every item is simply a line, where the first word is the name,
         the second the type and the rest is the contents.
-        
+
         """
         self._variables = d = {}
         if variables:
@@ -142,30 +142,30 @@ class Resolver(object):
                 except ValueError:
                     continue
                 d[name] = (type, text)
-    
+
     def format(self, text):
         """Replaces all {variable} items in the text."""
         return read._variable_re.sub(self.replace, text)
-        
+
     def replace(self, matchObj):
         """Return the replace string for the match.
-        
+
         For a match like {blabla}, self.resolve('blabla') is called, and if
         the result is not None, '{blabla}' is replaced with the result.
-        
+
         """
         result = self.resolve(matchObj.group(1))
         return matchObj.group() if result is None else result
-    
+
     def resolve(self, name):
         """Try to find the value for the named variable.
-        
+
         First, the #VARS section is searched. If that yields no result,
         the named function in the resolve module is called. If that yields
         no result either, None is returned.
-        
+
         """
-        
+
         try:
             typ, text = self._variables[name]
         except KeyError:
@@ -186,7 +186,7 @@ class Resolver(object):
     def handle_html(self, text):
         """Return text as is, it may contain HTML."""
         return text
-    
+
     def handle_text(self, text):
         """Return text escaped, it will not be represented as HTML."""
         return simplemarkdown.html_escape(text)
@@ -216,17 +216,17 @@ class Resolver(object):
         seq = action.shortcut()
         key = seq.toString(QKeySequence.NativeText) or _("(no key defined)")
         return '<span class="shortcut">{0}</span>'.format(simplemarkdown.html_escape(key))
-    
+
     def handle_menu(self, text):
         """Split the text on '->' in menu or action titles and translate them.
-        
+
         The pieces are then formatted as a nice menu path.
         When an item contains a "|", the part before the "|" is the message
         context.
-        
+
         When an item starts with "!", the accelerators are not removed (i.e.
         it is not an action or menu name).
-        
+
         """
         pieces = [name.strip() for name in text.split('->')]
         import qutil
@@ -261,10 +261,10 @@ class Resolver(object):
             if removeAccel:
                 translation = qutil.removeAccelerator(translation).strip('.')
             return translation
-            
+
         translated = [title(name) for name in pieces]
         return '<em>{0}</em>'.format(' &#8594; '.join(translated))
-        
+
     def handle_image(self, filename):
         url = simplemarkdown.html_escape(filename).replace('"', '&quot;')
         return '<img src="{0}" alt="{0}"/>'.format(url)

--- a/frescobaldi_app/userguide/read.py
+++ b/frescobaldi_app/userguide/read.py
@@ -34,11 +34,11 @@ _document_split_re = re.compile(r'^#([A-Z]\w+)\s*$', re.MULTILINE)
 
 def split_document(s):
     """Split the help page text and its #SUBDOCS and other headers.
-    
+
     Returns a tuple consisting of the document text and a dictionary
     representing the #-named blocks; every value is the content of the block
     with a list of lines for every block.
-    
+
     """
     l = _document_split_re.split(s)
     i = iter(l[1:])
@@ -74,14 +74,14 @@ class Parser(simplemarkdown.Parser):
                     result.append(self.probably_translate(tx))
             if None not in result:
                 super(Parser, self).parse_inline_text(''.join(result))
-    
+
     def probably_translate(self, s):
         """Translates the string if it is a sensible translatable message.
-        
+
         The string is not translated if it does not contain any letters
         or if it is is a Python format string without any text outside the
         variable names.
-        
+
         """
         pos = 0
         for m in _variable_re.finditer(s):

--- a/frescobaldi_app/userguide/util.py
+++ b/frescobaldi_app/userguide/util.py
@@ -36,10 +36,10 @@ class Formatter(object):
         """Return a full userguide page HTML."""
         page = Page(name)
         from appinfo import appname, version
-        
+
         parents = cache.parents(name) if name != 'index' else []
         children = cache.children(name)
-        
+
         qt_detail = '<qt type=detail>' if page.is_popup() else ''
         title = page.title()
         nav_up = ''
@@ -61,7 +61,7 @@ class Formatter(object):
                 '\n'.join('<li>{0}</li>'.format(self.format_link(c))
                 for c in children))
         else:
-            # add navigation to next page, or if last page, to next page in 
+            # add navigation to next page, or if last page, to next page in
             # the first parent document that has a next page.
             html = []
             def sibling(parent, name):
@@ -95,16 +95,16 @@ class Formatter(object):
     def format_link(self, name):
         """Make a clickable link to the page."""
         return format_link(name)
-    
+
     def markexternal(self, text):
         """Marks http(s)/ftp(s) links as external with an arrow."""
         return markexternal(text)
-    
+
     def _html_template(self):
         """Return the userguide html template to render the html().
-        
+
         The default implementation returns _userguide_html_template.
-        
+
         """
         return _userguide_html_template
 
@@ -145,15 +145,15 @@ body {{
 
 class Cache(object):
     """Cache certain information about pages.
-    
+
     Just one instance of this is created and put in the cache global.
-    
+
     """
     def __init__(self):
         self._title = {}
         self._children = {}
         app.languageChanged.connect(lambda: self._title.clear(), -999)
-    
+
     def title(self, name):
         """Return the title of the named page."""
         try:
@@ -161,7 +161,7 @@ class Cache(object):
         except KeyError:
             t = self._title[name] = Page(name).title()
         return t
-    
+
     def children(self, name):
         """Return the list of children of the named page."""
         try:
@@ -169,7 +169,7 @@ class Cache(object):
         except KeyError:
             c = self._children[name] = Page(name).children()
         return c
-        
+
     def parents(self, name):
         """Return the list of parents (zero or more) of the named page."""
         try:
@@ -181,7 +181,7 @@ class Cache(object):
             return self._parents[name]
         except KeyError:
             return []
-    
+
     def _compute_parents(self):
         def _compute(n1):
             for n in self.children(n1):

--- a/frescobaldi_app/util.py
+++ b/frescobaldi_app/util.py
@@ -37,10 +37,10 @@ import variables
 
 def findexe(cmd, path=None):
     """Checks the PATH for the executable and returns the absolute path or None.
-    
+
     If path (a list or tuple of directory names) is given, it is searched as
     well when the operating system's PATH did not contain the executable.
-    
+
     """
     if os.path.isabs(cmd):
         return cmd if os.access(cmd, os.X_OK) else None
@@ -73,7 +73,7 @@ else:
     def equal_paths(p1, p2):
         """Returns True if the paths are equal."""
         return p1 == p2
-        
+
 
 # Make sure that also on Windows, directory slashes remain forward
 if os.name == 'nt':
@@ -128,17 +128,17 @@ def newer_files(files, time):
 
 def group_files(names, groups):
     """Groups the given filenames by extension.
-    
+
     names: an iterable (or list or tuple) yielding filenames.
     groups: an iterable (or list or tuple) yielding strings.
-    
+
     Each group is a string containing one or more extensions, without period,
     separated by a space. If a filename has one of the extensions in the group,
     the names is added to the list of file for that group.
     An exclamation sign at the beginning of the string negates the match.
-    
+
     Yields the same number of lists as there were group arguments.
-    
+
     """
     allgroups = []
     for group in groups:
@@ -158,9 +158,9 @@ def group_files(names, groups):
 
 def naturalsort(text):
     """Returns a key for the list.sort() method.
-    
+
     Intended to sort strings in a human way, for e.g. version numbers.
-    
+
     """
     return tuple(int(s) if s.isdigit() else s for s in re.split(r'(\d+)', text))
 
@@ -173,10 +173,10 @@ def filenamesort(filename):
 
 def next_file(filename):
     """Return a similar filename with e.g. "-1" added before the extension.
-    
+
     If there is already a "-n" before the extension, where n is a number,
     the number is increased by one.
-    
+
     """
     name, ext = os.path.splitext(filename)
     try:
@@ -191,15 +191,15 @@ def next_file(filename):
 
 def bytes_environ(encoding='latin1'):
     """Return the environment as a dictionary with bytes keys and values.
-    
+
     This can be used for subprocess, as it chokes on Windows on unicode strings
     in Python 2.x.
-    
+
     """
     return dict((s.encode(encoding) if type(s) is not type(b'') else s
                  for s in v) for v in os.environ.items())
 
-    
+
 def uniq(iterable):
     """Returns an iterable, removing duplicates. The items should be hashable."""
     s, l = set(), 0
@@ -212,12 +212,12 @@ def uniq(iterable):
 
 def get_bom(data):
     """Get the BOM mark of data, if any.
-    
-    A two-tuple is returned (encoding, data). If the data starts with a BOM 
-    mark, its encoding is determined and the BOM mark is stripped off. 
-    Otherwise, the returned encoding is None and the data is returned 
+
+    A two-tuple is returned (encoding, data). If the data starts with a BOM
+    mark, its encoding is determined and the BOM mark is stripped off.
+    Otherwise, the returned encoding is None and the data is returned
     unchanged.
-    
+
     """
     for bom, encoding in (
         (codecs.BOM_UTF8, 'utf-8'),
@@ -233,12 +233,12 @@ def get_bom(data):
 
 def decode(data, encoding=None):
     """Decode binary data, using encoding if specified.
-    
-    When the encoding can't be determined and isn't specified, it is tried to 
+
+    When the encoding can't be determined and isn't specified, it is tried to
     get the encoding from the document variables (see variables module).
-    
+
     Otherwise utf-8 and finally latin1 are tried.
-    
+
     """
     enc, data = get_bom(data)
     for e in (enc, encoding):
@@ -260,11 +260,11 @@ def decode(data, encoding=None):
 
 def encode(text, encoding=None, default_encoding='utf-8'):
     """Return the bytes representing the text, encoded.
-    
-    Looks at the specified encoding or the 'coding' variable to determine 
-    the encoding, otherwise falls back to the given default encoding, 
+
+    Looks at the specified encoding or the 'coding' variable to determine
+    the encoding, otherwise falls back to the given default encoding,
     defaulting to 'utf-8'.
-    
+
     """
     enc = encoding or variables.variables(text).get("coding")
     if enc:
@@ -282,9 +282,9 @@ def universal_newlines(text):
 
 def platform_newlines(text):
     """Convert newlines in text to the platform-specific newline.
-    
+
     On Unix/Linux/Mac OS X this is '\\n', on Windows '\\r\\n'.
-    
+
     """
     return universal_newlines(text).replace('\n', os.linesep)
 

--- a/frescobaldi_app/variables.py
+++ b/frescobaldi_app/variables.py
@@ -40,10 +40,10 @@ _LINES = 5      # how many lines from top and bottom to scan for variables
 
 def get(document, varname, default=None):
     """Get a single value from the document.
-    
+
     If a default is given and the type is bool or int, the value is converted to the same type.
     If no value exists, the default is returned.
-    
+
     """
     variables = manager(document).variables()
     try:
@@ -63,8 +63,8 @@ def update(document, dictionary):
 def manager(document):
     """Returns a VariableManager for this document."""
     return VariableManager.instance(document)
-    
-    
+
+
 def variables(text):
     """Reads variables from the first and last _LINES lines of text."""
     lines = text.splitlines()
@@ -75,35 +75,35 @@ def variables(text):
         start = count - _LINES
     d.update(m.group(1, 2) for n, m in positions(lines[start:]))
     return d
-    
-    
+
+
 class VariableManager(plugin.DocumentPlugin):
     """Caches variables in the document and monitors for changes.
-    
+
     The changed() Signal is emitted some time after the list of variables has been changed.
     It is recommended to not change the document itself in response to this signal.
-    
+
     """
     changed = signals.Signal() # without argument
-    
+
     def __init__(self, document):
         self._updateTimer = QTimer(singleShot=True, timeout=self.slotTimeout)
         self._variables = self.readVariables()
         document.contentsChange.connect(self.slotContentsChange)
         document.closed.connect(self._updateTimer.stop) # just to be sure
-    
+
     def slotTimeout(self):
         variables = self.readVariables()
         if variables != self._variables:
             self._variables = variables
             self.changed()
-        
+
     def slotContentsChange(self, position, removed, added):
         """Called if the document changes."""
         if (self.document().findBlock(position).blockNumber() < _LINES or
             self.document().findBlock(position + added).blockNumber() > self.document().blockCount() - _LINES):
             self._updateTimer.start(500)
-    
+
     def variables(self):
         """Returns the document variables (cached) as a dictionary. This method is recommended."""
         if self._updateTimer.isActive():
@@ -111,7 +111,7 @@ class VariableManager(plugin.DocumentPlugin):
             self._updateTimer.stop()
             self.slotTimeout()
         return self._variables
-    
+
     def readVariables(self):
         """Reads the variables from the document and returns a dictionary. Internal."""
         count = self.document().blockCount()
@@ -127,14 +127,14 @@ class VariableManager(plugin.DocumentPlugin):
         for block in blocks:
             variables.update(m.group(1, 2) for n, m in positions(lines(block)))
         return variables
-        
+
 
 def positions(lines):
     """Lines should be an iterable returning lines of text.
-    
+
     Returns an iterable yielding tuples (lineNum, matchObj) for every variable found.
     Every matchObj has group(1) pointing to the variable name and group(2) to the value.
-    
+
     """
     commentstart = ''
     interesting = False
@@ -168,9 +168,9 @@ def positions(lines):
 
 def prepare(value, default):
     """Try to convert the value (which is a string) to the type of the default value.
-    
+
     If (for int and bool) that fails, returns the default, otherwise returns the string unchanged.
-    
+
     """
     if isinstance(default, bool):
         if value.lower() in ('true', 'yes', 'on', 't', '1'):

--- a/frescobaldi_app/vcs/__init__.py
+++ b/frescobaldi_app/vcs/__init__.py
@@ -28,11 +28,11 @@ from .gitrepo import GitError
 
 def app_is_git_controlled():
     """Return True if Frescobaldi is running from Git.
-    
+
     This is done by checking for the presence of the .git/ directory.
     The function is very cheap, the directory test is only performed on the
     first call.
-        
+
     """
     global _app_is_git_controlled
     try:
@@ -49,7 +49,7 @@ def app_is_git_controlled():
             except (GitError, OSError) as error:
                 error_type = type(error).__name__
                 from PyQt5.QtWidgets import QMessageBox
-                QMessageBox.warning(None, 
+                QMessageBox.warning(None,
                                     _("Git not found"),
                                     _("Frescobaldi is run from within a Git "
                                       "repository, but Git does not appear "
@@ -75,14 +75,14 @@ if app_is_git_controlled():
 
 def app_active_branch_window_title():
     """Return the active branch, suitable as window title.
-    
+
     If the app is not git-controlled, the empty string is returned.
-    
+
     """
     if app_is_git_controlled():
         git_branch = app_repo.active_branch()
         return '({branch} [{remote}])'.format(
-                branch=git_branch, 
+                branch=git_branch,
                 remote=app_repo.tracked_remote_label(git_branch))
     return ''
 

--- a/frescobaldi_app/vcs/abstractrepo.py
+++ b/frescobaldi_app/vcs/abstractrepo.py
@@ -45,7 +45,7 @@ class AbstractVCSRepo(object):
     @abstractmethod
     def checkout(self, branch):
         pass
-        
+
     @abstractmethod
     def current_branch(self):
         """
@@ -60,7 +60,7 @@ class AbstractVCSRepo(object):
         Checks by actually running git branch.
         """
         pass
-    
+
     @abstractmethod
     def has_remote(self, remote):
         """Returns True if the given remote name is registered."""
@@ -73,7 +73,7 @@ class AbstractVCSRepo(object):
         is tracking a remote branch.
         """
         pass
-    
+
     @abstractmethod
     def remotes(self):
         """Return a string list with registered remote names"""
@@ -89,7 +89,7 @@ class AbstractVCSRepo(object):
         Return ('local', 'local') if it doesn't track any branch.
         """
         pass
-    
+
     @abstractmethod
     def tracked_remote_label(self, branch):
         """

--- a/frescobaldi_app/vcs/apprepo.py
+++ b/frescobaldi_app/vcs/apprepo.py
@@ -36,7 +36,7 @@ class AppRepo(GitRepo):
         super(AppRepo, self).__init__((os.path.normpath(
                                         os.path.join(sys.path[0], '..'))))
         self._activeBranch = self.current_branch()
-    
+
     def active_branch(self):
         """
         Returns the name of the branch that was current_branch

--- a/frescobaldi_app/vcs/gitrepo.py
+++ b/frescobaldi_app/vcs/gitrepo.py
@@ -30,7 +30,7 @@ from .abstractrepo import AbstractVCSRepo
 
 class GitError(Exception):
     pass
-    
+
 class GitRepo(AbstractVCSRepo):
     """
     Manage a git repository, be it
@@ -42,11 +42,11 @@ class GitRepo(AbstractVCSRepo):
             raise GitError(_("The given directory '{rootdir} "
                              "doesn't seem to be a Git repository.".format(rootdir=root)))
         self.rootDir = root
-    
+
     # #########################
     # Internal helper functions
-    
-    def _run_git_command(self, cmd, args = []): 
+
+    def _run_git_command(self, cmd, args = []):
         """
         run a git command and return its output
         as a string list.
@@ -106,7 +106,7 @@ class GitRepo(AbstractVCSRepo):
         If local is False also return 'remote' branches.
         """
         return self._branches(local)[0]
-        
+
     def checkout(self, branch):
         """
         Tries to checkout a branch.
@@ -114,7 +114,7 @@ class GitRepo(AbstractVCSRepo):
         return its confirmation message on stderr.
         May raise a GitError exception"""
         self._run_git_command('checkout', ['-q', branch])
-        
+
     def current_branch(self):
         """
         Returns the name of the current branch.
@@ -129,22 +129,22 @@ class GitRepo(AbstractVCSRepo):
         Returns True if the given local branch exists.
         """
         return (branch in self.branches(local=True))
-    
+
     def has_remote(self, remote):
         """Returns True if the given remote name is registered."""
         return remote in self.remotes()
-        
+
     def has_remote_branch(self, branch):
         """
         Return True if the given branch is tracking a remote branch.
         """
         remote, remote_branch = self.tracked_remote(branch)
         return (remote != "local" or remote_branch != "local")
-        
+
     def remotes(self):
         """Return a string list with registered remote names"""
         return self._run_git_command('remote', ['show'])
-        
+
     def tracked_remote(self, branch):
         """
         Return a tuple with the remote and branch tracked by
@@ -167,7 +167,7 @@ class GitRepo(AbstractVCSRepo):
         remote_merge = remote_merge[0]
         remote_branch = remote_merge[remote_merge.rfind('/')+1:]
         return (remote_name, remote_branch)
-    
+
     def tracked_remote_label(self, branch):
         """
         Returns a label for the tracked branch to be used in the GUI.

--- a/frescobaldi_app/vcs/menu.py
+++ b/frescobaldi_app/vcs/menu.py
@@ -36,27 +36,27 @@ class GitMenu(QMenu):
         super(GitMenu, self).__init__(mainwindow)
         self.aboutToShow.connect(self.populate)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setTitle(_('menu title', '&Git'))
-    
+
     def populate(self):
         self.clear()
         mainwindow = self.parentWidget()
         for a in GitBranchGroup.instance(mainwindow).actions():
             self.addAction(a)
-            
+
 
 class GitBranchGroup(plugin.MainWindowPlugin, QActionGroup):
     """
     Maintains a list of actions to switch the branch
     Frescobali is run from.
-    
+
     The actions are added to the Git menu in order to be able
     to switch the branch Frescobaldi is run from.
     The actions also get accelerators that are kept
     during their lifetime.
-    
+
     """
     def __init__(self, mainwindow):
         QActionGroup.__init__(self, mainwindow)
@@ -66,7 +66,7 @@ class GitBranchGroup(plugin.MainWindowPlugin, QActionGroup):
         for branch in vcs.app_repo.branches():
             self.addBranch(branch)
         self.triggered.connect(self.slotTriggered)
-    
+
     def actions(self):
         """
         Returns a list with actions for each branch.
@@ -106,7 +106,7 @@ class GitBranchGroup(plugin.MainWindowPlugin, QActionGroup):
             self._accels[branch] = ''
         name = name + " ({0})".format(vcs.app_repo.tracked_remote_label(branch))
         self._acts[branch].setText(name)
-    
+
     def slotTriggered(self, action):
         msgBox = QMessageBox()
         for branch, act in self._acts.items():

--- a/frescobaldi_app/view.py
+++ b/frescobaldi_app/view.py
@@ -46,14 +46,14 @@ metainfo.define('position', 0)
 
 class View(QPlainTextEdit):
     """View is the text editor widget a Document is displayed and edited with.
-    
+
     It is basically a QPlainTextEdit with some extra features:
     - it draws a grey cursor when out of focus
     - it reads basic palette colors from the preferences
     - it determines tab width from the document variables (defaulting to 8 characters)
     - it stores the cursor position in the metainfo
     - it runs the auto_indenter when enabled (also checked via metainfo)
-    
+
     """
     def __init__(self, document):
         """Create the View for the given document."""
@@ -77,16 +77,16 @@ class View(QPlainTextEdit):
 
     def event(self, ev):
         """General event handler.
-        
+
         This is reimplemented to:
-        
+
         - prevent inserting the hard line separator, which makes no sense in
           plain text
-        
+
         - prevent handling Undo and Redo, they work better via the menu actions
-          
+
         - handle Tab and Backtab to change the indent
-        
+
         """
         if ev in (
                 # avoid the line separator, makes no sense in plain text
@@ -133,14 +133,14 @@ class View(QPlainTextEdit):
 
     def keyPressEvent(self, ev):
         """Reimplemented to perform actions after a key has been pressed.
-        
+
         Currently handles:
-        
+
         - indent change on Enter, }, # or >
-        
+
         """
         super(View, self).keyPressEvent(ev)
-        
+
         if metainfo.info(self.document()).auto_indent:
             # run the indenter on Return or when the user entered a dedent token.
             import indent
@@ -150,7 +150,7 @@ class View(QPlainTextEdit):
                 # fix subsequent vertical moves
                 cursor.setPosition(cursor.position())
                 self.setTextCursor(cursor)
-            
+
     def focusOutEvent(self, ev):
         """Reimplemented to store the cursor position on focus out."""
         super(View, self).focusOutEvent(ev)
@@ -162,19 +162,19 @@ class View(QPlainTextEdit):
             ev.accept()
         else:
             super(View, self).dragEnterEvent(ev)
-        
+
     def dragMoveEvent(self, ev):
         """Reimplemented to avoid showing the cursor when dropping URLs."""
         if ev.mimeData().hasUrls():
             ev.accept()
         else:
             super(View, self).dragMoveEvent(ev)
-        
+
     def dropEvent(self, ev):
         """Called when something is dropped.
-        
+
         Calls dropEvent() of MainWindow if URLs are dropped.
-        
+
         """
         if ev.mimeData().hasUrls():
             self.window().dropEvent(ev)
@@ -190,15 +190,15 @@ class View(QPlainTextEdit):
                 color = self.palette().text().color()
                 color.setAlpha(128)
                 QPainter(self.viewport()).fillRect(rect, color)
-    
+
     def gotoTextCursor(self, cursor, numlines=3):
         """Go to the specified cursor.
-        
+
         If possible, at least numlines (default: 3) number of surrounding lines
         is shown. The number of surrounding lines can also be set in the
         preferences, under the key "view_preferences/context_lines". This
         setting takes precedence.
-        
+
         """
         numlines = QSettings().value("view_preferences/context_lines", numlines, int)
         if numlines > 0:
@@ -210,31 +210,31 @@ class View(QPlainTextEdit):
             c.movePosition(QTextCursor.Up, QTextCursor.MoveAnchor, numlines)
             self.setTextCursor(c)
         self.setTextCursor(cursor)
-    
+
     def readSettings(self):
         """Read preferences and adjust to those.
-        
+
         Called on init and when app.settingsChanged fires.
         Sets colors, font and tab width from the preferences.
-        
+
         """
         data = textformats.formatData('editor')
         self.setFont(data.font)
         self.setPalette(data.palette())
         self.setTabWidth()
-        
+
     def slotDocumentClosed(self):
         """Store the current cursor position in a document on close"""
         if self.hasFocus():
             self.storeCursor()
-            
+
     def restoreCursor(self):
         """Place the cursor on the position saved in metainfo."""
         cursor = QTextCursor(self.document())
         cursor.setPosition(metainfo.info(self.document()).position)
         self.setTextCursor(cursor)
         QTimer.singleShot(0, self.ensureCursorVisible)
-    
+
     def storeCursor(self):
         """Stores our cursor position in the metainfo."""
         metainfo.info(self.document()).position = self.textCursor().position()
@@ -244,7 +244,7 @@ class View(QPlainTextEdit):
         tabwidth = QSettings().value("indent/tab_width", 8, int)
         tabwidth = self.fontMetrics().width(" ") * variables.get(self.document(), 'tab-width', tabwidth)
         self.setTabStopWidth(tabwidth)
-    
+
     def contextMenuEvent(self, ev):
         """Called when the user requests the context menu."""
         cursor = self.textCursor()
@@ -281,7 +281,7 @@ class View(QPlainTextEdit):
             if definition.goto_definition(self.window(), clicked):
                 return
         super(View, self).mousePressEvent(ev)
-    
+
     def createMimeDataFromSelection(self):
         """Reimplemented to only copy plain text."""
         m = QMimeData()

--- a/frescobaldi_app/viewers/pointandclick.py
+++ b/frescobaldi_app/viewers/pointandclick.py
@@ -60,16 +60,16 @@ def links(document):
 
 class Links(pointandclick.Links):
     """Stores all the links of a Poppler document sorted by URL and text position.
-    
+
     Only textedit:// urls are stored.
-    
+
     """
     def cursor(self, link, load=False):
         """Returns the destination of a link as a QTextCursor of the destination document.
-        
+
         If load (defaulting to False) is True, the document is loaded if it is not yet loaded.
         Returns None if the url was not valid or the document could not be loaded.
-        
+
         """
         import popplerqt5
         if not isinstance(link, popplerqt5.Poppler.LinkBrowse) or not link.url():

--- a/frescobaldi_app/viewmanager.py
+++ b/frescobaldi_app/viewmanager.py
@@ -44,21 +44,21 @@ import qutil
 class ViewStatusBar(QWidget):
     def __init__(self, parent=None):
         super(ViewStatusBar, self).__init__(parent)
-        
+
         layout = QHBoxLayout()
         layout.setContentsMargins(2, 1, 0, 1)
         layout.setSpacing(8)
         self.setLayout(layout)
         self.positionLabel = QLabel()
         layout.addWidget(self.positionLabel)
-        
+
         self.stateLabel = QLabel()
         self.stateLabel.setFixedSize(16, 16)
         layout.addWidget(self.stateLabel)
-        
+
         self.infoLabel = QLabel(minimumWidth=10)
         layout.addWidget(self.infoLabel, 1)
-        
+
     def event(self, ev):
         if ev.type() == QEvent.MouseButtonPress:
             if ev.button() == Qt.RightButton:
@@ -73,7 +73,7 @@ class ViewStatusBar(QWidget):
         menu.aboutToHide.connect(menu.deleteLater)
         viewspace = self.parent()
         manager = viewspace.manager()
-        
+
         a = QAction(icons.get('view-split-top-bottom'), _("Split &Horizontally"), menu)
         menu.addAction(a)
         a.triggered.connect(lambda: manager.splitViewSpace(viewspace, Qt.Vertical))
@@ -85,30 +85,30 @@ class ViewStatusBar(QWidget):
         a.triggered.connect(lambda: manager.closeViewSpace(viewspace))
         a.setEnabled(manager.canCloseViewSpace())
         menu.addAction(a)
-        
+
         menu.exec_(pos)
 
 
 class ViewSpace(QWidget):
     """A ViewSpace manages a stack of views, one of them is visible.
-    
+
     The ViewSpace also has a statusbar, accessible in the status attribute.
     The viewChanged(View) signal is emitted when the current view for this ViewSpace changes.
-    
+
     Also, when a ViewSpace is created (e.g. when a window is created or split), the
     app.viewSpaceCreated(space) signal is emitted.
-    
+
     You can use the app.viewSpaceCreated() and the ViewSpace.viewChanged() signals to implement
     things on a per ViewSpace basis, e.g. in the statusbar of a ViewSpace.
-    
+
     """
     viewChanged = pyqtSignal(view_.View)
-    
+
     def __init__(self, manager, parent=None):
         super(ViewSpace, self).__init__(parent)
         self.manager = weakref.ref(manager)
         self.views = []
-        
+
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
@@ -120,20 +120,20 @@ class ViewSpace(QWidget):
         layout.addWidget(self.status)
         app.languageChanged.connect(self.updateStatusBar)
         app.viewSpaceCreated(self)
-        
+
     def activeView(self):
         if self.views:
             return self.views[-1]
 
     def document(self):
         """Returns the currently active document in this space.
-        
+
         If there are no views, returns None.
-        
+
         """
         if self.views:
             return self.views[-1].document()
-    
+
     def showDocument(self, doc):
         """Shows the document, creating a View if necessary."""
         if doc is self.document():
@@ -152,7 +152,7 @@ class ViewSpace(QWidget):
         self.connectView(view)
         self.stack.setCurrentWidget(view)
         self.updateStatusBar()
-        
+
     def removeDocument(self, doc):
         active = doc is self.document()
         if active:
@@ -168,7 +168,7 @@ class ViewSpace(QWidget):
             self.connectView(self.views[-1])
             self.stack.setCurrentWidget(self.views[-1])
             self.updateStatusBar()
-    
+
     def connectView(self, view):
         view.installEventFilter(self)
         view.cursorPositionChanged.connect(self.updateCursorPosition)
@@ -181,7 +181,7 @@ class ViewSpace(QWidget):
         view.cursorPositionChanged.disconnect(self.updateCursorPosition)
         view.modificationChanged.disconnect(self.updateModificationState)
         view.document().urlChanged.disconnect(self.updateDocumentName)
-    
+
     def eventFilter(self, view, ev):
         if ev.type() == QEvent.FocusIn:
             self.setActiveViewSpace()
@@ -189,14 +189,14 @@ class ViewSpace(QWidget):
 
     def setActiveViewSpace(self):
         self.manager().setActiveViewSpace(self)
-        
+
     def updateStatusBar(self):
         """Update all info in the statusbar, e.g. on document change."""
         if self.views:
             self.updateCursorPosition()
             self.updateModificationState()
             self.updateDocumentName()
-        
+
     def updateCursorPosition(self):
         cur = self.activeView().textCursor()
         line = cur.blockNumber() + 1
@@ -206,39 +206,39 @@ class ViewSpace(QWidget):
             column = cur.position() - cur.block().position()
         self.status.positionLabel.setText(_("Line: {line}, Col: {column}").format(
             line = line, column = column))
-    
+
     def updateModificationState(self):
         modified = self.document().isModified()
         pixmap = icons.get('document-save').pixmap(16) if modified else QPixmap()
         self.status.stateLabel.setPixmap(pixmap)
-    
+
     def updateDocumentName(self):
         self.status.infoLabel.setText(self.document().documentName())
 
 
 class ViewManager(QSplitter):
-    
+
     # This signal is always emitted on setCurrentDocument,
     # even if the view is the same as before.
     # use MainWindow.currentViewChanged() to be informed about
     # real View changes.
     viewChanged = pyqtSignal(view_.View)
-    
+
     # This signal is emitted when another ViewSpace becomes active.
     activeViewSpaceChanged = pyqtSignal(ViewSpace, ViewSpace)
-    
+
     def __init__(self, parent=None):
         super(ViewManager, self).__init__(parent)
         self._viewSpaces = []
-        
+
         viewspace = ViewSpace(self)
         viewspace.status.setEnabled(True)
         self.addWidget(viewspace)
         self._viewSpaces.append(viewspace)
-        
+
         self.createActions()
         app.documentClosed.connect(self.slotDocumentClosed)
-    
+
     def setCurrentDocument(self, doc, findOpenView=False):
         if doc is not self.activeViewSpace().document():
             done = False
@@ -257,10 +257,10 @@ class ViewManager(QSplitter):
             if not space.document():
                 space.showDocument(doc)
         self.focusActiveView()
-        
+
     def focusActiveView(self):
         self.activeViewSpace().activeView().setFocus()
-        
+
     def setActiveViewSpace(self, space):
         prev = self._viewSpaces[-1]
         if space is prev:
@@ -282,7 +282,7 @@ class ViewManager(QSplitter):
             for space in self._viewSpaces[:-1]:
                 if not space.document():
                     space.showDocument(activeDocument)
-            
+
     def createActions(self):
         self.actionCollection = ac = ViewActions()
         # connections
@@ -297,37 +297,37 @@ class ViewManager(QSplitter):
 
     def splitCurrentVertical(self):
         self.splitViewSpace(self.activeViewSpace(), Qt.Vertical)
-        
+
     def splitCurrentHorizontal(self):
         self.splitViewSpace(self.activeViewSpace(), Qt.Horizontal)
-        
+
     def closeCurrent(self):
         self.closeViewSpace(self.activeViewSpace())
-    
+
     def closeOthers(self):
         for space in self._viewSpaces[-2::-1]:
             self.closeViewSpace(space)
-    
+
     def nextViewSpace(self):
         self.focusNextChild()
-        
+
     def previousViewSpace(self):
         self.focusPreviousChild()
-        
+
     def activeViewSpace(self):
         return self._viewSpaces[-1]
-    
+
     def splitViewSpace(self, viewspace, orientation):
         """Split the given view.
-        
+
         If orientation == Qt.Horizontal, adds a new view to the right.
         If orientation == Qt.Vertical, adds a new view to the bottom.
-        
+
         """
         active = viewspace is self.activeViewSpace()
         splitter = viewspace.parentWidget()
         newspace = ViewSpace(self)
-        
+
         if splitter.count() == 1:
             splitter.setOrientation(orientation)
             size = splitter.sizes()[0]
@@ -353,7 +353,7 @@ class ViewManager(QSplitter):
             newspace.activeView().setFocus()
         self.actionCollection.window_close_view.setEnabled(self.canCloseViewSpace())
         self.actionCollection.window_close_others.setEnabled(self.canCloseViewSpace())
-        
+
     def closeViewSpace(self, viewspace):
         """Closes the given view."""
         active = viewspace is self.activeViewSpace()
@@ -388,7 +388,7 @@ class ViewManager(QSplitter):
             parent = splitter.parentWidget()
             sizes = parent.sizes()
             index = parent.indexOf(splitter)
-            
+
             if isinstance(other, ViewSpace):
                 parent.insertWidget(index, other)
             else:
@@ -404,11 +404,11 @@ class ViewManager(QSplitter):
         self._viewSpaces.remove(viewspace)
         self.actionCollection.window_close_view.setEnabled(self.canCloseViewSpace())
         self.actionCollection.window_close_others.setEnabled(self.canCloseViewSpace())
-        
+
     def canCloseViewSpace(self):
         return bool(self.count() > 1)
-        
-            
+
+
 
 
 class ViewActions(actioncollection.ActionCollection):
@@ -420,14 +420,14 @@ class ViewActions(actioncollection.ActionCollection):
         self.window_close_others = QAction(parent)
         self.window_next_view = QAction(parent)
         self.window_previous_view = QAction(parent)
-        
+
         # icons
         self.window_split_horizontal.setIcon(icons.get('view-split-top-bottom'))
         self.window_split_vertical.setIcon(icons.get('view-split-left-right'))
         self.window_close_view.setIcon(icons.get('view-close'))
         self.window_next_view.setIcon(icons.get('go-next-view'))
         self.window_previous_view.setIcon(icons.get('go-previous-view'))
-        
+
         # shortcuts
         self.window_close_view.setShortcut(Qt.CTRL + Qt.SHIFT + Qt.Key_W)
         self.window_next_view.setShortcuts(QKeySequence.NextChild)
@@ -442,4 +442,4 @@ class ViewActions(actioncollection.ActionCollection):
         self.window_close_others.setText(_("Close &Other Views"))
         self.window_next_view.setText(_("&Next View"))
         self.window_previous_view.setText(_("&Previous View"))
-    
+

--- a/frescobaldi_app/vimode/__init__.py
+++ b/frescobaldi_app/vimode/__init__.py
@@ -37,15 +37,15 @@ class ViMode(QObject):
     """Handles a Vi-like mode for a QPlainTextEdit."""
     def __init__(self, textedit=None):
         QObject.__init__(self)
-        
+
         # init all internal variables
         self._mode = None
         self._handlers = [None] * 4
         self._textedit = None
         self._originalCursorWidth = 1
-        
+
         self.setTextEdit(textedit)
-    
+
     def setTextEdit(self, edit):
         old = self._textedit
         if edit is old:
@@ -70,7 +70,7 @@ class ViMode(QObject):
 
     def textEdit(self):
         return self._textedit
-    
+
     def setMode(self, mode):
         """Sets the mode (NORMAL, VISUAL, INSERT or REPLACE)."""
         if mode is self._mode:
@@ -83,23 +83,23 @@ class ViMode(QObject):
             self._handlers[mode] = self.createModeHandler(mode)
         self.handler().enter()
         self.updateCursorPosition()
-    
+
     def mode(self):
         """Return the current mode (NORMAL, VISUAL, INSERT or REPLACE)."""
         return self._mode
-    
+
     def isNormal(self):
         return self._mode is NORMAL
-    
+
     def isVisual(self):
         return self._mode is VISUAL
-    
+
     def isInsert(self):
         return self._mode is INSERT
-    
+
     def isReplace(self):
         return self._mode is REPLACE
-    
+
     def createModeHandler(self, mode):
         """Returns a Handler for the specified mode."""
         if mode == NORMAL:
@@ -114,15 +114,15 @@ class ViMode(QObject):
         elif mode == REPLACE:
             from . import replace
             return replace.ReplaceMode(self)
-    
+
     def handler(self):
         """Returns the current mode handler."""
         return self._handlers[self._mode]
-        
+
     def updateCursorPosition(self):
         """If in command mode, shows a square cursor on the right spot."""
         self.handler().updateCursorPosition()
-    
+
     def drawCursor(self, cursor):
         """Draws the cursor position as the selection of the specified cursor."""
         es = QTextEdit.ExtraSelection()
@@ -144,7 +144,7 @@ class ViMode(QObject):
         return False
 
 
-            
+
 def test():
     a = QApplication([])
     e = QTextEdit()

--- a/frescobaldi_app/vimode/handlerbase.py
+++ b/frescobaldi_app/vimode/handlerbase.py
@@ -31,29 +31,29 @@ class Handler(object):
 
     def enter(self):
         """Called when the mode is entered."""
-    
+
     def leave(self):
         """Called when the mode is left."""
 
     def textCursor(self):
         """Returns the text cursor of the Q(Plain)TextEdit."""
         return self.vimode.textEdit().textCursor()
-    
+
     def setTextCursor(self, cursor):
         """Sets the text cursor of the Q(Plain)TextEdit."""
         self.vimode.textEdit().setTextCursor(cursor)
-        
+
     def handleKeyPress(self, ev):
         """Called when a key is pressed in this mode.
-        
+
         Should return True if the keypress is not to be handled anymore
         by the widget.
-        
+
         """
-    
+
     def updateCursorPosition(self):
         """Should redraw the cursor position."""
-    
+
     def setNormalMode(self):
         self.vimode.setMode(NORMAL)
 

--- a/frescobaldi_app/vimode/insert.py
+++ b/frescobaldi_app/vimode/insert.py
@@ -28,7 +28,7 @@ from . import handlerbase
 
 
 class InsertMode(handlerbase.Handler):
-    
+
     def enter(self):
         m = self.vimode
         m.textEdit().setCursorWidth(m._originalCursorWidth)

--- a/frescobaldi_app/vimode/normal.py
+++ b/frescobaldi_app/vimode/normal.py
@@ -37,10 +37,10 @@ class NormalMode(handlerbase.Handler):
         super(NormalMode, self).__init__(vimode)
         self._command = []
         self._count = 0
-        
+
     def enter(self):
         self.vimode.textEdit().setCursorWidth(0)
-    
+
     def updateCursorPosition(self):
         cursor = self.textCursor()
         if cursor.hasSelection() and cursor.position() > cursor.anchor():
@@ -65,11 +65,11 @@ class NormalMode(handlerbase.Handler):
             else:
                 self._count = 0
             return True
-        
+
         # TEMP
         if ev.text():
             self._command.append(ev.text())
-        
+
         cmd = ''.join(self._command)
         for s, f in commands:
             if re.compile(s).match(cmd):
@@ -77,10 +77,10 @@ class NormalMode(handlerbase.Handler):
                 self._count = 0
                 self._command = []
                 return True
-        
+
         return True
-    
-    
+
+
     def command(cmds, count=True, set_cursor=True):
         def decorator(func):
             def wrapper(self):
@@ -95,21 +95,21 @@ class NormalMode(handlerbase.Handler):
             for c in cmds:
                 commands.append((c, wrapper))
         return decorator
-    
+
     @command(['h', '<left>'])
     def move_left(self, cursor):
         if cursor.position() > cursor.block().position():
             cursor.movePosition(QTextCursor.PreviousCharacter)
-    
+
     @command(['l', '<right>'])
     def move_right(self, cursor):
         if cursor.position() < cursor.block().position() + cursor.block().length() - 2:
             cursor.movePosition(QTextCursor.NextCharacter)
-    
+
     @command('i', set_cursor=False)
     def insert_mode(self, cursor):
         self.setInsertMode()
-    
-    
-        
+
+
+
 

--- a/frescobaldi_app/widgets/__init__.py
+++ b/frescobaldi_app/widgets/__init__.py
@@ -36,7 +36,7 @@ class Separator(QFrame):
         self.setLineWidth(1)
         self.setMidLineWidth(0)
         self.setOrientation(Qt.Horizontal)
-        
+
     def setOrientation(self, orientation):
         if orientation == Qt.Vertical:
             self.setFrameShape(QFrame.VLine)
@@ -47,7 +47,7 @@ class Separator(QFrame):
             self.setFrameShadow(QFrame.Sunken)
             self.setMinimumSize(0, 2)
         self.updateGeometry()
-        
+
     def orientation(self):
         return Qt.Vertical if self.frameStyle() & QFrame.VLine == QFrame.VLine else Qt.Horizontal
 

--- a/frescobaldi_app/widgets/blink.py
+++ b/frescobaldi_app/widgets/blink.py
@@ -28,20 +28,20 @@ from PyQt5.QtWidgets import QWidget
 
 class Blinker(QWidget):
     """Can draw a blinking region above its parent widget."""
-    
+
     finished = pyqtSignal()
-    
+
     lineWidth = 3
     radius = 3
-    
+
     @classmethod
     def blink(cls, widget, rect=None, color=None):
         """Shortly blinks a rectangular region on a widget.
-        
+
         If rect is not given, the full rect() of the widget is used.
         If color is not given, the highlight color of the widget is used.
         This method instantiates a Blinker widget and discards it after use.
-        
+
         """
         window = widget.window()
         if rect is None:
@@ -62,14 +62,14 @@ class Blinker(QWidget):
         width = metrics.boundingRect("m").width()
         rect = textedit.cursorRect().normalized().adjusted(0, 0, width, 0)
         cls.blink(textedit, rect.translated(textedit.viewport().pos()), color)
-    
+
     def __init__(self, widget):
         """Initializes ourselves to draw on the widget."""
         super(Blinker, self).__init__(widget)
         self._color = None
         self._animation = ()
         self._timer = QTimer(singleShot=True, timeout=self._updateAnimation)
-        
+
     def start(self, rect):
         """Starts blinking the specified rectangle."""
         self._blink_rect = rect
@@ -78,39 +78,39 @@ class Blinker(QWidget):
         self.show()
         self._animation = self.animateColor()
         self._updateAnimation()
-        
+
     def done(self):
         """(Internal) Called when the animation ends."""
         self.hide()
         self._animation = ()
         self.finished.emit()
-    
+
     def _updateAnimation(self):
         for delta, self._color in self._animation:
             self.update()
             self._timer.start(delta)
             return
         self.done()
-        
+
     def animateColor(self):
         """A generator yielding tuples (msec_delta, color) to animate colors.
-        
+
         When the generator exits, the animation ends.
         The color is taken from the Highlight palette value.
-        
+
         """
         color = self.palette().color(QPalette.Highlight)
         for delta, alpha in self.animateAlpha():
             color.setAlpha(alpha)
             yield delta, color
-    
+
     def animateAlpha(self):
         """A generator yielding (msec_delta, alpha) tuples."""
         for alpha in (255, 0, 255, 0, 255):
             yield 120, alpha
         for alpha in range(255, 0, -15):
             yield 40, alpha
-    
+
     def paintEvent(self, ev):
         color = self._color
         if not color or color.alpha() == 0:

--- a/frescobaldi_app/widgets/charmap.py
+++ b/frescobaldi_app/widgets/charmap.py
@@ -36,7 +36,7 @@ class CharMap(QWidget):
     """A widget displaying a table of characters."""
     characterSelected = pyqtSignal(str)
     characterClicked = pyqtSignal(str)
-    
+
     def __init__(self, parent=None):
         super(CharMap, self).__init__(parent)
         self._showToolTips = True
@@ -46,20 +46,20 @@ class CharMap(QWidget):
         self._square = 24
         self._range = (0, 0)
         self._font = QFont()
-        
+
     def setRange(self, first, last):
         self._range = (first, last)
         self._selected = -1
         self.adjustSize()
         self.update()
-    
+
     def range(self):
         return self._range
-    
+
     def square(self):
         """Returns the width of one item (determined by font size)."""
         return self._square
-    
+
     def select(self, charcode):
         """Selects the specified character (int or str)."""
         if not isinstance(charcode, int):
@@ -70,47 +70,47 @@ class CharMap(QWidget):
             self._selected = charcode
             self.characterSelected.emit(chr(charcode))
             self.update()
-    
+
     def character(self):
         """Returns the currently selected character, if any."""
         if self._selected != -1:
             return chr(self._selected)
-    
+
     def setDisplayFont(self, font):
         self._font.setFamily(font.family())
         self.update()
-    
+
     def displayFont(self):
         return QFont(self._font)
-    
+
     def setDisplayFontSize(self, size):
         self._font.setPointSize(size)
         self._square = max(24, QFontMetrics(self._font).xHeight() * 3)
         self.adjustSize()
         self.update()
-    
+
     def displayFontSize(self):
         return self._font.pointSize()
-    
+
     def setDisplayFontSizeF(self, size):
         self._font.setPointSizeF(size)
         self._square = max(24, QFontMetrics(self._font).xHeight() * 3)
         self.adjustSize()
         self.update()
-    
+
     def displayFontSizeF(self):
         return self._font.pointSizeF()
-    
+
     def setColumnCount(self, count):
         """Sets how many columns should be used."""
         count = max(1, count)
         self._column_count = count
         self.adjustSize()
         self.update()
-    
+
     def columnCount(self):
         return self._column_count
-        
+
     def sizeHint(self):
         return self.sizeForColumnCount(self._column_count)
 
@@ -119,18 +119,18 @@ class CharMap(QWidget):
         s = self._square
         rows = range(rect.top() // s, rect.bottom() // s + 1)
         cols = range(rect.left() // s, rect.right() // s + 1)
-        
+
         painter = QPainter(self)
         painter.setPen(QPen(self.palette().color(QPalette.Window)))
         painter.setFont(self._font)
         metrics = QFontMetrics(self._font)
-        
+
         # draw characters on white tiles
         tile = self.palette().color(QPalette.Base)
         selected_tile = self.palette().color(QPalette.Highlight)
         selected_tile.setAlpha(96)
         selected_box = self.palette().color(QPalette.Highlight)
-        
+
         text_pen = QPen(self.palette().text().color())
         disabled_pen = QPen(self.palette().color(QPalette.Disabled, QPalette.Text))
         selection_pen = QPen(selected_box)
@@ -155,12 +155,12 @@ class CharMap(QWidget):
             else:
                 continue
             break
-    
+
     def sizeForColumnCount(self, count):
         """Returns the size the widget would have in a certain column count.
-        
+
         This can be used in e.g. a resizable scroll area.
-        
+
         """
         first, last = self._range
         rows = ((last - first) // count) + 1
@@ -176,14 +176,14 @@ class CharMap(QWidget):
             self.select(charcode)
             if ev.button() != Qt.RightButton:
                 self.characterClicked.emit(chr(charcode))
-    
+
     def charcodeRect(self, charcode):
         """Returns the rectangular box around the given charcode, if any."""
         if self._range[0] <= charcode <= self._range[1]:
             row, col = divmod(charcode - self._range[0], self._column_count)
             s = self._square
             return QRect(col * s, row * s, s, s)
-        
+
     def charcodeAt(self, position):
         row = position.y() // self._square
         col = position.x() // self._square
@@ -219,13 +219,13 @@ class CharMap(QWidget):
                     QWhatsThis.leaveWhatsThisMode()
             return True
         return super(CharMap, self).event(ev)
-    
+
     def getToolTipText(self, charcode):
         try:
             return unicodedata.name(chr(charcode))
         except ValueError:
             pass
-    
+
     def getWhatsThisText(self, charcode):
         try:
             name = unicodedata.name(chr(charcode))
@@ -233,16 +233,16 @@ class CharMap(QWidget):
             return
         return whatsthis_html.format(
             self._font.family(), chr(charcode), name, charcode)
-    
+
     def setShowToolTips(self, enabled):
         self._showToolTips = bool(enabled)
-    
+
     def showToolTips(self):
         return self._showToolTips
 
     def setShowWhatsThis(self, enabled):
         self._showWhatsThis = bool(enabled)
-    
+
     def showWhatsThis(self):
         return self._showWhatsThis
 

--- a/frescobaldi_app/widgets/colorbutton.py
+++ b/frescobaldi_app/widgets/colorbutton.py
@@ -31,23 +31,23 @@ from PyQt5.QtWidgets import (
 
 class ColorButton(QPushButton):
     """A PushButton displaying a color.
-    
+
     When clicked, opens a color dialog to change the color.
-    
+
     """
     colorChanged = pyqtSignal(QColor)
-    
+
     def __init__(self, parent=None):
         super(ColorButton, self).__init__(parent)
-        
+
         self.setFixedSize(self.sizeHint())
         self._color = QColor()
         self.clicked.connect(self.openDialog)
-    
+
     def color(self):
         """Returns the currently set color."""
         return self._color
-    
+
     def setColor(self, color):
         """Sets the current color. Maybe QColor() to indicate 'unset'."""
         if self._color != color:
@@ -58,7 +58,7 @@ class ColorButton(QPushButton):
     def clear(self):
         """Unsets the current color (setting it to QColor())."""
         self.setColor(QColor())
-        
+
     def openDialog(self):
         """Called when clicked, opens a dialog to change the color."""
         color = self._color if self._color.isValid() else QColor(Qt.white)

--- a/frescobaldi_app/widgets/completer.py
+++ b/frescobaldi_app/widgets/completer.py
@@ -29,22 +29,22 @@ from PyQt5.QtWidgets import QCompleter
 
 class Completer(QCompleter):
     """A QCompleter providing completions in a Q(Plain)TextEdit.
-    
+
     Use setWidget() to assign the completer to a text edit.
-    
+
     You can reimplement completionCursor() to make your own, other than simple
     string-based completions.
-    
+
     Call showCompletionPopup() to force the popup to show.
-    
+
     """
     autoComplete = True
     autoCompleteLength = 2
-    
+
     def __init__(self, *args, **kwargs):
         super(Completer, self).__init__(*args, **kwargs)
         self.activated[QModelIndex].connect(self.insertCompletion)
-        
+
     def eventFilter(self, obj, ev):
         if ev.type() != QEvent.KeyPress:
             return super(Completer, self).eventFilter(obj, ev)
@@ -84,46 +84,46 @@ class Completer(QCompleter):
             self.showCompletionPopup(False)
             return True
         return False
-    
+
     def isTextEvent(self, ev, visible):
         """Called when a key is pressed.
-        
+
         Should return True if the given KeyPress event 'ev' represents text that
         makes sense for showing the completions popup.
-        
+
         The 'visible' argument is True when the popup is currently visible.
-        
+
         """
         return ev.text()[-1:] > " " and ev.key() != Qt.Key_Delete
 
     def textCursor(self):
         """Returns the current text cursor of the TextEdit."""
         return self.widget().textCursor()
-        
+
     def completionCursor(self):
         """Should return a QTextCursor or None.
-        
+
         If a QTextCursor is returned, its selection is used as the completion
         prefix and its selectionStart() as the place to popup the popup.
-        
+
         This method may also alter the completion model.
-        
+
         """
         cursor = self.textCursor()
         cursor.movePosition(QTextCursor.StartOfWord, QTextCursor.KeepAnchor)
         return cursor
-    
+
     def showCompletionPopup(self, forced=True):
         """Shows the completion popup.
-        
+
         Calls completionCursor() to get the place where to popup, and that
         method may also alter the completion model.
-        
+
         If forced is True (the default) the popup is always shown (if it
         contains any entries). Otherwise it is only shown self.autoComplete is
         True and the cursor returned by completionCursor() has at least
         self.autoCompleteLength characters selected.
-        
+
         """
         cursor = self.completionCursor()
         if not cursor:
@@ -146,13 +146,13 @@ class Completer(QCompleter):
             rect.translate(-frameWidth, frameWidth + 2)
             rect.translate(-self.popup().viewport().pos())
             self.complete(rect)
-        
+
     def insertCompletion(self, index):
         """Inserts the completion at the given index.
-        
+
         The default implementation reads the model data under the Qt.EditRole,
         and inserts that with the (already entered) completionPrefix removed.
-        
+
         """
         text = self.completionModel().data(index, Qt.EditRole)
         text = text[len(self.completionPrefix()):]

--- a/frescobaldi_app/widgets/dialog.py
+++ b/frescobaldi_app/widgets/dialog.py
@@ -68,12 +68,12 @@ standardbuttons = {
 
 class Dialog(QDialog):
     """A Dialog with basic layout features:
-    
+
     a main widget,
     an icon or pixmap,
     a separator,
     buttons (provided by a QDialogButtonBox)
-    
+
     """
     def __init__(self,
                  parent = None,
@@ -88,9 +88,9 @@ class Dialog(QDialog):
                  help = None,
                  **kwargs):
         """Initializes the dialog.
-        
+
         parent = a parent widget or None.
-        
+
         The following keyword arguments are recognized:
         - message: the text to display in the message label
         - title: the window title
@@ -100,9 +100,9 @@ class Dialog(QDialog):
         - buttonOrientation: Qt.Horizontal (default) or Qt.Vertical
         - buttons: which buttons to use (default: Ok, Cancel)
         - help: function to call when a help button is clicked.
-        
+
         Other keyword arguments are passed to QDialog.
-        
+
         """
         super(Dialog, self).__init__(parent, **kwargs)
         self._icon = QIcon()
@@ -117,7 +117,7 @@ class Dialog(QDialog):
         layout = QGridLayout()
         layout.setSpacing(10)
         self.setLayout(layout)
-        
+
         # handle keyword args
         self._buttonOrientation = buttonOrientation
         self._iconSize = iconSize
@@ -132,37 +132,37 @@ class Dialog(QDialog):
         b.helpRequested.connect(help or self.helpRequest)
         self.setStandardButtons(buttons)
         self.reLayout()
-        
+
     def helpRequest(self):
         """Called when a help button is clicked."""
         pass
-    
+
     def setButtonOrientation(self, orientation):
         """Sets the button orientation.
-        
+
         Qt.Horizontal (default) puts the buttons at the bottom of the dialog
         in a horizontal row, Qt.Vertical puts the buttons at the right in a
         vertical column.
-        
+
         """
         if orientation != self._buttonOrientation:
             self._buttonOrientation = orientation
             self._buttonBox.setOrientation(orientation)
             self.reLayout()
-    
+
     def buttonOrientation(self):
         """Returns the button orientation."""
         return self._buttonOrientation
-        
+
     def setIcon(self, icon):
         """Sets the icon to display in the left area.
-        
+
         May be:
         - None or QIcon()
         - one of 'info', 'warning', 'critical', 'question'
         - a QStyle.StandardPixmap
         - a QIcon.
-        
+
         """
         if icon in standardicons:
             icon = standardicons[icon]
@@ -172,11 +172,11 @@ class Dialog(QDialog):
             icon = QIcon()
         self._icon = icon
         self.setPixmap(icon.pixmap(self._iconSize))
-    
+
     def icon(self):
         """Returns the currently set icon as a QIcon."""
         return self._icon
-        
+
     def setIconSize(self, size):
         """Sets the icon size (QSize or int)."""
         if isinstance(size, int):
@@ -185,11 +185,11 @@ class Dialog(QDialog):
         self._iconSize = size
         if changed and not self._icon.isNull():
             self.setPixmap(self._icon.pixmap(size))
-    
+
     def iconSize(self):
         """Returns the icon size (QSize)."""
         return self._iconSize
-        
+
     def setPixmap(self, pixmap):
         """Sets the pixmap to display in the left area."""
         changed = self._pixmap.isNull() != pixmap.isNull()
@@ -199,61 +199,61 @@ class Dialog(QDialog):
             self._pixmapLabel.setFixedSize(pixmap.size())
         if changed:
             self.reLayout()
-        
+
     def pixmap(self):
         """Returns the currently set pixmap."""
         return self._pixmap
-    
+
     def setMessage(self, text):
         """Sets the main text in the dialog."""
         self._messageLabel.setText(text)
-    
+
     def message(self):
         """Returns the main text."""
         return self._messageLabel.text()
-    
+
     def messageLabel(self):
         """Returns the QLabel displaying the message text."""
         return self._messageLabel
-        
+
     def buttonBox(self):
         """Returns our QDialogButtonBox instance."""
         return self._buttonBox
-    
+
     def setStandardButtons(self, buttons):
         """Convenience method to set standard buttons in the button box.
-        
+
         Accepts a sequence of string names from the standardbuttons constant,
         or a QDialogButtonBox.StandardButtons value.
-        
+
         """
         if isinstance(buttons, (set, tuple, list)):
             buttons = functools.reduce(operator.or_,
                 map(standardbuttons.get, buttons),
                 QDialogButtonBox.StandardButtons())
         self._buttonBox.setStandardButtons(buttons)
-    
+
     def button(self, button):
         """Returns the given button.
-        
+
         May be a QDialogButtonBox.StandardButton or a key from standardbuttons.
-        
+
         """
         if button in standardbuttons:
             button = standardbuttons[button]
         return self._buttonBox.button(button)
-    
+
     def setSeparator(self, enabled):
         """Sets whether to show a line between contents and buttons."""
         changed = self._separator != enabled
         self._separator = enabled
         if changed:
             self.reLayout()
-    
+
     def hasSeparator(self):
         """Returns whether a separator line is shown."""
         return self._separator
-        
+
     def setMainWidget(self, widget):
         """Sets the specified widget as our main widget."""
         old = self._mainWidget
@@ -261,17 +261,17 @@ class Dialog(QDialog):
             old.setParent(None)
         self._mainWidget = widget
         self.reLayout()
-    
+
     def mainWidget(self):
         """Returns the current main widget (an empty QWidget by default)."""
         return self._mainWidget
-    
+
     def reLayout(self):
         """(Internal) Lays out all items in this dialog."""
         layout = self.layout()
         while layout.takeAt(0):
             pass
-        
+
         if not self._pixmap.isNull():
             col = 1
             layout.addWidget(self._pixmapLabel, 0, 0, 2, 1)
@@ -279,7 +279,7 @@ class Dialog(QDialog):
             layout.setColumnStretch(1, 0)
             col = 0
         layout.setColumnStretch(col, 1)
-        self._pixmapLabel.setVisible(not self._pixmap.isNull())    
+        self._pixmapLabel.setVisible(not self._pixmap.isNull())
         layout.addWidget(self._messageLabel, 0, col)
         layout.addWidget(self._mainWidget, 1, col)
         if self._buttonOrientation == Qt.Horizontal:
@@ -300,27 +300,27 @@ class TextDialog(Dialog):
         self._validateFunction = None
         self.setMainWidget(QLineEdit())
         self.lineEdit().setFocus()
-    
+
     def lineEdit(self):
         """Returns the QLineEdit widget."""
         return self.mainWidget()
-    
+
     def setText(self, text):
         """Sets the text in the lineEdit()."""
         self.lineEdit().setText(text)
-    
+
     def text(self):
         """Returns the text in the lineEdit()."""
         return self.lineEdit().text()
-        
+
     def setValidateFunction(self, func):
         """Sets a function to run on every change in the lineEdit().
-        
+
         If the function returns True, the OK button is enabled, otherwise
         disabled.
-        
+
         If func is None, an earlier validate function will be removed.
-        
+
         """
         old = self._validateFunction
         self._validateFunction = func
@@ -331,15 +331,15 @@ class TextDialog(Dialog):
         elif old:
             self.lineEdit().textChanged.disconnect(self._validate)
             self.button('ok').setEnabled(True)
-    
+
     def setValidateRegExp(self, regexp):
         """Sets a regular expression the text must match.
-        
+
         If the regular expression matches the full text, the OK button is
         enabled, otherwise disabled.
-        
+
         If regexp is None, an earlier set regular expression is removed.
-        
+
         """
         validator = function = None
         if regexp is not None:
@@ -348,7 +348,7 @@ class TextDialog(Dialog):
             function = rx.exactMatch
         self.lineEdit().setValidator(validator)
         self.setValidateFunction(function)
-    
+
     def _validate(self, text):
         self.button('ok').setEnabled(self._validateFunction(text))
 

--- a/frescobaldi_app/widgets/growingtext.py
+++ b/frescobaldi_app/widgets/growingtext.py
@@ -38,26 +38,26 @@ class _GrowingTextEditBase(object):
         self.setLineWrapMode(self.NoWrap)
         self.document().documentLayout().documentSizeChanged.connect(self.updateVerticalSize)
         self.updateVerticalSize()
-        
+
     def updateVerticalSize(self):
         # can vertical or horizontal scrollbars appear?
         vcan = self.verticalScrollBarPolicy() == Qt.ScrollBarAsNeeded
         hcan = self.horizontalScrollBarPolicy() == Qt.ScrollBarAsNeeded
-        
+
         # width a scrollbar takes off the viewport size
         framewidth = 0
         if self.style().styleHint(QStyle.SH_ScrollView_FrameOnlyAroundContents, None, self):
             framewidth = self.style().pixelMetric(QStyle.PM_DefaultFrameWidth) * 2
         scrollbarextent = self.style().pixelMetric(QStyle.PM_ScrollBarExtent, None, self) + framewidth
-        
+
         margin = framewidth + self.document().documentMargin()
         size = self.documentSize() + QSize(margin, margin)
         width = size.width()
         height = size.height()
-        
+
         max_width = self.width()
         max_height = self.maximumHeight()
-        
+
         # will scrollbars appear?
         hwill, vwill = False, False
         if hcan and width > max_width:
@@ -71,11 +71,11 @@ class _GrowingTextEditBase(object):
         if hwill:
             height += scrollbarextent
         self.resize(self.width(), min(max_height, height))
-    
+
     def documentSize(self):
         """Implemented differently for QTextEdit and QPlainTextEdit."""
         raise NotImplementedError
-    
+
     def setLineWrapMode(self, mode):
         """Reimplemented to avoid WidgetWidth wrap mode, which causes resize loops."""
         if mode == self.WidgetWidth:

--- a/frescobaldi_app/widgets/imageviewer.py
+++ b/frescobaldi_app/widgets/imageviewer.py
@@ -36,16 +36,16 @@ DRAG = 2
 
 
 class ImageViewer(QScrollArea):
-    
+
     actualSizeChanged = pyqtSignal(bool)
-    
+
     def __init__(self, parent=None):
         super(ImageViewer, self).__init__(parent, alignment=Qt.AlignCenter)
         self._actualsize = True
         self._image = QImage()
         self.setBackgroundRole(QPalette.Dark)
         self.setWidget(ImageWidget(self))
-        
+
     def setActualSize(self, enabled=True):
         if enabled == self._actualsize:
             return
@@ -54,10 +54,10 @@ class ImageViewer(QScrollArea):
             self.widget().resize(self._image.size())
         self._actualsize = enabled
         self.actualSizeChanged.emit(enabled)
-    
+
     def actualSize(self):
         return self._actualsize
-    
+
     def setImage(self, image):
         self._image = image
         self._pixmap = None
@@ -65,10 +65,10 @@ class ImageViewer(QScrollArea):
         if self._actualsize:
             self.widget().resize(image.size())
         self.widget().update()
-    
+
     def image(self):
         return self._image
-        
+
     def pixmap(self, size):
         """Returns (and caches) a scaled pixmap for the image."""
         if self._pixmapsize == size:
@@ -77,7 +77,7 @@ class ImageViewer(QScrollArea):
             self._image.scaled(size, Qt.KeepAspectRatio, Qt.SmoothTransformation))
         self._pixmapsize = size
         return self._pixmap
-    
+
     def startDrag(self):
         image = self.image()
         data = QMimeData()
@@ -105,7 +105,7 @@ class ImageWidget(QWidget):
         self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Ignored)
         self._mode = None
         self._startpos = None
-    
+
     def paintEvent(self, ev):
         image = self.viewer.image()
         painter = QPainter(self)
@@ -126,7 +126,7 @@ class ImageWidget(QWidget):
             else:
                 self._mode = DRAG
             self._startpos = ev.globalPos()
-    
+
     def mouseMoveEvent(self, ev):
         diff = self._startpos - ev.globalPos()
         if self._mode == MOVE:
@@ -137,7 +137,7 @@ class ImageWidget(QWidget):
             v.setValue(v.value() + diff.y())
         elif self._mode == DRAG and diff.manhattanLength() >= QApplication.startDragDistance():
             self.viewer.startDrag()
-    
+
     def mouseReleaseEvent(self, ev):
         mode, self._mode = self._mode, None
         if (ev.button() == Qt.LeftButton and

--- a/frescobaldi_app/widgets/keysequencewidget.py
+++ b/frescobaldi_app/widgets/keysequencewidget.py
@@ -39,7 +39,7 @@ from . import ClearButton
 class KeySequenceWidget(QWidget):
 
     keySequenceChanged = pyqtSignal(int)
-    
+
     def __init__(self, parent=None, num=0):
         super(KeySequenceWidget, self).__init__(parent)
         self._num = num
@@ -47,27 +47,27 @@ class KeySequenceWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
         self.setLayout(layout)
-        
+
         self.button = KeySequenceButton(self)
         self.clearButton = ClearButton(self, iconSize=QSize(16, 16))
         layout.addWidget(self.button)
         layout.addWidget(self.clearButton)
-        
+
         self.clearButton.clicked.connect(self.clear)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.button.setToolTip(_("Start recording a key sequence."))
         self.clearButton.setToolTip(_("Clear the key sequence."))
-        
+
     def setShortcut(self, shortcut):
         """Sets the initial shortcut to display."""
         self.button.setKeySequence(shortcut)
-    
+
     def shortcut(self):
         """Returns the currently set key sequence."""
         return self.button.keySequence()
-        
+
     def clear(self):
         """Empties the displayed shortcut."""
         if self.button.isRecording():
@@ -78,16 +78,16 @@ class KeySequenceWidget(QWidget):
 
     def setModifierlessAllowed(self, allow):
         self.button._modifierlessAllowed = allow
-        
+
     def isModifierlessAllowed(self):
         return self.button._modifierlessAllowed
-    
+
     def num(self):
         return self._num
 
 
 class KeySequenceButton(QPushButton):
-    
+
     def __init__(self, parent=None):
         super(KeySequenceButton, self).__init__(parent)
         self.setIcon(icons.get("configure"))
@@ -107,7 +107,7 @@ class KeySequenceButton(QPushButton):
         if self._isrecording:
             self.doneRecording()
         return self._seq
-    
+
     def updateDisplay(self):
         if self._isrecording:
             s = self._recseq.toString(QKeySequence.NativeText).replace('&', '&&')
@@ -123,7 +123,7 @@ class KeySequenceButton(QPushButton):
 
     def isRecording(self):
         return self._isrecording
-        
+
     def event(self, ev):
         if self._isrecording:
             # prevent Qt from special casing Tab and Backtab
@@ -131,7 +131,7 @@ class KeySequenceButton(QPushButton):
                 self.keyPressEvent(ev)
                 return True
         return super(KeySequenceButton, self).event(ev)
-        
+
     def keyPressEvent(self, ev):
         if not self._isrecording:
             return super(KeySequenceButton, self).keyPressEvent(ev)
@@ -139,7 +139,7 @@ class KeySequenceButton(QPushButton):
             return
         modifiers = int(ev.modifiers() & (Qt.SHIFT | Qt.CTRL | Qt.ALT | Qt.META))
         ev.accept()
-        
+
         key = ev.key()
         # check if key is a modifier or a character key without modifier (and if that is allowed)
         if (
@@ -163,38 +163,38 @@ class KeySequenceButton(QPushButton):
 #                key = key | (modifiers & ~Qt.SHIFT)
             else:
                 key = key | modifiers
-            
+
             # append max. 4 keystrokes
             if self._recseq.count() < 4:
                 l = list(self._recseq)
                 l.append(key)
                 self._recseq = QKeySequence(*l)
-        
+
         self._modifiers = modifiers
         self.controlTimer()
         self.updateDisplay()
-        
+
     def keyReleaseEvent(self, ev):
         if not self._isrecording:
             return super(KeySequenceButton, self).keyReleaseEvent(ev)
         modifiers = int(ev.modifiers() & (Qt.SHIFT | Qt.CTRL | Qt.ALT | Qt.META))
         ev.accept()
-        
+
         self._modifiers = modifiers
         self.controlTimer()
         self.updateDisplay()
-    
+
     def hideEvent(self, ev):
         if self._isrecording:
             self.cancelRecording()
         super(KeySequenceButton, self).hideEvent(ev)
-        
+
     def controlTimer(self):
         if self._modifiers or self._recseq.isEmpty():
             self._timer.stop()
         else:
             self._timer.start(600)
-    
+
     def startRecording(self):
         self.setFocus(True) # because of QTBUG 17810
         self.setDown(True)
@@ -204,13 +204,13 @@ class KeySequenceButton(QPushButton):
         self._modifiers = int(QApplication.keyboardModifiers() & (Qt.SHIFT | Qt.CTRL | Qt.ALT | Qt.META))
         self.grabKeyboard()
         self.updateDisplay()
-        
+
     def doneRecording(self):
         self._seq = self._recseq
         self.cancelRecording()
         self.clearFocus()
         self.parentWidget().keySequenceChanged.emit(self.parentWidget().num())
-        
+
     def cancelRecording(self):
         if not self._isrecording:
             return

--- a/frescobaldi_app/widgets/lineedit.py
+++ b/frescobaldi_app/widgets/lineedit.py
@@ -41,7 +41,7 @@ class LineEdit(QLineEdit):
         self.textChanged.connect(self._updateClearButton)
         self._updateLayoutDirection()
         self._updateClearButton()
-    
+
     def _updateLayoutDirection(self):
         b = self._clearButton
         if self.layoutDirection() == Qt.RightToLeft:
@@ -50,7 +50,7 @@ class LineEdit(QLineEdit):
         else:
             self.setTextMargins(0, 0, b.width(), 0)
             b.setIcon(icons.get('edit-clear-locationbar-rtl'))
-        
+
     def _updateClearButton(self):
         b = self._clearButton
         if self.text():

--- a/frescobaldi_app/widgets/linenumberarea.py
+++ b/frescobaldi_app/widgets/linenumberarea.py
@@ -32,7 +32,7 @@ class LineNumberArea(QWidget):
         self._textedit = None
         self.setAutoFillBackground(True)
         self.setTextEdit(textedit)
-    
+
     def setTextEdit(self, edit):
         """Sets a QPlainTextEdit instance to show linenumbers for, or None."""
         if self._textedit:
@@ -46,11 +46,11 @@ class LineNumberArea(QWidget):
         else:
             self._width = 0
         self.update()
-        
+
     def textEdit(self):
         """Returns our QPlainTextEdit."""
         return self._textedit
-        
+
     def sizeHint(self):
         return QSize(self._width, 50)
 

--- a/frescobaldi_app/widgets/listedit.py
+++ b/frescobaldi_app/widgets/listedit.py
@@ -33,116 +33,116 @@ import icons
 
 class ListEdit(QWidget):
     """A widget to edit a list of items (e.g. a list of directories)."""
-    
+
     # emitted when anything changed in the listbox.
     changed = pyqtSignal()
-    
+
     def __init__(self, *args, **kwargs):
         QWidget.__init__(self, *args, **kwargs)
         layout = QGridLayout(self)
         self.setLayout(layout)
-        
+
         self.addButton = QPushButton(icons.get('list-add'), '')
         self.editButton = QPushButton(icons.get('document-edit'), '')
         self.removeButton = QPushButton(icons.get('list-remove'), '')
         self.listBox = QListWidget()
-        
+
         layout.setContentsMargins(1, 1, 1, 1)
         layout.setSpacing(0)
         layout.addWidget(self.listBox, 0, 0, 8, 1)
         layout.addWidget(self.addButton, 0, 1)
         layout.addWidget(self.editButton, 1, 1)
         layout.addWidget(self.removeButton, 2, 1)
-        
+
         @self.addButton.clicked.connect
         def addClicked():
             item = self.createItem()
             if self.openEditor(item):
                 self.addItem(item)
-                
+
         @self.editButton.clicked.connect
         def editClicked():
             item = self.listBox.currentItem()
             item and self.editItem(item)
-        
+
         @self.removeButton.clicked.connect
         def removeClicked():
             item = self.listBox.currentItem()
             if item:
                 self.removeItem(item)
-        
+
         @self.listBox.itemDoubleClicked.connect
         def itemDoubleClicked(item):
             item and self.editItem(item)
-            
+
         self.listBox.model().layoutChanged.connect(self.changed)
-    
+
         def updateSelection():
             selected = bool(self.listBox.currentItem())
             self.editButton.setEnabled(selected)
             self.removeButton.setEnabled(selected)
-        
+
         self.changed.connect(updateSelection)
         self.listBox.itemSelectionChanged.connect(updateSelection)
         updateSelection()
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.addButton.setText(_("&Add..."))
         self.editButton.setText(_("&Edit..."))
         self.removeButton.setText(_("&Remove"))
-    
+
     def createItem(self):
         return QListWidgetItem()
-        
+
     def addItem(self, item):
         self.listBox.addItem(item)
         self.itemChanged(item)
         self.changed.emit()
-        
+
     def removeItem(self, item):
         self.listBox.takeItem(self.listBox.row(item))
         self.changed.emit()
-        
+
     def editItem(self, item):
         if self.openEditor(item):
             self.itemChanged(item)
             self.changed.emit()
-            
+
     def setCurrentItem(self, item):
         self.listBox.setCurrentItem(item)
-        
+
     def setCurrentRow(self, row):
         self.listBox.setCurrentRow(row)
-        
+
     def openEditor(self, item):
         """Opens an editor (dialog) for the item.
-        
+
         Returns True if the dialog was accepted and the item edited.
         Returns False if the dialog was cancelled (the item must be left
         unedited).
         """
         pass
-    
+
     def itemChanged(self, item):
         """Called after an item has been added or edited.
-        
+
         Re-implement to do something at this moment if needed, e.g. alter the
         text or display of other items.
         """
         pass
-    
+
     def setValue(self, strings):
         """Sets the listbox to a list of strings."""
         self.listBox.clear()
         self.listBox.addItems(strings)
         self.changed.emit()
-        
+
     def value(self):
         """Returns the list of paths in the listbox."""
         return [self.listBox.item(i).text()
             for i in range(self.listBox.count())]
-    
+
     def setItems(self, items):
         """Sets the listbox to a list of items."""
         self.listBox.clear()
@@ -150,17 +150,17 @@ class ListEdit(QWidget):
             self.listBox.addItem(item)
             self.itemChanged(item)
         self.changed.emit()
-    
+
     def items(self):
         """Returns the list of items in the listbox."""
         return [self.listBox.item(i)
             for i in range(self.listBox.count())]
-        
+
     def clear(self):
         """Clears the listbox."""
         self.listBox.clear()
         self.changed.emit()
-        
+
 
 class FilePathEdit(ListEdit):
     """
@@ -168,7 +168,7 @@ class FilePathEdit(ListEdit):
     """
     def __init__(self, *args, **kwargs):
         super(FilePathEdit, self).__init__(*args, **kwargs)
-    
+
     def fileDialog(self):
         """The QFileDialog this widget is using."""
         try:
@@ -177,7 +177,7 @@ class FilePathEdit(ListEdit):
             self._filedialog = d = QFileDialog(self)
             d.setFileMode(QFileDialog.Directory)
             return d
-    
+
     def openEditor(self, item):
         """Asks the user for an (existing) directory."""
         directory = item.text()

--- a/frescobaldi_app/widgets/progressbar.py
+++ b/frescobaldi_app/widgets/progressbar.py
@@ -33,13 +33,13 @@ class TimedProgressBar(QProgressBar):
         self._timeline = QTimeLine(updateInterval=100, frameChanged=self.setValue)
         self._timeline.setFrameRange(0, 100)
         self._hideTimer = QTimer(timeout=self._done, singleShot=True, interval=3000)
-    
+
     def start(self, total, elapsed=0.0):
         """Starts showing progress.
-        
+
         total is the number of seconds (maybe float) the timeline will last,
         elapsed (defaulting to 0) is the value to start with.
-        
+
         """
         self._hideTimer.stop()
         self._timeline.stop()
@@ -49,14 +49,14 @@ class TimedProgressBar(QProgressBar):
         self._timeline.resume()
         if self.hideOnTimeout:
             self.show()
-        
+
     def stop(self, showFinished=True):
         """Ends the progress display.
-        
+
         If showFinished is True (the default), 100% is shown for a few
         seconds and then the progress is reset.
         The progressbar is hidden if the hideOnTimeout attribute is True.
-        
+
         """
         self._hideTimer.stop()
         self._timeline.stop()

--- a/frescobaldi_app/widgets/schemeselector.py
+++ b/frescobaldi_app/widgets/schemeselector.py
@@ -24,7 +24,7 @@ A widget that provides a scheme selector, with New and Remove buttons.
 
 from PyQt5.QtCore import QDir, QSettings, pyqtSignal, Qt
 from PyQt5.QtWidgets import (
-    QComboBox, QHBoxLayout, QInputDialog, QLabel, QPushButton, QWidget, 
+    QComboBox, QHBoxLayout, QInputDialog, QLabel, QPushButton, QWidget,
     QAction, QMenu, QFileDialog)
 
 import app
@@ -33,16 +33,16 @@ import os
 
 
 class SchemeSelector(QWidget):
-    
+
     currentChanged = pyqtSignal()
     changed = pyqtSignal()
-    
+
     def __init__(self, parent=None):
         super(SchemeSelector, self).__init__(parent)
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-        
+
         self.label = QLabel()
         self.scheme = QComboBox()
         self.menuButton = QPushButton(flat=True)
@@ -58,34 +58,34 @@ class SchemeSelector(QWidget):
             self.addAction(a)
             icon and a.setIcon(icons.get(icon))
             return a
-        
+
         # add action
         a = self.addAction_ = act(self.slotAdd, 'list-add')
         menu.addAction(a)
-        
+
         # remove action
         a = self.removeAction = act(self.slotRemove, 'list-remove')
         menu.addAction(a)
-        
-       
+
+
         # rename action
         a = self.renameAction = act(self.slotRename, 'document-edit')
         menu.addAction(a)
-        
+
         menu.addSeparator()
-        
+
         # import action
         a = self.importAction = act(self.slotImport, 'document-open')
         menu.addAction(a)
-        
+
         # export action
         a = self.exportAction = act(self.slotExport, 'document-save-as')
         menu.addAction(a)
-        
-        
+
+
         self.scheme.currentIndexChanged.connect(self.slotSchemeChanged)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.label.setText(_("Scheme:"))
         self.menuButton.setText(_("&Menu"))
@@ -94,25 +94,25 @@ class SchemeSelector(QWidget):
         self.renameAction.setText(_("Re&name..."))
         self.importAction.setText(_("&Import..."))
         self.exportAction.setText(_("&Export..."))
-        
+
     def slotSchemeChanged(self, index):
         """Called when the Scheme combobox is changed by the user."""
         self.disableDefault(self.scheme.itemData(index) == 'default')
         self.currentChanged.emit()
         self.changed.emit()
-    
+
     def disableDefault(self, val):
         self.removeAction.setDisabled(val)
         self.renameAction.setDisabled(val)
-    
+
     def schemes(self):
         """Returns the list with internal names of currently available schemes."""
         return [self.scheme.itemData(i) for i in range(self.scheme.count())]
-        
+
     def currentScheme(self):
         """Returns the internal name of the currently selected scheme"""
         return self.scheme.itemData(self.scheme.currentIndex())
-        
+
     def insertSchemeItem(self, name, scheme):
         for i in range(1, self.scheme.count()):
             n = self.scheme.itemText(i)
@@ -121,7 +121,7 @@ class SchemeSelector(QWidget):
                 break
         else:
             self.scheme.addItem(name, scheme)
-    
+
     def addScheme(self, name):
         num, key = 1, 'user1'
         while key in self.schemes() or key in self._schemesToRemove:
@@ -130,24 +130,24 @@ class SchemeSelector(QWidget):
         self.insertSchemeItem(name, key)
         self.scheme.setCurrentIndex(self.scheme.findData(key))
         return key
-    
+
     def slotAdd(self):
         name, ok = QInputDialog.getText(self,
             app.caption(_("Add Scheme")),
             _("Please enter a name for the new scheme:"))
         if ok:
             self.addScheme(name)
-        
-    
+
+
     def slotRemove(self):
         index = self.scheme.currentIndex()
         scheme = self.scheme.itemData(index)
         if scheme == 'default':
             return # default can not be removed
-        
+
         self._schemesToRemove.add(scheme)
         self.scheme.removeItem(index)
-    
+
     def slotRename(self):
         index = self.scheme.currentIndex()
         name = self.scheme.itemText(index)
@@ -160,14 +160,14 @@ class SchemeSelector(QWidget):
             self.scheme.setCurrentIndex(self.scheme.findData(scheme))
             self.scheme.blockSignals(False)
             self.changed.emit()
-           
+
     def slotImport(self):
         filetypes = "{0} (*.xml);;{1} (*)".format(_("XML Files"), _("All Files"))
         caption = app.caption(_("dialog title", "Import color theme"))
         filename = QFileDialog.getOpenFileName(self, caption, QDir.homePath(), filetypes)[0]
         if filename:
             self.parent().import_(filename)
-    
+
     def slotExport(self):
         name = self.scheme.currentText()
         filetypes = "{0} (*.xml);;{1} (*)".format(_("XML Files"), _("All Files"))
@@ -179,15 +179,15 @@ class SchemeSelector(QWidget):
             if os.path.splitext(filename)[1] != '.xml':
                 filename += '.xml'
             self.parent().export(name, filename)
-            
-    
+
+
     def loadSettings(self, currentKey, namesGroup):
         # don't mark schemes for removal anymore
         self._schemesToRemove = set()
-        
+
         s = QSettings()
         cur = s.value(currentKey, "default", str)
-        
+
         # load the names for the shortcut schemes
         s.beginGroup(namesGroup)
         block = self.scheme.blockSignals(True)
@@ -196,14 +196,14 @@ class SchemeSelector(QWidget):
         lst = [(s.value(key, key, str), key) for key in s.childKeys()]
         for name, key in sorted(lst, key=lambda f: f[0].lower()):
             self.scheme.addItem(name, key)
-        
+
         # find out index
         index = self.scheme.findData(cur)
         self.disableDefault(cur == 'default')
         self.scheme.setCurrentIndex(index)
         self.scheme.blockSignals(block)
         self.currentChanged.emit()
-        
+
     def saveSettings(self, currentKey, namesGroup, removePrefix=None):
         # first save new scheme names
         s = QSettings()
@@ -211,7 +211,7 @@ class SchemeSelector(QWidget):
         for i in range(self.scheme.count()):
             if self.scheme.itemData(i) != 'default':
                 s.setValue(self.scheme.itemData(i), self.scheme.itemText(i))
-        
+
         for scheme in self._schemesToRemove:
             s.remove(scheme)
         s.endGroup()

--- a/frescobaldi_app/widgets/shortcuteditdialog.py
+++ b/frescobaldi_app/widgets/shortcuteditdialog.py
@@ -36,23 +36,23 @@ from .keysequencewidget import KeySequenceWidget
 
 class ShortcutEditDialog(QDialog):
     """A modal dialog to view and/or edit keyboard shortcuts."""
-    
+
     def __init__(self, parent=None, conflictCallback=None, *cbArgs):
         """conflictCallback is a optional method called when a shortcut is changed.
-        
+
         cbArgs is optional arguments of the conflictCallback method.
         it should return the name of the potential conflict or a null value """
-        
+
         super(ShortcutEditDialog, self).__init__(parent)
         self.conflictCallback = conflictCallback
         self.cbArgs = cbArgs
         self.setMinimumWidth(400)
         # create gui
-        
+
         layout = QVBoxLayout()
         layout.setSpacing(10)
         self.setLayout(layout)
-        
+
         top = QHBoxLayout()
         top.setSpacing(4)
         p = self.toppixmap = QLabel()
@@ -64,7 +64,7 @@ class ShortcutEditDialog(QDialog):
         grid.setSpacing(4)
         grid.setColumnStretch(1, 2)
         layout.addLayout(grid)
-        
+
         self.buttonDefault = QRadioButton(self, toggled=self.slotButtonDefaultToggled)
         self.buttonNone = QRadioButton(self)
         self.lconflictDefault = QLabel('test')
@@ -75,7 +75,7 @@ class ShortcutEditDialog(QDialog):
         grid.addWidget(self.lconflictDefault, 1, 0, 1, 2)
         grid.addWidget(self.buttonNone, 2, 0, 1, 2)
         grid.addWidget(self.buttonCustom, 3, 0, 1, 2)
-        
+
         self.keybuttons = []
         self.keylabels = []
         self.conflictlabels = []
@@ -95,28 +95,28 @@ class ShortcutEditDialog(QDialog):
             self.conflictlabels.append(lconflict)
             lconflict.setVisible(False)
             grid.addWidget(lconflict, num+5+num, 0, 1, 2, Qt.AlignHCenter)
-        
+
         layout.addWidget(Separator(self))
-        
+
         b = QDialogButtonBox(self)
         b.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         layout.addWidget(b)
         b.accepted.connect(self.accept)
         b.rejected.connect(self.reject)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.setWindowTitle(app.caption(_("window title", "Edit Shortcut")))
         self.buttonNone.setText(_("&No shortcut"))
         self.buttonCustom.setText(_("Use a &custom shortcut:"))
         for num in range(4):
             self.keylabels[num].setText(_("Alternative #{num}:").format(num=num) if num else _("Primary shortcut:"))
-    
+
     def slotKeySequenceChanged(self, num):
         """Called when one of the keysequence buttons has changed."""
         self.checkConflict(num)
         self.buttonCustom.setChecked(True)
-    
+
     def slotButtonDefaultToggled(self, val):
         if self.conflictCallback is not None:
             if not val:
@@ -134,7 +134,7 @@ class ShortcutEditDialog(QDialog):
                         self.lconflictDefault.setText(text)
                         self.lconflictDefault.setVisible(True)
             QTimer.singleShot(0, self.adjustSize)
-                    
+
     def checkConflict(self, num):
         if self.conflictCallback is not None:
             conflictName = self.conflictCallback(self.keybuttons[num].shortcut(), *self.cbArgs)
@@ -146,7 +146,7 @@ class ShortcutEditDialog(QDialog):
             else:
                 self.conflictlabels[num].setVisible(False)
             QTimer.singleShot(0, self.adjustSize)
-     
+
     def editAction(self, action, default=None):
         # load the action
         self._action = action
@@ -167,14 +167,14 @@ class ShortcutEditDialog(QDialog):
                     self.checkConflict(num)
             else:
                 self.buttonNone.setChecked(True)
-            
+
         if default:
             ds = "; ".join(key.toString(QKeySequence.NativeText) for key in default)
         else:
             ds = _("no keyboard shortcut", "none")
         self.buttonDefault.setText(_("Use &default shortcut ({name})").format(name=ds))
         return self.exec_()
-        
+
     def done(self, result):
         if result:
             shortcuts = []

--- a/frescobaldi_app/widgets/tempobutton.py
+++ b/frescobaldi_app/widgets/tempobutton.py
@@ -35,10 +35,10 @@ class TempoButton(QToolButton):
     """A button the user can tap a tempo on.
 
     emits tempo(bpm) when the user clicks the button multiple times.
-    
+
     """
     tempo = pyqtSignal(int)
-    
+
     def __init__(self, icon=None, parent=None):
         super(TempoButton, self).__init__(parent)
         self.setIcon(icon or icons.get("media-record"))
@@ -47,7 +47,7 @@ class TempoButton(QToolButton):
         self.tapCount = 0
         self.pressed.connect(self.slotPressed)
         app.translateUI(self)
-        
+
     def translateUI(self):
         self.setToolTip(_("The tempo is set as you click this button."))
         self.setWhatsThis(_(

--- a/frescobaldi_app/widgets/treewidget.py
+++ b/frescobaldi_app/widgets/treewidget.py
@@ -27,20 +27,20 @@ from PyQt5.QtWidgets import QTreeWidget, QTreeWidgetItem
 
 class TreeWidget(QTreeWidget):
     """A QTreeWidget with some item-manipulation methods.
-    
+
     We use a widget instead of a view with a standard model because
     this lets us really have control over the items. With a standard
     model, items are recreated e.g. when dragging and this loses the
     python subclassed instances with their own parameters.
-    
+
     Calls the cleanup() method on QTreeWidgetItems as they are removed,
     but does not error out if the QTreeWidgetItem does not have a cleanup()
     method.
-    
+
     """
     def __init__(self, parent=None, **kws):
         super(TreeWidget, self).__init__(parent, **kws)
-    
+
     def items(self, parent=None):
         """Yields all items from parent or the invisibleRootItem."""
         if parent is None:
@@ -50,13 +50,13 @@ class TreeWidget(QTreeWidget):
             for i in self.items(c):
                 yield i
             yield c
-    
+
     def clear(self):
         """Removes all items, calling their cleanup() method (if available) first."""
         for item in self.items():
             self._cleanup(item)
         super(TreeWidget, self).clear()
-    
+
     def removeSelectedItems(self, item=None):
         """Removes all selected items from the specified item or the root item."""
         if item is None:
@@ -73,13 +73,13 @@ class TreeWidget(QTreeWidget):
                 self._cleanup(descendant)
             item.removeChild(child)
             self._cleanup(child)
-    
+
     def findSelectedItem(self, item=None):
         """Returns an item that has selected children, if any exists.
-        
+
         The item closest to the specified item or the root item that
         has selected children, is returned.
-        
+
         """
         if item is None:
             item = self.invisibleRootItem()
@@ -91,7 +91,7 @@ class TreeWidget(QTreeWidget):
             r = self.findSelectedItem(child)
             if r:
                 return r
-    
+
     def moveSelectedChildrenUp(self):
         item = self.findSelectedItem()
         if item:

--- a/frescobaldi_app/widgets/urlrequester.py
+++ b/frescobaldi_app/widgets/urlrequester.py
@@ -32,53 +32,53 @@ import icons
 
 class UrlRequester(QWidget):
     """Shows a lineedit and a button to select a file or directory.
-    
+
     The lineEdit, button, and fileDialog attributes represent their
     respective objects.
-    
+
     """
     changed = pyqtSignal()
-    
+
     def __init__(self, parent=None):
         super(UrlRequester, self).__init__(parent)
-        
+
         self._fileDialog = None
         self._dialogTitle = None
         self._fileMode = None
-        
+
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
         self.setLayout(layout)
-        
+
         self.lineEdit = QLineEdit()
         layout.addWidget(self.lineEdit)
         self.button = QToolButton(clicked=self.browse)
         layout.addWidget(self.button)
-        
+
         self.lineEdit.textChanged.connect(self.changed)
         self.setFileMode(QFileDialog.Directory)
         app.translateUI(self)
-    
+
     def translateUI(self):
         self.button.setToolTip(_("Open file dialog"))
-    
+
     def fileDialog(self, create = False):
         """Returns the QFileDialog, if already instantiated.
-        
+
         If create is True, the dialog is instantiated anyhow.
-        
+
         """
         if create and self._fileDialog is None:
             self._fileDialog = QFileDialog(self)
         return self._fileDialog
-            
+
     def setPath(self, path):
         self.lineEdit.setText(path)
-        
+
     def path(self):
         return self.lineEdit.text()
-        
+
     def setFileMode(self, mode):
         """Sets the mode for the dialog, is a QFileDialog.FileMode value."""
         if mode == QFileDialog.Directory:
@@ -86,18 +86,18 @@ class UrlRequester(QWidget):
         else:
             self.button.setIcon(icons.get('document-open'))
         self._fileMode = mode
-    
+
     def fileMode(self):
         return self._fileMode
-    
+
     def setDialogTitle(self, title):
         self._dialogTitle = title
         if self._fileDialog:
             self._fileDialog.setWindowTitle(title)
-    
+
     def dialogTitle(self):
         return self._dialogTitle
-        
+
     def browse(self):
         """Opens the dialog."""
         dlg = self.fileDialog(True)

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     maintainer_email = appinfo.maintainer_email,
     url = appinfo.url,
     license = appinfo.license,
-    
+
     scripts = scripts,
     packages = packages,
     package_data = package_data,

--- a/windows/freeze.py
+++ b/windows/freeze.py
@@ -47,7 +47,7 @@ includes = [
     'PyQt5.QtXml',
     'popplerqt5',
     'pypm',
-    
+
     '__future__',
     'argparse',
     'bisect',

--- a/windows/frescobaldi-wininst.py
+++ b/windows/frescobaldi-wininst.py
@@ -47,11 +47,11 @@ python = os.path.join(sys.exec_prefix, 'pythonw.exe') # because sys.executable p
 
 def install_association():
     """Installs a file association for the LilyPond file type.
-    
+
     Sets HKEY_CLASSES_ROOT\\LilyPond\\shell\\frescobaldi to 'Open with &Frescobaldi...'
     Sets HKEY_CLASSES_ROOT\\LilyPond\\shell\\frescobaldi\\command
         to '{python} "{script}" "%1"'
-    
+
     """
     key = winreg.CreateKey(winreg.HKEY_CLASSES_ROOT, "LilyPond\\shell\\frescobaldi")
     with key:
@@ -61,9 +61,9 @@ def install_association():
 
 def remove_association():
     """Removes the file association.
-    
+
     Removes HKEY_CLASSES_ROOT\\LilyPond\\shell\\frescobaldi
-    
+
     """
     try:
         key = winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, "LilyPond\\shell")
@@ -112,7 +112,7 @@ def shortcut(directory):
 def welcome():
     """Prints a nice welcome message in the installer."""
     print("\nWelcome to {0} {1}!".format(appinfo.appname, appinfo.version))
-    
+
 
 ### Main:
 if sys.argv[1] == '-install':


### PR DESCRIPTION
Relates to #917 

The sed command

for f in $(find . -print | grep \.py$); do sed -i 's/\s*$//g' $f; done

cleans all whitespace-only lines and removes trailing whitespace
throughout all the .py files in the repository

I suggest doing this for *all* currently published branches to have a consistent codebase without trailing whitespace.

The thing is only that we should provide tools to ensure that no trailing
whitespace gets back in in the future. Some editors don't clean up upon saving while others do. And particularly with Python there are often lines
filled with indents between function definitions.

I see two options:
a)
provide a pre-commit hook that cleans up *before*
committing. The problem is that this hook has to be installed manually
by any contributor (no way to automatically distribute it).
b) a pre-receive hook on Github that rejects pushes. Problem is that this may be quite off-putting for contributors.

Both could be accompanied by having a clean-up script available in the
repo that can easily be invoked, even by new contributors.

@wbsoft what do you think? I would volunteer doing this clean-up for all current branches, but it only makes sense if we establish a policy for later.