### PR TITLE
Submenus for grouping sessions in Sessions menu

### DIFF
--- a/frescobaldi_app/sessions/menu.py
+++ b/frescobaldi_app/sessions/menu.py
@@ -61,8 +61,6 @@ class SessionMenu(QMenu):
                 add_session(self, name)
 
         def add_groups():
-            g_keys = [k for k in groups.keys()]
-            g_keys.sort()
             for k in sorted(groups.keys()):
                 m = self.addMenu(k)
                 for name in groups[k]:

--- a/frescobaldi_app/sessions/menu.py
+++ b/frescobaldi_app/sessions/menu.py
@@ -87,7 +87,6 @@ class SessionMenu(QMenu):
         for name in sessions.sessionNames():
             if '/' in name:
                 group, name = name.split('/')
-#                g = groups.get(group, [])
                 if group in groups:
                     groups[group].append(name)
                 else:

--- a/frescobaldi_app/sessions/menu.py
+++ b/frescobaldi_app/sessions/menu.py
@@ -87,9 +87,9 @@ class SessionMenu(QMenu):
         for name in sessions.sessionNames():
             if '/' in name:
                 group, name = name.split('/')
-                g = groups.get(group, [])
-                if g:
-                    g.append(name)
+#                g = groups.get(group, [])
+                if group in groups:
+                    groups[group].append(name)
                 else:
                     groups[group] = [name]
             else:

--- a/frescobaldi_app/sessions/menu.py
+++ b/frescobaldi_app/sessions/menu.py
@@ -105,6 +105,8 @@ class SessionMenu(QMenu):
             else:
                 tl_sessions.append(name)
         add_groups()
+        if groups:
+            self.addSeparator()
         add_sessions()
         qutil.addAccelerators(self.actions())
 


### PR DESCRIPTION
This commit parses session names for (one) slash in it and treats such
sessions as grouped sessions and creates submenus for each.

![image](https://user-images.githubusercontent.com/1812148/37453805-227b6782-2839-11e8-8bdb-b3dcba7a8ed1.png)

The image also shows that the current session is within the `Group` submenu