### PR TITLE
Remove all __future__ imports

### DIFF
--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -21,7 +21,7 @@
 The global things in Frescobaldi.
 """
 
-from __future__ import print_function
+
 
 import os
 import sys

--- a/frescobaldi_app/debug.py
+++ b/frescobaldi_app/debug.py
@@ -6,7 +6,7 @@
 # signals to debug-print functions, and imports the most important modules such
 # as app.
 
-from __future__ import print_function
+
 
 import sys
 

--- a/frescobaldi_app/hyphenator.py
+++ b/frescobaldi_app/hyphenator.py
@@ -14,7 +14,7 @@ info@wilbertberendsen.nl
 License: LGPL. More info: http://python-hyphenator.googlecode.com/
 
 """
-from __future__ import print_function
+
 
 try:
     chr = unichr

--- a/frescobaldi_app/language_names/generate.py
+++ b/frescobaldi_app/language_names/generate.py
@@ -89,7 +89,7 @@ def write_dict(langs):
     with codecs.open("data.py", "w", "utf-8") as output:
         output.write("# -*- coding: utf-8;\n\n")
         output.write("# Do not edit, this file is generated. See generate.py.\n")
-        output.write("\nfrom __future__ import unicode_literals\n")
+        output.write("\n
         output.write("\n\n")
 
         output.write("language_names = {\n")

--- a/frescobaldi_app/lydocinfo.py
+++ b/frescobaldi_app/lydocinfo.py
@@ -28,7 +28,7 @@ available to both text documents on disk and loaded Frescobaldi documents.
 
 """
 
-from __future__ import absolute_import
+
 
 import re
 

--- a/frescobaldi_app/lydocument.py
+++ b/frescobaldi_app/lydocument.py
@@ -31,7 +31,7 @@ discard it.
 
 """
 
-from __future__ import absolute_import
+
 
 from PyQt5.QtGui import QTextCursor
 

--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -21,7 +21,7 @@
 Frescobaldi Main Window.
 """
 
-from __future__ import division
+
 
 import itertools
 import os

--- a/frescobaldi_app/midifile/parser.py
+++ b/frescobaldi_app/midifile/parser.py
@@ -29,7 +29,7 @@ Runs with Python 2.6, 2.7 and 3.
 
 """
 
-from __future__ import print_function
+
 
 import sys
 import struct

--- a/frescobaldi_app/musicview/pointandclick.py
+++ b/frescobaldi_app/musicview/pointandclick.py
@@ -21,7 +21,7 @@
 Handles Point and Click.
 """
 
-from __future__ import absolute_import
+
 
 import re
 import os

--- a/frescobaldi_app/musicview/widget.py
+++ b/frescobaldi_app/musicview/widget.py
@@ -21,7 +21,7 @@
 The PDF preview panel widget.
 """
 
-from __future__ import division
+
 
 import itertools
 import os

--- a/frescobaldi_app/objecteditor/widget.py
+++ b/frescobaldi_app/objecteditor/widget.py
@@ -21,7 +21,7 @@
 An Object Editor widget.
 """
 
-from __future__ import print_function
+
 
 import sys
 

--- a/frescobaldi_app/po/qtranslator.py
+++ b/frescobaldi_app/po/qtranslator.py
@@ -24,7 +24,7 @@ The strings that are needed are in the qtmessages.py file in this directory.
 
 """
 
-from __future__ import print_function
+
 
 from PyQt5.QtCore import QCoreApplication, QTranslator
 

--- a/frescobaldi_app/progress.py
+++ b/frescobaldi_app/progress.py
@@ -21,7 +21,7 @@
 Manages the progress bar in the status bar of ViewSpaces.
 """
 
-from __future__ import division
+
 
 from PyQt5.QtCore import Qt, QTimeLine, QTimer
 from PyQt5.QtWidgets import QProgressBar

--- a/frescobaldi_app/quickinsert/buttongroup.py
+++ b/frescobaldi_app/quickinsert/buttongroup.py
@@ -21,7 +21,7 @@
 A QGroupBox in the Quick Insert Panel that auto-layouts its buttons.
 """
 
-from __future__ import print_function
+
 
 import weakref
 

--- a/frescobaldi_app/simplestate.py
+++ b/frescobaldi_app/simplestate.py
@@ -35,7 +35,7 @@ The first word is always the mode of the file (e.g. 'lilypond', 'html', etc.).
 
 """
 
-from __future__ import print_function
+
 
 import ly.lex.lilypond
 import ly.lex.scheme

--- a/frescobaldi_app/svgview/view.py
+++ b/frescobaldi_app/svgview/view.py
@@ -25,8 +25,8 @@ that runs inside the displayed SVG file.
 
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 
 import os
 import sys

--- a/frescobaldi_app/userguide/whatsthis.py
+++ b/frescobaldi_app/userguide/whatsthis.py
@@ -21,7 +21,7 @@
 Link help:urls in WhatsThis text to the help browser.
 """
 
-from __future__  import unicode_literals
+
 
 from PyQt5.QtCore import QEvent, QObject, QUrl
 

--- a/frescobaldi_app/vcs/test.py
+++ b/frescobaldi_app/vcs/test.py
@@ -1,6 +1,6 @@
 # Test file to test and demonstrate the API for the vcs module.
 
-from __future__ import print_function
+
 
 from vcs import app_repo
 

--- a/frescobaldi_app/viewers/pointandclick.py
+++ b/frescobaldi_app/viewers/pointandclick.py
@@ -21,7 +21,7 @@
 Handles Point and Click.
 """
 
-from __future__ import absolute_import
+
 
 import re
 import os

--- a/frescobaldi_app/viewers/popplerwidget.py
+++ b/frescobaldi_app/viewers/popplerwidget.py
@@ -21,7 +21,7 @@
 Abstract base class for a Poppler based viewer widget.
 """
 
-from __future__ import division
+
 
 import os
 import weakref

--- a/macosx/mac-app.py
+++ b/macosx/mac-app.py
@@ -6,7 +6,7 @@ A setup file to build Frescobaldi.app with py2app.
 
 Use the '-h' flag to see the usage notes.
 """
-from __future__ import print_function
+
 
 import argparse
 import os

--- a/windows/freeze.py
+++ b/windows/freeze.py
@@ -48,7 +48,6 @@ includes = [
     'popplerqt5',
     'pypm',
 
-    '__future__',
     'argparse',
     'bisect',
     'contextlib',

--- a/windows/frescobaldi-wininst.py
+++ b/windows/frescobaldi-wininst.py
@@ -9,7 +9,7 @@ It is called with the '-install' argument after installing, and with the
 
 """
 
-from __future__ import print_function
+
 
 import os
 import sys


### PR DESCRIPTION
Closes #1003

It seems these `__future__` imports are all obsolete by now since Python2 isn't supported anymore.
(For reference: Has been done through `for file in $(find . -iname "*.py"); do sed -i 's/from __future__.*//g' $file; done`)