### PR TITLE
WIP: Rewrite gitjob.Git() as a single-job class using Qt-style signals

### DIFF
--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -65,10 +65,15 @@ class Git(QObject):
         process.readyReadStandardOutput.connect(self.readyReadStandardOutput)
         process.started.connect(self.started)
         process.stateChanged.connect(self.stateChanged)
+
+        # Note: 
+        # Signal "errorOccurred" is listed as an attribute in QProcess in PyQt5
+        # And it is available in PyQt-5.8.2. Reference: https://stackoverflow.com/questions/44868741/is-qqueue-missing-from-pyqt-5
+        # It is still not available in our current development environment PyQt-5.5.1 
+        # So we use its obsolete version "error" 
         try:
             process.errorOccurred.connect(self.errorOccurred)
         except AttributeError:
-            # errorOccurred may not be supported 
             process.error.connect(self.errorOccurred)  
 
     def _start_process(self, args, isbinary=False):

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -81,7 +81,7 @@ class Git(QObject):
         """
         Internal command preparing and starting the Git process
         """
-        if args == None:
+        if args is None:
             raise Exception("Command 'args' is not specified")
         self._stderr = None
         self._stdout = None
@@ -101,7 +101,7 @@ class Git(QObject):
 
         Results will only be available after the _finished() slot has been executed
         """
-        args = self.preset_args if args == None else args   
+        args = self.preset_args if args is None else args   
         self._start_process(args, isbinary)
 
     def run_blocking(self, args = None, isbinary = False):
@@ -116,7 +116,7 @@ class Git(QObject):
 
         Results will be returned but are also available through stdout() and stderr() afterwards
         """
-        args = self.preset_args if args == None else args
+        args = self.preset_args if args is None else args
         self._start_process(args, isbinary)
         self._process.waitForFinished()
         return (self._stdout, self._stderr)

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -132,21 +132,6 @@ class Git(QObject):
             # Note: Qt handles the OS differences transparently
             self._process.kill()
 
-    def _tic(self):
-        """
-        Helper function to count how much time a git command takes
-        """
-        self._timer = time.perf_counter()
-
-    def _toc(self, args = []):
-        """
-        Helper function to count how much time a git command takes
-        """
-        if self._timer:
-            print('command git {} takes {}'.format(' '.join(args), 
-                time.perf_counter()-self._timer))
-            self._timer = None
-
     def _handle_results(self):
         """
         will be called when the process has completed.

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -34,7 +34,6 @@ class GitError(Exception):
     pass
 
 class Git(QObject):
-    done = pyqtSignal(bool)
 
     # "custom" signals for passing on QProcess's signals
     errorOccured(QProcess.ProcessError)

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -75,6 +75,8 @@ class Git(QObject):
         """
         Internal command preparing and starting the Git process
         """
+        if args == None:
+            raise Exception("Command 'args' is not specified")
         self._stderr = None
         self._stdout = None
         self._isbinary = isbinary
@@ -84,19 +86,31 @@ class Git(QObject):
     def run(self, args = None, isbinary=False):
         """
         Asynchronously run the command.
+        
+        Arguments:
+                  args([]): arguments of the Git command. 
+                            If 'args' is not given, 'preset_args' will be used.
+            isbinary(bool): True - return the binary result.
+                            False - return the 'utf-8' encoded string list.
+
         Results will only be available after the _finished() slot has been executed
         """
-        if args == None:
-            args = self.preset_args
-
-        # exception: args == None    
+        args = self.preset_args if args == None else args   
         self._start_process(args, isbinary)
 
-    def run_blocking(self, args, isbinary = False):
+    def run_blocking(self, args = None, isbinary = False):
         """
         Synchronously run the command.
+
+        Arguments:
+                  args([]): arguments of the Git command. 
+                            If 'args' is not given, 'preset_args' will be used.
+            isbinary(bool): True - return the binary result.
+                            False - return the 'utf-8' encoded string list.
+
         Results will be returned but are also available through stdout() and stderr() afterwards
         """
+        args = self.preset_args if args == None else args
         self._start_process(args, isbinary)
         self._process.waitForFinished()
         return (self._stdout, self._stderr)

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -24,7 +24,6 @@ run_blocking() will return the data while run() will invoke the finished signal,
 giving the caller the opportunity to retrieve the data.
 """
 
-import os
 import re
 import time
 

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -251,7 +251,7 @@ class GitJobQueue(QObject):
             # args of Git process has been set in advance
             self._queue[0].run() 
     
-    def killAll(self):
+    def kill_all(self):
         """
         Kill all the process this queue contains
         Will be used when the file has lost focus.
@@ -262,7 +262,7 @@ class GitJobQueue(QObject):
         self._queue.clear()
 
 
-    def _auto_run_next(self, execute_status):
+    def run_next(self, execute_status = 0):
         """
         To run next git process
         Triggered by the previous Git instance's executed signal.

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -20,7 +20,7 @@
 
 import re
 import time
-import collections 
+import collections
 
 from PyQt5.QtCore import QObject, QProcess, pyqtSignal
 
