### PR TITLE
WIP: Add "First system only" option to Engrave (Custom)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,10 @@ ChangeLog of Frescobaldi, http://www.frescobaldi.org/
 =====================================================
 
 
-Changes in 3.0.1 -- 
+Changes in 3.0.1 --
 
+* New features:
+  - New "First System Only" option in Custom Engrave
 * Bug fixes:
   - fixed #895 seeking in MIDI player during playing stops sound
 * Improvements:
@@ -16,8 +18,8 @@ Changes in 3.0.0 -- February 17th, 2017
 
 * New features:
   - Zoom with pinch gesture in Music View, contributed by David Rydh
-  - An option (enabled by default) to move the cursor to the end of the line 
-    when PageDown is pressed on the last line, and to move the cursor to the 
+  - An option (enabled by default) to move the cursor to the end of the line
+    when PageDown is pressed on the last line, and to move the cursor to the
     start of the first line if PageUp is pressed on the first line
 * Improvements:
   - Retina display support in Music View, contributed by David Rydh
@@ -82,7 +84,7 @@ Changes in 2.19.0 -- April 22nd, 2016
   - Autocompile was not triggered in some circumstances.
     Now it is also triggered:
     * when a document is saved
-    * when undoing a change after a save (i.e. the undo would reset the 
+    * when undoing a change after a save (i.e. the undo would reset the
       "modifified" flag of the document)
   - When tapping a tempo in the Score Wizard, it is now configurable whether
     a "common" metronome value is picked, or the exact tapped BPM (#792)

--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -84,7 +84,7 @@ class Dialog(QDialog):
         self.resolutionCombo.addItems(['100', '200', '300', '600', '1200'])
         self.resolutionCombo.setCurrentIndex(2)
 
-        self.modeCombo.addItems(['preview', 'publish', 'debug'])
+        self.modeCombo.addItems(['preview', 'publish', 'debug', 'incipit'])
         layout.addWidget(self.versionLabel, 0, 0)
         layout.addWidget(self.lilyChooser, 0, 1, 1, 3)
         layout.addWidget(self.outputLabel, 1, 0)
@@ -141,7 +141,8 @@ class Dialog(QDialog):
         self.modeLabel.setText(_("Engraving mode:"))
         self.modeCombo.setItemText(0, _("Preview"))
         self.modeCombo.setItemText(1, _("Publish"))
-        self.modeCombo.setItemText(2, _("Layout Control"))
+        self.modeCombo.setItemText(2, _("First System Only"))
+        self.modeCombo.setItemText(3, _("Layout Control"))
         self.deleteCheck.setText(_("Delete intermediate output files"))
         self.embedSourceCodeCheck.setText(_("Embed Source Code (LilyPond >= 2.19.39)"))
         self.englishCheck.setText(_("Run LilyPond with English messages"))
@@ -172,6 +173,8 @@ class Dialog(QDialog):
             cmd.append('-dpoint-and-click')
         elif self.modeCombo.currentIndex() == 1: # publish mode
             cmd.append('-dno-point-and-click')
+        elif self.modeCombo.currentIndex() == 2: # incipit mode
+            cmd.extend(['-dpreview', '-dno-print-pages'])
         else:                                    # debug mode
             args = panelmanager.manager(self.parent()).layoutcontrol.widget().preview_options()
             cmd.extend(args)


### PR DESCRIPTION
This is a preliminary Pull Request to have people test the feature and discuss before finishing it.

Addresses #724

Adds an entry "First System Only" to the "Engraving Mode" combo in the Engrave (Custom) dialog.
Please test and discuss the naming conventions used.

**Missing:** The compiled preview is *not* displayed in the Music View and only available through `LilyPond=>Generated Files`. A quick look into the code didn't tell me how to fix that as well.