### PR TITLE
Add Ctrl + mouse hovering to display tooltips for include files

### DIFF
--- a/frescobaldi_app/open_file_at_cursor.py
+++ b/frescobaldi_app/open_file_at_cursor.py
@@ -26,8 +26,7 @@ Generate the include files' tooltips
 
 import os
 
-from PyQt5.QtCore import QUrl, Qt
-from PyQt5.QtGui import QTextCharFormat, QFont, QTextCursor  
+from PyQt5.QtCore import QUrl 
 
 import documentinfo
 import browseriface

--- a/frescobaldi_app/view.py
+++ b/frescobaldi_app/view.py
@@ -300,6 +300,7 @@ class View(QPlainTextEdit):
             self.showTooltip(ev.globalPos())
             
     def showTooltip(self, globalPos):
+        """Check the cursor's position. Show the tooltips while it meets the conditions"""
         localPos = self.mapFromGlobal(globalPos)
         blockheight = self.fontMetrics().height()
         contentstart = self.firstVisibleBlock().blockNumber()


### PR DESCRIPTION
I write this new version.

 A user will get a tooltip displaying the exact path of a include file when the mouse is hovering near the include file with the Ctrl button pressed. 

For invalid files it will display "This is an invalid include file"

![](http://ww1.sinaimg.cn/large/006KGMUcly1fffezntdl8g30dw08cwfo.gif)