@@ -29,7 +29,7 @@ class Git(QObject):
     """Executes a single Git command, either blocking or non-blocking.
 
     The output of the command will be stored in the _stdout and _stderr fields,
-    run_blocking() will return the data while run() will invoke the finished 
+    run_blocking() will return the data while run() will invoke the finished
     signal, giving the caller the opportunity to retrieve the data.
     """
 
@@ -40,7 +40,7 @@ class Git(QObject):
     started = pyqtSignal()
     stateChanged = pyqtSignal(QProcess.ProcessState)
     errorOccurred = pyqtSignal(QProcess.ProcessError)
-    
+
     # emits when the receiver finish executing
     executed = pyqtSignal(int)
 
@@ -49,7 +49,7 @@ class Git(QObject):
         # TODO: check for preference
         executable = 'git'
         # args could be set in advance
-        self.preset_args = None 
+        self.preset_args = None
 
         self._version = None
         self._stderr = None
@@ -67,15 +67,15 @@ class Git(QObject):
         process.started.connect(self.started)
         process.stateChanged.connect(self.stateChanged)
 
-        # Note: 
+        # Note:
         # Signal "errorOccurred" is listed as an attribute in QProcess in PyQt5
         # And it is available in PyQt-5.8.2. Reference: https://stackoverflow.com/questions/44868741/is-qqueue-missing-from-pyqt-5
-        # It is still not available in our current development environment PyQt-5.5.1 
-        # So we use its obsolete version "error" 
+        # It is still not available in our current development environment PyQt-5.5.1
+        # So we use its obsolete version "error"
         try:
             process.errorOccurred.connect(self.errorOccurred)
         except AttributeError:
-            process.error.connect(self.errorOccurred)  
+            process.error.connect(self.errorOccurred)
 
     def _start_process(self, args):
         """
@@ -91,14 +91,14 @@ class Git(QObject):
     def run(self, args = None):
         """
         Asynchronously run the command.
-        
+
         Arguments:
-                  args([]): arguments of the Git command. 
+                  args([]): arguments of the Git command.
                             If 'args' is not given, 'preset_args' will be used.
 
         Results will only be available after the _finished() slot has been executed
         """
-        args = self.preset_args if args is None else args   
+        args = self.preset_args if args is None else args
         self._start_process(args)
 
     def run_blocking(self, args = None, isbinary = False):
@@ -106,7 +106,7 @@ class Git(QObject):
         Synchronously run the command.
 
         Arguments:
-                  args([]): arguments of the Git command. 
+                  args([]): arguments of the Git command.
                             If 'args' is not given, 'preset_args' will be used.
             isbinary(bool): True - return the binary result.
                             False - return the 'utf-8' encoded string list.
@@ -144,20 +144,20 @@ class Git(QObject):
         """
         Called when the process has completed.
         process results and forward the signal
-        
-        exitcode == 0 : Process executes successfully. 
+
+        exitcode == 0 : Process executes successfully.
                         Result will output to stdout().
         exitcode == 1 : Process returns an error message.
-                        Error message will output to stderr() 
-        """ 
+                        Error message will output to stderr()
+        """
         self._handle_results()
         self.finished.emit(self, exitcode)
 
     def stdout(self, isbinary = False):
         """
         Returns the content of the stdout output, if any.
-        
-        Returns: 
+
+        Returns:
             None: Git() is running / Git() hasn't started / Git() has crashed
              b'': isbinary is True.
                   Git() has finished running and returns a binary result.
@@ -166,7 +166,7 @@ class Git(QObject):
         """
         if self._stdout is None:
             return None
-        
+
         if isbinary:
             return self._stdout
         else:
@@ -176,7 +176,7 @@ class Git(QObject):
         """
         Returns the content of the stderr output, if any.
 
-        Returns: 
+        Returns:
             None: Git() is running / Git() hasn't started / Git() has crashed
              b'': isbinary is True.
                   Git() has finished running and returns a binary result.
@@ -185,7 +185,7 @@ class Git(QObject):
         """
         if self._stderr is None:
             return None
-        
+
         if isbinary:
             return self._stderr
         else:
@@ -207,7 +207,7 @@ class GitJobQueue(QObject):
     You may need this when you want to run some Git commands in order.
     Git() objects in the queue run one after another.  When an error occurrs
     during runing, GitJobQueue will stop running and emits an "errorOccurred"
-    signal. 
+    signal.
     """
 
     errorOccurred = pyqtSignal(QProcess.ProcessError)
@@ -217,21 +217,21 @@ class GitJobQueue(QObject):
         self._queue = collections.deque()
 
     def enqueue(self, gitjob):
-        """ 
+        """
         Appends a Git() object (gitjob) into the queue.
         If the queue is empty, the Git() object will run immediately.
 
-        CAUTION: 
+        CAUTION:
         enqueue a same Git() object multiple times will lead to a runtime-error.
-        """   
+        """
         gitjob.executed.connect(self.run_next)
-        gitjob.errorOccurred.connect(self.errorOccurred) 
+        gitjob.errorOccurred.connect(self.errorOccurred)
 
         self._queue.append(gitjob)
         if len(self._queue) == 1:
             # args of Git process has been set in advance
-            self._queue[0].run() 
-    
+            self._queue[0].run()
+
     def kill_all(self):
         """
         Kills and removes all the Git() objects this queue contains
