### PR TITLE
Add -p/--python-ly command line option

### DIFF
--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -192,6 +192,10 @@ def main():
         sys.exit(0)
 
     if args.python_ly:
+        # The python-ly path has to be inserted at the *second* position
+        # because the first element in sys.path is the directory of the invoked
+        # script (an information we need in determining if Frescobaldi is run
+        # from its Git repository)
         sys.path.insert(1, args.python_ly)
 
     check_ly()
@@ -280,5 +284,3 @@ def main():
         cursor.setPosition(pos)
         win.currentView().setTextCursor(cursor)
         win.currentView().centerCursor()
-
-

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -85,7 +85,6 @@ def parse_commandline():
         parser.add_argument('-p', '--port')
         parser.add_argument('-f', '--file')
         parser.add_argument('-o', '--output')
-        parser.add_argument('--python-ly')
 
 
 

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -72,7 +72,7 @@ def parse_commandline():
         help=_("List the session names and exit"))
     parser.add_argument('-n', '--new', action="store_true", default=False,
         help=_("Always start a new instance"))
-    parser.add_argument('-p', '--python-ly', type=str, metavar=_("STR"), default="",
+    parser.add_argument('--python-ly', type=str, metavar=_("STR"), default="",
         help=_("Path to python-ly"))
     parser.add_argument('files', metavar=_("file"), nargs='*',
         help=_("File to be opened"))
@@ -85,7 +85,7 @@ def parse_commandline():
         parser.add_argument('-p', '--port')
         parser.add_argument('-f', '--file')
         parser.add_argument('-o', '--output')
-        parser.add_argument('-y', '--python-ly')
+        parser.add_argument('--python-ly')
 
 
 

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -193,7 +193,7 @@ def main():
         sys.exit(0)
 
     if args.python_ly:
-        sys.path = [args.python_ly] + sys.path
+        sys.path.insert(1, args.python_ly)
 
     check_ly()
     patch_pyqt()

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -72,6 +72,8 @@ def parse_commandline():
         help=_("List the session names and exit"))
     parser.add_argument('-n', '--new', action="store_true", default=False,
         help=_("Always start a new instance"))
+    parser.add_argument('-p', '--python-ly', type=str, metavar=_("STR"), default="",
+        help=_("Path to python-ly"))
     parser.add_argument('files', metavar=_("file"), nargs='*',
         help=_("File to be opened"))
 
@@ -83,6 +85,7 @@ def parse_commandline():
         parser.add_argument('-p', '--port')
         parser.add_argument('-f', '--file')
         parser.add_argument('-o', '--output')
+        parser.add_argument('-y', '--python-ly')
 
 
 
@@ -188,6 +191,9 @@ def main():
         import debuginfo
         sys.stdout.write(debuginfo.version_info_string() + '\n')
         sys.exit(0)
+
+    if args.python_ly:
+        sys.path = [args.python_ly] + sys.path
 
     check_ly()
     patch_pyqt()


### PR DESCRIPTION
With the -p or --python-ly option the path to python-ly can be specified.
This maybe makes it cleaner to use python-ly from the Git repository
(rather than wrapping the call to Python with a PYTHONPATH= clause).

This is inspired by the recent discussion about installation instructions.