### PR TITLE
Add library path to LilyPond invocation

### DIFF
--- a/frescobaldi_app/engrave/command.py
+++ b/frescobaldi_app/engrave/command.py
@@ -84,6 +84,7 @@ def defaultJob(document, args=None):
     j.directory = os.path.dirname(filename)
     command.append(filename)
     j.command = command
+    j.environment['LD_LIBRARY_PATH'] = i.libdir()
     if s.value("no_translation", False, bool):
         j.environment['LANG'] = 'C'
         j.environment['LC_ALL'] = 'C'

--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -211,6 +211,7 @@ class Dialog(QDialog):
         j = job.Job()
         j.directory = os.path.dirname(filename)
         j.command = cmd
+        j.environment['LD_LIBRARY_PATH'] = i.libdir()
         if self.englishCheck.isChecked():
             j.environment['LANG'] = 'C'
             j.environment['LC_ALL'] = 'C'

--- a/frescobaldi_app/lilypondinfo.py
+++ b/frescobaldi_app/lilypondinfo.py
@@ -184,6 +184,17 @@ class LilyPondInfo(object):
         else:
             path = None
         return util.findexe(self.command, path) or False
+
+    #NOTE/TODO:
+    # This has only been tested for downloaded and self-compiled releases on Linux so far
+    @CachedProperty.cachedproperty(depends=abscommand)
+    def libdir(self):
+        exe = self.abscommand()
+        if exe:
+            parent = os.path.dirname(os.path.dirname(exe))
+            return os.path.join(parent, 'lib')
+        else:
+            return False
     
     @CachedProperty.cachedproperty(depends=abscommand)
     def displaycommand(self):


### PR DESCRIPTION
This will fix a long-standing annoyance - but is only implemented with downloaded and self-compiled versions on Linux. I assume distro packages will work as well (or don't need it anyway), but I have no idea about Mac and Win. Maybe the problem doesn't apply to them, but I want to wait for feedback on that before merging this PR.

Not adding this can cause compilation failures when the bundled versions of libraries (like Ghostscript) don't match the system-provided ones.