@@ -260,11 +260,5 @@ class GitJobQueue(QObject):
                 # prevent the git errorOccurred signals being handled
                 self._queue[0].errorOccurred.disconnect()
                 self._queue[0].kill()
-            self._queue[0].deleteLater()    
+            self._queue[0].deleteLater()
             self._queue.popleft()
-
-
- 
-
-
-

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -48,9 +48,7 @@ class Git(QObject):
     def __init__(self, owner):
         super(Git, self).__init__(owner)
         # TODO: check for preference
-        self._executable = 'git'
-        # TODO: change to a .root() method in gitrepo.Repo()
-        self._workingdirectory = owner.root_path
+        executable = 'git'
         self._version = None
         self._isbinary = False
         self._stderr = None
@@ -58,8 +56,8 @@ class Git(QObject):
 
         # Create and configure QProcess object
         self._process = process = QProcess()
-        process.setProgram(self._executable)
-        process.setWorkingDirectory(self._workingdirectory)
+        process.setProgram(executable)
+        process.setWorkingDirectory(owner._root_path) # TODO: change to a .root() method in gitrepo.Repo()
         process.errorOccured.connect(self.slotErrorOccured)
 
         # Connect QProcess's signals to our own intermediate slots or our own signals
@@ -205,41 +203,3 @@ class Git(QObject):
             # TODO: Implement this case
             pass
 
-    # Deprecated
-    # I don't think we need that. directory is set in __init__
-    def setWorkingDirectory(self, workingdirectory):
-        self._process.setWorkingDirectory(workingdirectory)
-        self._workingdirectory = workingdirectory
-
-    # Deprecated
-    # Probably we'll never need this
-    def workingDirectory(self):
-        return self._workingdirectory
-
-    # Deprecated
-    # I don't think we need that. executable is set in __init__
-    def setGitExecutable(self, executable):
-        self._process.setProgram(executable)
-        self._executable = executable
-
-    # Deprecated
-    # Probably we'll never need this
-    def gitExecutable(self):
-        return self._executable
-
-    # Deprecated
-    def killCurrent(self):
-        if self.isRunning():
-            self._queue[0]['process'].finished.disconnect()
-            # termination should be sync?
-            if os.name == "nt":
-                self._queue[0]['process'].kill()
-            else:
-                self._queue[0]['process'].terminate()
-            del self._queue[0]
-
-    # Deprecated.
-    # We don't even have a queue anymore
-    def killAll(self):
-        self.killCurrent()
-        self._queue = []

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -41,7 +41,7 @@ class Git(QObject):
     stateChanged = pyqtSignal(QProcess.ProcessState)
     errorOccurred = pyqtSignal(QProcess.ProcessError)
 
-    # emits when the receiver finish executing
+    # should be emitted in the body of signal finished's slot.
     executed = pyqtSignal(int)
 
     def __init__(self, owner):

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -246,6 +246,9 @@ class GitJobQueue(QObject):
         """ 
         Append 'Git instance' into the queue.
         If the queue is empty, the 'Git instacne' will run immediately.
+
+        CAUTION: 
+        enqueue a same Git() object multiple times will lead to runtime-error.
         """   
         gitjob.executed.connect(self.run_next)
         gitjob.errorOccurred.connect(self.errorOccurred) 

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -215,35 +215,6 @@ class Git(QObject):
             res.pop()
         return res
 
-    # TODO: is it a good place to keep this command
-    # We can assume (can we?) the Git version not to change within a session,
-    # so could there be a more global place where this information could be cached?
-    def version(self):
-        """
-        Return git executable version.
-
-        The version string is used to check, whether git executable exists and
-        works properly. It may also be used to enable functions with newer git
-        versions.
-
-        Returns:
-            tuple: PEP-440 conform git version (major, minor, patch)
-        """
-        if self._version:
-            return self._version
-        args = ['--version']
-        # Query git version synchronously
-        output = self.run_blocking(args) or ''
-        # Parse version string like (git version 2.12.2.windows.1)
-        match = re.match(r'git version (\d+)\.(\d+)\.(\d+)', output[0])
-        if match:
-            # PEP-440 conform git version (major, minor, patch)
-            self._version = tuple(int(g) for g in match.groups())
-            return self._version
-        else:
-            # TODO: Implement this case
-            pass
-
 
 class GitJobQueue(QObject):
 

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -164,15 +164,14 @@ class Git(QObject):
         """
         Called when the process has completed.
         process results and forward the signal
-
-        If error occurrs during the execution process, signal 'errorOccurred' 
-        will be emitted. Signal 'finished' will be blocked. So this function 
-        only works when process executes successfully. 
-        """
-        # Only handles the result when process exit normaly. 
-        if exitstatus == QProcess.NormalExit:
-            self._handle_results()
-            self.finished.emit(self)
+        
+        exitcode == 0 : Process executes successfully. 
+                        Result will output to stdout().
+        exitcode == 1 : Process returns an error message.
+                        Error message will output to stderr() 
+        """ 
+        self._handle_results()
+        self.finished.emit(exitcode)
 
     def stdout(self):
         """

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -236,6 +236,8 @@ class Git(QObject):
 
 class GitJobQueue(QObject):
 
