### PR TITLE
fixing typo in it language

### DIFF
--- a/frescobaldi_app/po/it.po
+++ b/frescobaldi_app/po/it.po
@@ -2051,7 +2051,7 @@ msgstr "Si maggiore (5 diesis)"
 
 #: ../midiinput/widget.py:178
 msgid "F sharp major (6 sharps)"
-msgstr "Fa maggiore (6 diesis)"
+msgstr "Fa diesis maggiore (6 diesis)"
 
 #: ../midiinput/widget.py:179
 msgid "C sharp major (7 sharps)"


### PR DESCRIPTION
"F sharp" → "Fa diesis"