### PR TITLE
Add file path as tooltip in Documents menu

### DIFF
--- a/frescobaldi_app/doclist/widget.py
+++ b/frescobaldi_app/doclist/widget.py
@@ -35,20 +35,6 @@ import documenticon
 import engrave
 
 
-def path(url):
-    """Returns the path, as a string, of the url to group documents.
-
-    Returns None if the document is nameless.
-
-    """
-    if url.isEmpty():
-        return None
-    elif url.toLocalFile():
-        return util.homify(os.path.dirname(url.toLocalFile()))
-    else:
-        return url.resolved(QUrl('.')).toString(QUrl.RemoveUserInfo)
-
-
 class Widget(QTreeWidget):
     def __init__(self, tool):
         super(Widget, self).__init__(tool, headerHidden=True)
@@ -110,7 +96,7 @@ class Widget(QTreeWidget):
         # set properties according to document
         i.setText(0, doc.documentName())
         i.setIcon(0, documenticon.icon(doc, self.parentWidget().mainwindow()))
-        i.setToolTip(0, path(doc.url()))
+        i.setToolTip(0, util.path(doc.url()))
         # handle ordering in groups if desired
         if self._group:
             self.groupDocument(doc)
@@ -120,7 +106,7 @@ class Widget(QTreeWidget):
     def groupDocument(self, doc):
         """Called, if grouping is enabled, to group the document."""
         i = self._items[doc]
-        p = path(doc.url())
+        p = util.path(doc.url())
         new_parent = self._paths.get(p)
         if new_parent is None:
             new_parent = self._paths[p] = QTreeWidgetItem(self)
@@ -210,5 +196,3 @@ class Widget(QTreeWidget):
 
         menu.exec_(ev.globalPos())
         menu.deleteLater()
-
-

--- a/frescobaldi_app/documentmenu.py
+++ b/frescobaldi_app/documentmenu.py
@@ -30,6 +30,7 @@ import icons
 import plugin
 import engrave
 import documenticon
+import util
 
 
 class DocumentMenu(QMenu):
@@ -37,6 +38,7 @@ class DocumentMenu(QMenu):
         super(DocumentMenu, self).__init__(mainwindow)
         self.aboutToShow.connect(self.populate)
         app.translateUI(self)
+        self.setToolTipsVisible(True)
 
     def translateUI(self):
         self.setTitle(_('menu title', '&Documents'))
@@ -108,6 +110,7 @@ class DocumentActionGroup(plugin.MainWindowPlugin, QActionGroup):
             # L10N: 'always engraved': the document is marked as 'Always Engrave' in the LilyPond menu
             name += " " + _("[always engraved]")
         self._acts[doc].setText(name)
+        self._acts[doc].setToolTip(util.path(doc.url()))
         icon = documenticon.icon(doc, self.mainwindow())
         if icon.name() == "text-plain":
             icon = QIcon()
@@ -118,5 +121,3 @@ class DocumentActionGroup(plugin.MainWindowPlugin, QActionGroup):
             if act == action:
                 self.mainwindow().setCurrentDocument(doc)
                 break
-
-

--- a/frescobaldi_app/tabbar.py
+++ b/frescobaldi_app/tabbar.py
@@ -99,12 +99,7 @@ class TabBar(QTabBar):
             text = doc.documentName().replace('&', '&&')
             if self.tabText(index) != text:
                 self.setTabText(index, text)
-            if doc.url().toLocalFile():
-                tooltip = util.homify(doc.url().toLocalFile())
-            elif not doc.url().isEmpty():
-                tooltip = doc.url().toString(QUrl.RemoveUserInfo)
-            else:
-                tooltip = None
+            tooltip = util.path(doc.url())
             self.setTabToolTip(index, tooltip)
             self.setTabIcon(index, documenticon.icon(doc, self.window()))
 
@@ -155,5 +150,3 @@ class TabBar(QTabBar):
             self._contextMenu = documentcontextmenu.DocumentContextMenu(
                 self.window())
         return self._contextMenu
-
-

--- a/frescobaldi_app/util.py
+++ b/frescobaldi_app/util.py
@@ -29,7 +29,7 @@ import io
 import os
 import re
 
-from PyQt5.QtCore import QDir
+from PyQt5.QtCore import QDir, QUrl
 
 import appinfo
 import variables
@@ -90,6 +90,20 @@ def homify(path):
     if equal_paths(path[:len(homedir)+1], homedir + '/'):
         path = "~" + path[len(homedir):]
     return path
+
+
+def path(url):
+    """Returns the path, as a string, of the url to group documents.
+
+    Returns None if the document is nameless.
+
+    """
+    if url.isEmpty():
+        return None
+    elif url.toLocalFile():
+        return homify(os.path.dirname(url.toLocalFile()))
+    else:
+        return url.resolved(QUrl('.')).toString(QUrl.RemoveUserInfo)
 
 
 def tempdir():
@@ -287,5 +301,3 @@ def platform_newlines(text):
 
     """
     return universal_newlines(text).replace('\n', os.linesep)
-
-


### PR DESCRIPTION
Adds the tooltip to the Documents menu that is also found in the Documents Tool and the editor's tabs.

Merges duplicate implementation to a common function in the `util` module.