+    errorOccurred = pyqtSignal(QProcess.ProcessError)
+
     def __init__(self):
         super().__init__()
         self._queue = collections.deque()
@@ -245,7 +247,9 @@ class GitJobQueue(QObject):
         Append 'Git instance' into the queue.
         If the queue is empty, the 'Git instacne' will run immediately.
         """   
-        gitjob.executed.connect(self._auto_run_next)
+        gitjob.executed.connect(self.run_next)
+        gitjob.errorOccurred.connect(self.errorOccurred) 
+
         self._queue.append(gitjob)
         if len(self._queue) == 1:
             # args of Git process has been set in advance

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -17,12 +17,6 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # See http://www.gnu.org/licenses/ for more information.
 
-"""
-Execute a single Git command, either blocking or non-blocking.
-The output of the command will be stored in the _stdout and _stderr fields,
-run_blocking() will return the data while run() will invoke the finished signal,
-giving the caller the opportunity to retrieve the data.
-"""
 
 import re
 import time
@@ -32,6 +26,12 @@ from PyQt5.QtCore import QObject, QProcess, pyqtSignal
 
 
 class Git(QObject):
+    """Executes a single Git command, either blocking or non-blocking.
+
+    The output of the command will be stored in the _stdout and _stderr fields,
+    run_blocking() will return the data while run() will invoke the finished 
+    signal, giving the caller the opportunity to retrieve the data.
+    """
 
     # "custom" signals for passing on QProcess's signals
     finished = pyqtSignal(QObject, int)

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -202,6 +202,13 @@ class Git(QObject):
 
 
 class GitJobQueue(QObject):
+    """GitJobQueue is the command queue manage Git() objects
+
+    You may need this when you want to run some Git commands in order.
+    Git() objects in the queue run one after another.  When an error occurrs
+    during runing, GitJobQueue will stop running and emits an "errorOccurred"
+    signal. 
+    """
 
     errorOccurred = pyqtSignal(QProcess.ProcessError)
 
@@ -211,11 +218,11 @@ class GitJobQueue(QObject):
 
     def enqueue(self, gitjob):
         """ 
-        Append 'Git instance' into the queue.
-        If the queue is empty, the 'Git instacne' will run immediately.
+        Appends a Git() object (gitjob) into the queue.
+        If the queue is empty, the Git() object will run immediately.
 
         CAUTION: 
-        enqueue a same Git() object multiple times will lead to runtime-error.
+        enqueue a same Git() object multiple times will lead to a runtime-error.
         """   
         gitjob.executed.connect(self.run_next)
         gitjob.errorOccurred.connect(self.errorOccurred) 
@@ -227,19 +234,17 @@ class GitJobQueue(QObject):
     
     def kill_all(self):
         """
-        Kill all the process this queue contains
-        Will be used when the file has lost focus.
+        Kills and removes all the Git() objects this queue contains
         """
         self._remove_current()
         for job in self._queue:
             job.deleteLater()
         self._queue.clear()
 
-
     def run_next(self, execute_status = 0):
         """
-        To run next git process
-        Triggered by the previous Git instance's executed signal.
+        Runs next Git() object in the queue.
+        It can be triggered by the previous Git() instance's executed signal.
         """
         self._remove_current()
         if self._queue:
@@ -247,8 +252,8 @@ class GitJobQueue(QObject):
 
     def _remove_current(self):
         """
-        Remove the Git() object in queue-head.
-        If the Git() object is running, terminate it by calling kill()
+        Removes the Git() object in queue-head.
+        If the Git() object is running, terminate it by calling its kill().
         """
         if self._queue:
             if self._queue[0].isRunning():

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -164,14 +164,15 @@ class Git(QObject):
         """
         Called when the process has completed.
         process results and forward the signal
+
+        If error occurrs during the execution process, signal 'errorOccurred' 
+        will be emitted. Signal 'finished' will be blocked. So this function 
+        only works when process executes successfully. 
         """
+        # Only handles the result when process exit normaly. 
         if exitstatus == QProcess.NormalExit:
             self._handle_results()
             self.finished.emit(self)
-        else:
-            # TODO, what to do when process crashed?
-            pass
-
 
     def stdout(self):
         """

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -33,7 +33,7 @@ from PyQt5.QtCore import QObject, QProcess, pyqtSignal
 class Git(QObject):
 
     # "custom" signals for passing on QProcess's signals
-    finished = pyqtSignal(QObject)
+    finished = pyqtSignal(QObject, int)
     readyReadStandardError = pyqtSignal()
     readyReadStandardOutput = pyqtSignal()
     started = pyqtSignal()
