### PR TITLE
Add Tools=>Directions submenu with three commands

### DIFF
--- a/frescobaldi_app/documentactions.py
+++ b/frescobaldi_app/documentactions.py
@@ -62,7 +62,9 @@ class DocumentActions(plugin.MainWindowPlugin):
         ac.tools_quick_remove_dynamics.triggered.connect(self.quickRemoveDynamics)
         ac.tools_quick_remove_fingerings.triggered.connect(self.quickRemoveFingerings)
         ac.tools_quick_remove_markup.triggered.connect(self.quickRemoveMarkup)
-
+        ac.tools_directions_force_neutral.triggered.connect(self.forceDirectionsNeutral)
+        ac.tools_directions_force_up.triggered.connect(self.forceDirectionsUp)
+        ac.tools_directions_force_down.triggered.connect(self.forceDirectionsDown)
         mainwindow.currentDocumentChanged.connect(self.updateDocActions)
         mainwindow.selectionStateChanged.connect(self.updateSelectionActions)
 
@@ -87,6 +89,9 @@ class DocumentActions(plugin.MainWindowPlugin):
         self.actionCollection.tools_quick_remove_dynamics.setEnabled(selection)
         self.actionCollection.tools_quick_remove_fingerings.setEnabled(selection)
         self.actionCollection.tools_quick_remove_markup.setEnabled(selection)
+        self.actionCollection.tools_directions_force_up.setEnabled(selection)
+        self.actionCollection.tools_directions_force_neutral.setEnabled(selection)
+        self.actionCollection.tools_directions_force_down.setEnabled(selection)
 
     def currentView(self):
         return self.mainwindow().currentView()
@@ -184,6 +189,18 @@ class DocumentActions(plugin.MainWindowPlugin):
         import quickremove
         quickremove.markup(self.mainwindow().textCursor())
 
+    def forceDirectionsUp(self):
+        import quickremove
+        quickremove.force_directions(self.mainwindow().textCursor(), 'up')
+
+    def forceDirectionsNeutral(self):
+        import quickremove
+        quickremove.force_directions(self.mainwindow().textCursor(), 'neutral')
+
+    def forceDirectionsDown(self):
+        import quickremove
+        quickremove.force_directions(self.mainwindow().textCursor(), 'down')
+
 
 class Actions(actioncollection.ActionCollection):
     name = "documentactions"
@@ -209,6 +226,10 @@ class Actions(actioncollection.ActionCollection):
         self.tools_quick_remove_dynamics = QAction(parent)
         self.tools_quick_remove_fingerings = QAction(parent)
         self.tools_quick_remove_markup = QAction(parent)
+
+        self.tools_directions_force_up = QAction(parent)
+        self.tools_directions_force_neutral = QAction(parent)
+        self.tools_directions_force_down = QAction(parent)
 
         self.edit_cut_assign.setIcon(icons.get('edit-cut'))
         self.edit_move_to_include_file.setIcon(icons.get('edit-cut'))
@@ -236,4 +257,6 @@ class Actions(actioncollection.ActionCollection):
         self.tools_quick_remove_dynamics.setText(_("Remove &Dynamics"))
         self.tools_quick_remove_fingerings.setText(_("Remove &Fingerings"))
         self.tools_quick_remove_markup.setText(_("Remove Text &Markup (from music)"))
-
+        self.tools_directions_force_up.setText(_("Force Directions &Up"))
+        self.tools_directions_force_neutral.setText(_("Make Directions &Neutral"))
+        self.tools_directions_force_down.setText(_("Force Directions &Down"))

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -300,6 +300,7 @@ def menu_tools(mainwindow):
     m.addMenu(menu_tools_rest(mainwindow))
     m.addMenu(menu_tools_rhythm(mainwindow))
     m.addMenu(menu_tools_lyrics(mainwindow))
+    m.addMenu(menu_tools_directions(mainwindow))
     m.addMenu(menu_tools_quick_remove(mainwindow))
     m.addSeparator()
     ac = documentactions.get(mainwindow).actionCollection
@@ -379,6 +380,17 @@ def menu_tools_rhythm(mainwindow):
     return m
 
 
