### PR TITLE
Update launch script for python 3

### DIFF
--- a/frescobaldi
+++ b/frescobaldi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 from frescobaldi_app import toplevel


### PR DESCRIPTION
Trying to package version 3.0.0 for fedora, I got an error because the launch script references python which executes python 2 by default.