@@ -176,7 +176,7 @@ class Git(QObject):
                         Error message will output to stderr() 
         """ 
         self._handle_results()
-        self.finished.emit(exitcode)
+        self.finished.emit(self, exitcode)
 
     def stdout(self):
         """

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -182,27 +182,24 @@ class Git(QObject):
     def stdout(self):
         """
         Returns the content of the stdout output, if any.
+        
+        Returns: 
+            None: Git() is running / Git() hasn't started / Git() has crashed
+             b'': Git() has finished running and returns a binary result.
+              []: Git() has finished running and returns a string-list result.
         """
-        # TODO: should we check isRunning() before or can we rely on the "is not None" check?
-        # A simpler approach would be to simply return self._stdout and have the caller interpret
-        # the type of result: either None (job not completed) or a (potentially empty) string list
-        # or the binary stream
-        if self._stdout is not None:
-            return self._stdout
-        else:
-            # TODO: Discuss what should happen here (job hasn't completed yet)
-            return None
+        return self._stdout
 
     def stderr(self):
         """
         Returns the content of the stderr output, if any.
+
+        Returns: 
+            None: Git() is running / Git() hasn't started / Git() has crashed
+             b'': Git() has finished running and returns a binary result.
+              []: Git() has finished running and returns a string-list result.
         """
-        # TODO: should we check isRunning() before or can we rely on the "is not None" check?
-        if self._stderr is not None:
-            return self._stderr
-        else:
-            # TODO: Discuss what should happen here (job hasn't completed yet)
-            return None
+        return self._stderr
 
     # TODO: is it a good place to keep this command
     # We can assume (can we?) the Git version not to change within a session,

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -114,7 +114,6 @@ class Git(QObject):
         if self.isRunning():
             # Note: Qt handles the OS differences transparently
             self._process.kill()
-#TODO: will this trigger a signal? is it necessary to signal this event to anybody besides the caller?
 
     def _tic(self):
         """

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -238,6 +238,8 @@ class GitJobQueue(QObject):
         """
         if self._queue:
             self._queue[0].kill()
+            for job in self._queue:
+                job.deleteLater()
             self._queue = []
 
 
@@ -246,6 +248,7 @@ class GitJobQueue(QObject):
         To run next git process
         Triggered by the previous Git instance's executed signal.
         """    
+        self._queue[0].deleteLater()    
         del self._queue[0]
         if self._queue:
             self._queue[0].run()

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -18,16 +18,17 @@
 # See http://www.gnu.org/licenses/ for more information.
 
 """
-Execute a Git command, both blocking and non-blocking
+Execute a single Git command, either blocking or non-blocking.
+The output of the command will be stored in the _stdout and _stderr fields,
+run_blocking() will return the data while run() will invoke the finished signal,
+giving the caller the opportunity to retrieve the data.
 """
 
 import os
 import re
 import time
-import functools
 
 from PyQt5.QtCore import QObject, QProcess, pyqtSignal
-
 
 
 class GitError(Exception):
@@ -36,97 +37,81 @@ class GitError(Exception):
 class Git(QObject):
     done = pyqtSignal(bool)
 
-    def __init__(self, workingdirectory = None, parent = None):
-        super(Git, self).__init__(parent)
-        self._executable = 'git'
-        self._workingdirectory = workingdirectory
-        self._queue = []
-        self._version = None
+    # "custom" signals for passing on QProcess's signals
+    errorOccured(QProcess.ProcessError)
+    finished = pyqtSignal(int, QProcess.ExitStatus)
+    readyReadStandardError = pyqtSignal()
+    readyReadStandardOutput = pyqtSignal()
+    started = pyqtSignal()
+    stateChanged = pyqtSignal(QProcess.ProcessState)
 
-    def run(self, args, receiver, isbinary = False):
-        unit = {}
-        
-        process = QProcess()
+    def __init__(self, owner):
+        super(Git, self).__init__(owner)
+        # TODO: check for preference
+        self._executable = 'git'
+        # TODO: change to a .root() method in gitrepo.Repo()
+        self._workingdirectory = owner.root_path
+        self._version = None
+        self._isbinary = False
+        self._stderr = None
+        self._stdout = None
+
+        # Create and configure QProcess object
+        self._process = process = QProcess()
         process.setProgram(self._executable)
-        process.setArguments(args)
         process.setWorkingDirectory(self._workingdirectory)
-        process.finished.connect(functools.partial(self._handleResult, isbinary))
-        
-        unit['process'] = process
-        unit['receiver'] = receiver
-        self._queue.append(unit)
-        
-        process = None
-        unit = None
- 
-        if len(self._queue) == 1:
-            self._queue[0]['process'].start()
+        process.errorOccured.connect(self.slotErrorOccured)
+
+        # Connect QProcess's signals to our own intermediate slots or our own signals
+        process.finished.connect(self._finished)
+        process.readyReadStandardError.connect(self.readyReadStandardError)
+        process.readyReadStandardOutput.connect(self.readStandardOutput)
+        process.started.connect(self.started)
+        process.stateChanged.connect(self.stateChanged)
+
+    def _start_process(self, args, isbinary=False):
+        """
+        Internal command preparing and starting the Git process
+        """
+        self._stderr = ''
+        self._stdout = ''
+        self._isbinary = isbinary
+        self._process.setArguments(args)
+        self._process.start()
+
+    def run(self, args, isbinary=False):
+        """
+        Asynchronously run the command.
+        Results will only be available after the _finished() slot has been executed
+        """
+        self._start_process(args, isbinary)
 
     def run_blocking(self, args, isbinary = False):
         """