+def menu_tools_directions(mainwindow):
+    m = Menu(_('submenu title', "&Directions"), mainwindow)
+# TODO: Find/make a suitable icon
+#    m.setIcon(icons.get('edit-clear'))
+    ac = documentactions.DocumentActions.instance(mainwindow).actionCollection
+    m.addAction(ac.tools_directions_force_up)
+    m.addAction(ac.tools_directions_force_neutral)
+    m.addAction(ac.tools_directions_force_down)
+    return m
+
+
 def menu_tools_quick_remove(mainwindow):
     m = Menu(_('submenu title', "&Quick Remove"), mainwindow)
     m.setIcon(icons.get('edit-clear'))
@@ -434,5 +446,3 @@ def menu_help(mainwindow):
     m.addSeparator()
     m.addAction(ac.help_about)
     return m
-
-

--- a/frescobaldi_app/quickremove.py
+++ b/frescobaldi_app/quickremove.py
@@ -180,6 +180,37 @@ def markup(cursor):
                     continue
                 break
 
+dir_operators = {
+    'up': '^',
+    'neutral': '-',
+    'down': '_'
+}
+dir_commands = {
+    'up': 'Up',
+    'neutral': 'Neutral',
+    'down': 'Down'
+}
+def force_directions(cursor, direction):
+    """Fort the directions to be all the same, neutral, up or down."""
+    import re
+    reg = re.compile('(.*)(Up|Down|Neutral)')
+    c = lydocument.cursor(cursor)
+    source = ly.document.Source(c, None, ly.document.PARTIAL, True)
+    with c.document as d:
+        for t in source:
+            if isinstance(t, ly.lex.lilypond.Direction):
+                d[t.pos] = dir_operators[direction]
+            elif isinstance(t, ly.lex.lilypond.Command):
+                match = reg.match(t)
+                if match:
+                    updated = match.groups()[0] + dir_commands[direction]
+                    # TODO: Replace token with the updated token,
+                    # making sure to use the proper techniques to preserve
+                    # point-and-click links
+                    print("Would replace {} with {}".format(t, updated))
+
+
+
 
 @remove
 def smart_delete(cursor, backspace=False):
@@ -199,5 +230,3 @@ def smart_delete(cursor, backspace=False):
     TODO: implement
     """
     pass
-
-

--- a/frescobaldi_app/quickremove.py
+++ b/frescobaldi_app/quickremove.py
@@ -191,7 +191,7 @@ dir_commands = {
     'down': 'Down'
 }
 def force_directions(cursor, direction):
-    """Fort the directions to be all the same, neutral, up or down."""
+    """Force the directions to be all the same, neutral, up or down."""
     from PyQt5.QtGui import QTextCursor
     import re
     reg = re.compile('(.*)(Up|Down|Neutral)')
@@ -205,12 +205,8 @@ def force_directions(cursor, direction):
                 match = reg.match(t)
                 if match:
                     updated = match.groups()[0] + dir_commands[direction]
-                    cursor.setPosition(t.pos)
-                    cursor.setPosition(t.end, QTextCursor.KeepAnchor)
-                    cursor.removeSelectedText()
-                    cursor.insertText(updated)
-
-
+                    del d[t.pos:t.end-1]
+                    d[t.pos] = updated
 
 
 @remove

--- a/frescobaldi_app/quickremove.py
+++ b/frescobaldi_app/quickremove.py
@@ -192,6 +192,7 @@ dir_commands = {
 }
 def force_directions(cursor, direction):
     """Fort the directions to be all the same, neutral, up or down."""
+    from PyQt5.QtGui import QTextCursor
     import re
     reg = re.compile('(.*)(Up|Down|Neutral)')
     c = lydocument.cursor(cursor)
@@ -204,10 +205,10 @@ def force_directions(cursor, direction):
                 match = reg.match(t)
                 if match:
                     updated = match.groups()[0] + dir_commands[direction]
-                    # TODO: Replace token with the updated token,
-                    # making sure to use the proper techniques to preserve
-                    # point-and-click links
-                    print("Would replace {} with {}".format(t, updated))
+                    cursor.setPosition(t.pos)
+                    cursor.setPosition(t.end, QTextCursor.KeepAnchor)
+                    cursor.removeSelectedText()
+                    cursor.insertText(updated)
 
 
 


### PR DESCRIPTION
Fixes #1044 

This is a tool similar to the Quick Remove tools used to force directions to be up, down or neutral.

I need help with correctly replacing words in the document,
and there would be the need for an icon