+        Synchronously run the command.
+        Results will be returned but are also available through stdout() and stderr() afterwards
         """
-        process = QProcess()
-        process.setWorkingDirectory(self._workingdirectory)
-        process.start(self._executable, args)
-        process.waitForFinished()
-        stderr = str(process.readAllStandardError(), 'utf-8')
-        if stderr:
-            raise GitError(stderr)
-        else:
-            if isbinary:
-                return process.readAllStandardOutput()
-            stdout = str(process.readAllStandardOutput(), 'utf-8').split('\n')
-            if not stdout[-1]:
-                stdout.pop()
-            return stdout
+        self._process.finished.disconnect()
+        self._start_process(args, isbinary)
+        self._process.waitForFinished()
+        self._handle_results()
+        self._process.finished.connect(self._finished)
+        # ? TODO: I think we should return a (_stdout, _stderr) tuple
+        return self._stdout
 
-
-    def _handleResult(self, isbinary):
-        """
-        """
-        stderr = str(self._queue[0]['process'].readAllStandardError(), 'utf-8')
-        if stderr:
-            raise GitError(stderr)
-        else:
-            if isbinary:
-                stdout = self._queue[0]['process'].readAllStandardOutput()
-            else:
-                stdout = str(self._queue[0]['process'].readAllStandardOutput(), 'utf-8').split('\n')
-                if not stdout[-1]:
-                    stdout.pop()
-            self._queue[0]['receiver'](stdout)
-        del self._queue[0]
-        if self._queue:
-            self._queue[0]['process'].start()    
-
-    def setWorkingDirectory(self, workingdirectory):
-        self._workingdirectory = workingdirectory
-
-    def workingDirectory(self):
-        return self._workingdirectory
-
-    def setGitExecutable(self, executable):
-        self._executable = executable
-
-    def gitExecutable(self):
-        return self._executable
-
-    def killCurrent(self):
-        if self.isRunning():
-            self._queue[0]['process'].finished.disconnect()
-            # termination should be sync? 
-            if os.name == "nt":
-                self._queue[0]['process'].kill()
-            else:
-                self._queue[0]['process'].terminate()
-            del self._queue[0]
-    
-    def killAll(self):
-        self.killCurrent()
-        self._queue = []
-        
     def isRunning(self):
-        return len(self._queue) > 0  
+        """
+        Returns True if the process is currently running.
+        """
+        return not self._process.state() == QProcess.NotRunning
+
+    def kill(self):
+        """
+        Kills the process if it is running
+        """
+        if not self.isRunning():
+            # Note: Qt handles the OS differences transparently
+            self._process.kill()
 
     def _tic(self):
         """
@@ -143,7 +128,57 @@ class Git(QObject):
                 time.perf_counter()-self._timer))
             self._timer = None
 
+    def _handle_results(self):
+        """
+        will be called when the process has completed.
+        Populates the result fields
+        """
+        if self._isbinary:
+            self._stderr = self._process.readAllStandardError()
+            self._stdout = self._process.readAllStandardOutput()
+        else:
+            self._stdout = str(self._process.readAllStandardError(), 'utf-8').split('\n')
+            if not self._stdout[-1]:
+                self._stdout.pop()
+            self._stderr = str(self._process.readAllStandardError(), 'utf-8').split('\n')
+            if not self._stderr[-1]:
+                self._stderr.pop()
 
+        # TODO: Discuss this. Actually we should change this and pass the responsibility to decide to the caller
+        if self._stderr:
+            raise GitError(stderr)
+
+    def _finished(self):
+        """
+        Called when the process has completed.
+        process results and forward the signal
+        """
+        self._handle_results()
+        self.finished.emit()
+
+    def stdout(self):
+        """
+        Returns the content of the stdout output, if any.
+        """
+        if self._stdout:
+            return self._stdout
+        else:
+            # TODO: Discuss what should happen here
+            return None
+
+    def stderr(self):
+        """
+        Returns the content of the stderr output, if any.
+        """
+        if self._stderr:
+            return self._stderr
+        else:
+            # TODO: Discuss what should happen here
+            return None
+
+    # TODO: is it a good place to keep this command
+    # We can assume (can we?) the Git version not to change within a session,
+    # so could there be a more global place where this information could be cached?
     def version(self):
         """
         Return git executable version.
@@ -155,6 +190,8 @@ class Git(QObject):
         Returns:
             tuple: PEP-440 conform git version (major, minor, patch)
         """
+        if self._version:
+            return self._version
         args = ['--version']
         # Query git version synchronously
         output = self.run_blocking(args) or ''
@@ -164,10 +201,45 @@ class Git(QObject):
             # PEP-440 conform git version (major, minor, patch)
             self._version = tuple(int(g) for g in match.groups())
             return self._version
+        else:
+            # TODO: Implement this case
+            pass
 
+    # Deprecated
+    # I don't think we need that. directory is set in __init__
+    def setWorkingDirectory(self, workingdirectory):
+        self._process.setWorkingDirectory(workingdirectory)
+        self._workingdirectory = workingdirectory
 
+    # Deprecated
+    # Probably we'll never need this
+    def workingDirectory(self):
+        return self._workingdirectory
 
+    # Deprecated
+    # I don't think we need that. executable is set in __init__
+    def setGitExecutable(self, executable):
+        self._process.setProgram(executable)
+        self._executable = executable
 
+    # Deprecated
+    # Probably we'll never need this
+    def gitExecutable(self):
+        return self._executable
 
+    # Deprecated
+    def killCurrent(self):
+        if self.isRunning():
+            self._queue[0]['process'].finished.disconnect()
+            # termination should be sync?
+            if os.name == "nt":
+                self._queue[0]['process'].kill()
+            else:
+                self._queue[0]['process'].terminate()
+            del self._queue[0]
 
-
+    # Deprecated.
+    # We don't even have a queue anymore
+    def killAll(self):
+        self.killCurrent()
+        self._queue = []

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -43,7 +43,7 @@ class Git(QObject):
     executed = pyqtSignal(int)
 
     def __init__(self, owner):
-        super(Git, self).__init__()
+        super().__init__()
         # TODO: check for preference
         executable = 'git'
         # args could be set in advance
@@ -212,7 +212,8 @@ class Git(QObject):
 class GitJobQueue(QObject):
 
     def __init__(self):
-        self._queue = QQueue()
+        super().__init__()
+        self._queue = []
 
     def enqueue(self, gitjob):
         """ 
@@ -220,19 +221,19 @@ class GitJobQueue(QObject):
         If the queue is empty, the 'Git instacne' will run immediately.
         """   
         gitjob.executed.connect(self._auto_run_next)
-        self._queue.enqueue(gitjob)
-        if self._queue.size() == 1:
+        self._queue.append(gitjob)
+        if len(self._queue) == 1:
             # args of Git process has been set in advance
-            self._queue.head().run() 
+            self._queue[0].run() 
     
     def killAll(self):
         """
         Kill all the process this queue contains
         Will be used when the file has lost focus.
         """
-        if not self._queue.isEmpty():
-            self._queue.head().kill()
-            self._queue.clear()
+        if self._queue:
+            self._queue[0].kill()
+            self._queue = []
 
 
     def _auto_run_next(self, execute_status):
@@ -240,9 +241,9 @@ class GitJobQueue(QObject):
         To run next git process
         Triggered by the previous Git instance's executed signal.
         """    
-        self._queue.dequeue()
-        if not self._queue.isEmpty():
-            self._queue.head().run()
+        del self._queue[0]
+        if self._queue:
+            self._queue[0].run()
 
  
 

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -26,6 +26,7 @@ giving the caller the opportunity to retrieve the data.
 
 import re
 import time
+import collections 
 
 from PyQt5.QtCore import QObject, QProcess, pyqtSignal
 
@@ -237,7 +238,7 @@ class GitJobQueue(QObject):
 
     def __init__(self):
         super().__init__()
-        self._queue = []
+        self._queue = collections.deque()
 
     def enqueue(self, gitjob):
         """ 
@@ -258,7 +259,7 @@ class GitJobQueue(QObject):
         self._remove_current()
         for job in self._queue:
             job.deleteLater()
-        self._queue = []
+        self._queue.clear()
 
 
     def _auto_run_next(self, execute_status):
@@ -281,7 +282,7 @@ class GitJobQueue(QObject):
                 self._queue[0].errorOccurred.disconnect()
                 self._queue[0].kill()
             self._queue[0].deleteLater()    
-            del self._queue[0]
+            self._queue.popleft()
 
 
  

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -251,22 +251,34 @@ class GitJobQueue(QObject):
         Kill all the process this queue contains
         Will be used when the file has lost focus.
         """
-        if self._queue:
-            self._queue[0].kill()
-            for job in self._queue:
-                job.deleteLater()
-            self._queue = []
+        self._remove_current()
+        for job in self._queue:
+            job.deleteLater()
+        self._queue = []
 
 
     def _auto_run_next(self, execute_status):
         """
         To run next git process
         Triggered by the previous Git instance's executed signal.
-        """    
-        self._queue[0].deleteLater()    
-        del self._queue[0]
+        """
+        self._remove_current()
         if self._queue:
             self._queue[0].run()
+
+    def _remove_current(self):
+        """
+        Remove the Git() object in queue-head.
+        If the Git() object is running, terminate it by calling kill()
+        """
+        if self._queue:
+            if self._queue[0].isRunning():
+                # prevent the git errorOccurred signals being handled
+                self._queue[0].errorOccurred.disconnect()
+                self._queue[0].kill()
+            self._queue[0].deleteLater()    
+            del self._queue[0]
+
 
  
 

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -104,6 +104,7 @@ class Git(QObject):
         if not self.isRunning():
             # Note: Qt handles the OS differences transparently
             self._process.kill()
+#TODO: will this trigger a signal? is it necessary to signal this event to anybody besides the caller?
 
     def _tic(self):
         """

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -38,6 +38,7 @@ class Git(QObject):
     readyReadStandardOutput = pyqtSignal()
     started = pyqtSignal()
     stateChanged = pyqtSignal(QProcess.ProcessState)
+    errorOccurred = pyqtSignal(QProcess.ProcessError)
     
     # emits when the receiver finish executing
     executed = pyqtSignal(int)
@@ -64,6 +65,11 @@ class Git(QObject):
         process.readyReadStandardOutput.connect(self.readyReadStandardOutput)
         process.started.connect(self.started)
         process.stateChanged.connect(self.stateChanged)
+        try:
+            process.errorOccurred.connect(self.errorOccurred)
+        except AttributeError:
+            # errorOccurred may not be supported 
+            process.error.connect(self.errorOccurred)  
 
     def _start_process(self, args, isbinary=False):
         """

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -111,7 +111,7 @@ class Git(QObject):
         """
         Kills the process if it is running
         """
-        if not self.isRunning():
+        if self.isRunning():
             # Note: Qt handles the OS differences transparently
             self._process.kill()
 #TODO: will this trigger a signal? is it necessary to signal this event to anybody besides the caller?

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -30,9 +30,6 @@ import time
 from PyQt5.QtCore import QObject, QProcess, pyqtSignal
 
 
-class GitError(Exception):
-    pass
-
 class Git(QObject):
 
     # "custom" signals for passing on QProcess's signals
@@ -69,8 +66,8 @@ class Git(QObject):
         """
         Internal command preparing and starting the Git process
         """
-        self._stderr = ''
-        self._stdout = ''
+        self._stderr = None
+        self._stdout = None
         self._isbinary = isbinary
         self._process.setArguments(args)
         self._process.start()
@@ -92,8 +89,7 @@ class Git(QObject):
         self._process.waitForFinished()
         self._handle_results()
         self._process.finished.connect(self._finished)
-        # ? TODO: I think we should return a (_stdout, _stderr) tuple
-        return self._stdout
+        return (self._stdout, self._stderr)
 
     def isRunning(self):
         """
@@ -140,10 +136,6 @@ class Git(QObject):
             if not self._stderr[-1]:
                 self._stderr.pop()
 
-        # TODO: Discuss this. Actually we should change this and pass the responsibility to decide to the caller
-        if self._stderr:
-            raise GitError(stderr)
-
     def _finished(self):
         """
         Called when the process has completed.
@@ -156,20 +148,25 @@ class Git(QObject):
         """
         Returns the content of the stdout output, if any.
         """
-        if self._stdout:
+        # TODO: should we check isRunning() before or can we rely on the "is not None" check?
+        # A simpler approach would be to simply return self._stdout and have the caller interpret
+        # the type of result: either None (job not completed) or a (potentially empty) string list
+        # or the binary stream
+        if self._stdout is not None:
             return self._stdout
         else:
-            # TODO: Discuss what should happen here
+            # TODO: Discuss what should happen here (job hasn't completed yet)
             return None
 
     def stderr(self):
         """
         Returns the content of the stderr output, if any.
         """
-        if self._stderr:
+        # TODO: should we check isRunning() before or can we rely on the "is not None" check?
+        if self._stderr is not none:
             return self._stderr
         else:
-            # TODO: Discuss what should happen here
+            # TODO: Discuss what should happen here (job hasn't completed yet)
             return None
 
     # TODO: is it a good place to keep this command

--- a/frescobaldi_app/vcs/gitjob.py
+++ b/frescobaldi_app/vcs/gitjob.py
@@ -198,7 +198,7 @@ class Git(QObject):
         Returns the content of the stderr output, if any.
         """
         # TODO: should we check isRunning() before or can we rely on the "is not None" check?
-        if self._stderr is not none:
+        if self._stderr is not None:
             return self._stderr
         else:
             # TODO: Discuss what should happen here (job hasn't completed yet)

--- a/frescobaldi_app/vcs/gitrepoo.py
+++ b/frescobaldi_app/vcs/gitrepoo.py
@@ -29,6 +29,10 @@ from PyQt5.QtCore import pyqtSignal
 
 import gitjob
 
+
+class GitError(Exception):
+    pass
+
 class Repo():
     """
     """


### PR DESCRIPTION
This refers to my comment https://github.com/wbsoft/frescobaldi/pull/974#issuecomment-311201492

Git() is now a more straightforward object responsible for synchronously
or asynchronously running a single Git command.
The asynchronous behaviour relies completely on Qt-style signalling,
i.e. there are no callback functions but the option to connect to signals.
The class forwards all the signals from QProcess.

I have removed the queue concept (although it was well implemented). If we need it at all we should move the idea to the `Repo()` object but keep the `Git()` object clean and focused.
Maybe we don't need a queue at all because the same effect may be achieved using signals and slots (call Git command A and connect to a slot. In that slot call Git command B etc.)

---

This code will *not* work without correspondingly updating the owning Git repo class. But I wanted to create this in order to discuss the approach. 

I'm feeling somewhat bad to suggest such far-reaching changes, but we should get to a common understanding before building too much further code upon it.
Please ask if there is *anything* you don't understand - or if you have *any* objections.