### PR TITLE
Restructure Tools Menu

### DIFF
--- a/frescobaldi_app/icons/Audio-x-generic.svg
+++ b/frescobaldi_app/icons/Audio-x-generic.svg
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="audio-x-generic.svg"
+   sodipodi:docbase="/home/tigert/cvs/freedesktop.org/tango-icon-theme/scalable/mimetypes"
+   inkscape:version="0.46"
+   sodipodi:version="0.32"
+   id="svg7032"
+   height="48.000000px"
+   width="48.000000px"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <defs
+     id="defs3">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 24 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="48 : 24 : 1"
+       inkscape:persp3d-origin="24 : 16 : 1"
+       id="perspective21" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2072">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2074" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop2076" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2315">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2317" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop2319" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2315"
+       id="radialGradient1358"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.000000,-2.843321e-17,5.340760e-18,0.509804,5.770894e-16,16.05392)"
+       cx="4.3920336"
+       cy="32.307854"
+       fx="4.3920336"
+       fy="32.307854"
+       r="6.3750000" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2315"
+       id="radialGradient1360"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.000000,-1.083254e-16,1.454372e-17,0.509804,1.185203e-14,16.05392)"
+       cx="4.3920336"
+       cy="32.307854"
+       fx="4.3920336"
+       fy="32.307854"
+       r="6.3750000" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2072"
+       id="radialGradient2078"
+       cx="23.250000"
+       cy="35.375000"
+       fx="23.250000"
+       fy="35.375000"
+       r="18.500000"
+       gradientTransform="matrix(1.000000,0.000000,0.000000,0.398649,0.000000,21.27280)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     fill="#9db029"
+     inkscape:window-y="160"
+     inkscape:window-x="219"
+     inkscape:window-height="688"
+     inkscape:window-width="810"
+     inkscape:showpageshadow="false"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     showgrid="false"
+     inkscape:current-layer="layer1"
+     inkscape:cy="27.236229"
+     inkscape:cx="73.976692"
+     inkscape:zoom="4"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="0.22745098"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Generic Audio</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/publicdomain/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1"
+     id="layer1">
+    <path
+       sodipodi:type="arc"
+       style="opacity:0.30000000;color:#000000;fill:url(#radialGradient2078);fill-opacity:1.0000000;fill-rule:evenodd;stroke:none;stroke-width:2.0000000;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dasharray:none;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:inline;overflow:visible"
+       id="path1344"
+       sodipodi:cx="23.250000"
+       sodipodi:cy="35.375000"
+       sodipodi:rx="18.500000"
+       sodipodi:ry="7.3750000"
+       d="M 41.750000 35.375000 A 18.500000 7.3750000 0 1 1  4.7500000,35.375000 A 18.500000 7.3750000 0 1 1  41.750000 35.375000 z"
+       transform="translate(0.000000,2.834646)" />
+    <path
+       sodipodi:nodetypes="cccccccccccccc"
+       id="path7042"
+       d="M 41.625000,7.7951523 C 41.625000,7.7951523 18.562500,10.629798 18.562500,10.629798 L 18.562500,32.411048 C 16.916545,31.853397 14.630715,31.707619 12.125000,32.223548 C 7.7686860,33.120517 4.6471398,35.523035 5.1250000,37.567298 C 5.6028601,39.611561 9.5186850,40.558018 13.875000,39.661048 C 17.991641,38.813428 21.559123,36.623246 21.477633,34.661048 L 21.633883,15.629798 C 21.633883,15.629798 38.564340,12.734492 38.564340,12.734492 L 38.564340,30.019106 C 28.314340,28.519106 25.272139,32.912342 25.750000,34.956606 C 26.227860,37.000869 30.143686,37.947325 34.500000,37.050356 C 38.365376,36.254471 41.132410,34.287145 41.406250,32.425356 L 41.625000,7.7951523 z "
+       style="color:#000000;fill:#9db029;fill-opacity:1.0000000;fill-rule:nonzero;stroke:#596616;stroke-width:1.0000000;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:block" />
+    <path
+       style="opacity:0.51176471;color:#000000;fill:none;fill-opacity:1.0000000;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dasharray:none;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:block"
+       d="M 40.729036,8.8956383 C 40.729036,8.8956383 19.547267,11.730284 19.547267,11.730284 L 19.547267,33.568621 C 11.982012,31.663311 5.8141632,35.403030 6.2685944,37.347065 C 6.9730255,40.666100 20.646969,38.449299 20.569474,34.208305 L 20.718063,14.735139 C 20.718063,14.735139 39.568437,11.842807 39.568437,11.842807 L 39.568437,31.279973 C 32.002153,29.353326 26.302939,32.656357 26.757371,34.600393 C 27.336802,37.794428 39.135597,36.713755 40.521011,31.943247 L 40.729036,8.8956383 z "
+       id="path2311"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       sodipodi:type="arc"
+       style="opacity:0.51176471;color:#000000;fill:url(#radialGradient1358);fill-opacity:1.0000000;fill-rule:nonzero;stroke:none;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dasharray:none;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:block;overflow:visible"
+       id="path2313"
+       sodipodi:cx="5.8750000"
+       sodipodi:cy="32.750000"
+       sodipodi:rx="6.3750000"
+       sodipodi:ry="3.2500000"
+       d="M 12.250000 32.750000 A 6.3750000 3.2500000 0 1 1  -0.50000000,32.750000 A 6.3750000 3.2500000 0 1 1  12.250000 32.750000 z"
+       transform="matrix(0.734516,-0.111645,0.111645,0.734516,3.903362,12.22551)" />
+    <path
+       transform="matrix(0.734516,-0.111645,0.111645,0.734516,23.74587,9.390864)"
+       d="M 12.250000 32.750000 A 6.3750000 3.2500000 0 1 1  -0.50000000,32.750000 A 6.3750000 3.2500000 0 1 1  12.250000 32.750000 z"
+       sodipodi:ry="3.2500000"
+       sodipodi:rx="6.3750000"
+       sodipodi:cy="32.750000"
+       sodipodi:cx="5.8750000"
+       id="path2323"
+       style="opacity:0.51176471;color:#000000;fill:url(#radialGradient1360);fill-opacity:1.0000000;fill-rule:nonzero;stroke:none;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dasharray:none;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:block;overflow:visible"
+       sodipodi:type="arc" />
+  </g>
+</svg>

--- a/frescobaldi_app/icons/Audio-x-generic.svg
+++ b/frescobaldi_app/icons/Audio-x-generic.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -9,14 +10,14 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   sodipodi:docname="audio-x-generic.svg"
-   sodipodi:docbase="/home/tigert/cvs/freedesktop.org/tango-icon-theme/scalable/mimetypes"
-   inkscape:version="0.46"
+   sodipodi:docname="Audio-x-generic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:version="0.32"
    id="svg7032"
    height="48.000000px"
    width="48.000000px"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
   <defs
      id="defs3">
     <inkscape:perspective
@@ -26,18 +27,6 @@
        inkscape:vp_z="48 : 24 : 1"
        inkscape:persp3d-origin="24 : 16 : 1"
        id="perspective21" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient2072">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop2074" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop2076" />
-    </linearGradient>
     <linearGradient
        inkscape:collect="always"
        id="linearGradient2315">
@@ -72,24 +61,13 @@
        fx="4.3920336"
        fy="32.307854"
        r="6.3750000" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2072"
-       id="radialGradient2078"
-       cx="23.250000"
-       cy="35.375000"
-       fx="23.250000"
-       fy="35.375000"
-       r="18.500000"
-       gradientTransform="matrix(1.000000,0.000000,0.000000,0.398649,0.000000,21.27280)"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      fill="#9db029"
-     inkscape:window-y="160"
-     inkscape:window-x="219"
-     inkscape:window-height="688"
-     inkscape:window-width="810"
+     inkscape:window-y="0"
+     inkscape:window-x="0"
+     inkscape:window-height="1019"
+     inkscape:window-width="1920"
      inkscape:showpageshadow="false"
      inkscape:document-units="px"
      inkscape:grid-bbox="true"
@@ -103,7 +81,8 @@
      borderopacity="0.22745098"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base" />
+     id="base"
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -137,44 +116,32 @@
      inkscape:label="Layer 1"
      id="layer1">
     <path
-       sodipodi:type="arc"
-       style="opacity:0.30000000;color:#000000;fill:url(#radialGradient2078);fill-opacity:1.0000000;fill-rule:evenodd;stroke:none;stroke-width:2.0000000;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dasharray:none;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:inline;overflow:visible"
-       id="path1344"
-       sodipodi:cx="23.250000"
-       sodipodi:cy="35.375000"
-       sodipodi:rx="18.500000"
-       sodipodi:ry="7.3750000"
-       d="M 41.750000 35.375000 A 18.500000 7.3750000 0 1 1  4.7500000,35.375000 A 18.500000 7.3750000 0 1 1  41.750000 35.375000 z"
-       transform="translate(0.000000,2.834646)" />
-    <path
        sodipodi:nodetypes="cccccccccccccc"
        id="path7042"
-       d="M 41.625000,7.7951523 C 41.625000,7.7951523 18.562500,10.629798 18.562500,10.629798 L 18.562500,32.411048 C 16.916545,31.853397 14.630715,31.707619 12.125000,32.223548 C 7.7686860,33.120517 4.6471398,35.523035 5.1250000,37.567298 C 5.6028601,39.611561 9.5186850,40.558018 13.875000,39.661048 C 17.991641,38.813428 21.559123,36.623246 21.477633,34.661048 L 21.633883,15.629798 C 21.633883,15.629798 38.564340,12.734492 38.564340,12.734492 L 38.564340,30.019106 C 28.314340,28.519106 25.272139,32.912342 25.750000,34.956606 C 26.227860,37.000869 30.143686,37.947325 34.500000,37.050356 C 38.365376,36.254471 41.132410,34.287145 41.406250,32.425356 L 41.625000,7.7951523 z "
-       style="color:#000000;fill:#9db029;fill-opacity:1.0000000;fill-rule:nonzero;stroke:#596616;stroke-width:1.0000000;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:block" />
+       d="m 41.625,7.7951523 c 0,0 -23.0625,2.8346457 -23.0625,2.8346457 v 21.78125 c -1.645955,-0.557651 -3.931785,-0.703429 -6.4375,-0.1875 -4.356314,0.896969 -7.4778602,3.299487 -7,5.34375 0.4778601,2.044263 4.393685,2.99072 8.75,2.09375 4.116641,-0.84762 7.684123,-3.037802 7.602633,-5 l 0.15625,-19.03125 c 0,0 16.930457,-2.895306 16.930457,-2.895306 v 17.284614 c -10.25,-1.5 -13.292201,2.893236 -12.81434,4.9375 0.47786,2.044263 4.393686,2.990719 8.75,2.09375 3.865376,-0.795885 6.63241,-2.763211 6.90625,-4.625 z"
+       style="color:#000000;display:block;visibility:visible;fill:#9db029;fill-opacity:1;fill-rule:nonzero;stroke:#596616;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       inkscape:connector-curvature="0" />
     <path
-       style="opacity:0.51176471;color:#000000;fill:none;fill-opacity:1.0000000;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dasharray:none;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:block"
-       d="M 40.729036,8.8956383 C 40.729036,8.8956383 19.547267,11.730284 19.547267,11.730284 L 19.547267,33.568621 C 11.982012,31.663311 5.8141632,35.403030 6.2685944,37.347065 C 6.9730255,40.666100 20.646969,38.449299 20.569474,34.208305 L 20.718063,14.735139 C 20.718063,14.735139 39.568437,11.842807 39.568437,11.842807 L 39.568437,31.279973 C 32.002153,29.353326 26.302939,32.656357 26.757371,34.600393 C 27.336802,37.794428 39.135597,36.713755 40.521011,31.943247 L 40.729036,8.8956383 z "
+       style="color:#000000;display:block;visibility:visible;opacity:0.51176471;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       d="m 40.729036,8.8956383 c 0,0 -21.181769,2.8346457 -21.181769,2.8346457 V 33.568621 C 11.982012,31.663311 5.8141632,35.40303 6.2685944,37.347065 6.9730255,40.6661 20.646969,38.449299 20.569474,34.208305 l 0.148589,-19.473166 c 0,0 18.850374,-2.892332 18.850374,-2.892332 v 19.437166 c -7.566284,-1.926647 -13.265498,1.376384 -12.811066,3.32042 0.579431,3.194035 12.378226,2.113362 13.76364,-2.657146 z"
        id="path2311"
-       sodipodi:nodetypes="ccccccccccc" />
-    <path
-       sodipodi:type="arc"
-       style="opacity:0.51176471;color:#000000;fill:url(#radialGradient1358);fill-opacity:1.0000000;fill-rule:nonzero;stroke:none;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dasharray:none;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:block;overflow:visible"
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:connector-curvature="0" />
+    <ellipse
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.51176471;fill:url(#radialGradient1358);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
        id="path2313"
-       sodipodi:cx="5.8750000"
-       sodipodi:cy="32.750000"
-       sodipodi:rx="6.3750000"
-       sodipodi:ry="3.2500000"
-       d="M 12.250000 32.750000 A 6.3750000 3.2500000 0 1 1  -0.50000000,32.750000 A 6.3750000 3.2500000 0 1 1  12.250000 32.750000 z"
-       transform="matrix(0.734516,-0.111645,0.111645,0.734516,3.903362,12.22551)" />
-    <path
+       transform="matrix(0.734516,-0.111645,0.111645,0.734516,3.903362,12.22551)"
+       cx="5.875"
+       cy="32.75"
+       rx="6.375"
+       ry="3.25" />
+    <ellipse
        transform="matrix(0.734516,-0.111645,0.111645,0.734516,23.74587,9.390864)"
-       d="M 12.250000 32.750000 A 6.3750000 3.2500000 0 1 1  -0.50000000,32.750000 A 6.3750000 3.2500000 0 1 1  12.250000 32.750000 z"
-       sodipodi:ry="3.2500000"
-       sodipodi:rx="6.3750000"
-       sodipodi:cy="32.750000"
-       sodipodi:cx="5.8750000"
        id="path2323"
-       style="opacity:0.51176471;color:#000000;fill:url(#radialGradient1360);fill-opacity:1.0000000;fill-rule:nonzero;stroke:none;stroke-width:1.0000000;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4.0000000;stroke-dasharray:none;stroke-dashoffset:0.0000000;stroke-opacity:1.0000000;visibility:visible;display:block;overflow:visible"
-       sodipodi:type="arc" />
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.51176471;fill:url(#radialGradient1360);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+       cx="5.875"
+       cy="32.75"
+       rx="6.375"
+       ry="3.25" />
   </g>
 </svg>

--- a/frescobaldi_app/icons/music-directions.ly
+++ b/frescobaldi_app/icons/music-directions.ly
@@ -1,0 +1,20 @@
+\version "2.19.82"
+% To be compiled with -dcrop to .svg and cropped again in (e.g.) Inkscape
+{
+  \omit Staff.StaffSymbol
+  \omit Staff.Clef
+  \omit Staff.TimeSignature
+  \omit Staff.NoteHead
+  \omit Staff.Stem
+  <<
+    {
+      \voiceOne
+      g'' \fermata
+    }
+    \new Voice {
+      \voiceTwo
+      \once \override Script.extra-offset = #'(0 . 3)
+      g''\fermata
+    }
+  >>
+}

--- a/frescobaldi_app/icons/music-directions.svg
+++ b/frescobaldi_app/icons/music-directions.svg
@@ -9,11 +9,11 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.2"
-   width="4.6649747mm"
-   height="8.0021172mm"
-   viewBox="8.5358 0.002 2.6560001 4.5540306"
+   width="8.00212mm"
+   height="8.00212mm"
+   viewBox="8.5358 0.002 4.5560015 4.5540322"
    id="svg10"
-   sodipodi:docname="music-directions.cropped.svg"
+   sodipodi:docname="music-directions.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <metadata
      id="metadata16">
@@ -38,24 +38,24 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="922"
-     inkscape:window-height="497"
+     inkscape:window-width="1920"
+     inkscape:window-height="1019"
      id="namedview12"
      showgrid="false"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:zoom="4.7054758"
-     inkscape:cx="6.5752642"
-     inkscape:cy="5.1646187"
+     inkscape:zoom="18.821903"
+     inkscape:cx="0.31407313"
+     inkscape:cy="4.9192923"
      inkscape:window-x="0"
      inkscape:window-y="0"
-     inkscape:window-maximized="0"
+     inkscape:window-maximized="1"
      inkscape:current-layer="svg10" />
   <g
      id="g827"
-     transform="translate(-0.672,3.672837e-4)">
+     transform="translate(0.36790088,-0.00763456)">
     <a
        id="a4"
        xlink:href="textedit:///home/uliska/git/lilypond/frescobaldi/frescobaldi_app/icons/music-directions.ly:23:9:10"

--- a/frescobaldi_app/icons/music-directions.svg
+++ b/frescobaldi_app/icons/music-directions.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.2"
+   width="4.6649747mm"
+   height="8.0021172mm"
+   viewBox="8.5358 0.002 2.6560001 4.5540306"
+   id="svg10"
+   sodipodi:docname="music-directions.cropped.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="922"
+     inkscape:window-height="497"
+     id="namedview12"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.7054758"
+     inkscape:cx="6.5752642"
+     inkscape:cy="5.1646187"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg10" />
+  <g
+     id="g827"
+     transform="translate(-0.672,3.672837e-4)">
+    <a
+       id="a4"
+       xlink:href="textedit:///home/uliska/git/lilypond/frescobaldi/frescobaldi_app/icons/music-directions.ly:23:9:10"
+       style="color:inherit">
+      <path
+         style="fill:currentColor"
+         inkscape:connector-curvature="0"
+         id="path2"
+         d="m -67,-48 c 0,37 30,67 67,67 37,0 67,-30 67,-67 0,-37 -30,-67 -67,-67 -37,0 -67,30 -67,67 z M 0,-363 c -157,0 -332,176 -332,366 0,9 10,15 19,15 9,0 17,-5 19,-18 26,-148 146,-262 294,-262 148,0 268,114 294,262 2,13 10,18 19,18 9,0 19,-6 19,-15 0,-190 -175,-366 -332,-366 z"
+         transform="matrix(0.004,0,0,-0.004,10.5358,3.104)" />
+    </a>
+    <a
+       id="a8"
+       xlink:href="textedit:///home/uliska/git/lilypond/frescobaldi/frescobaldi_app/icons/music-directions.ly:18:10:11"
+       style="color:inherit">
+      <path
+         style="fill:currentColor"
+         inkscape:connector-curvature="0"
+         id="path6"
+         d="m -67,48 c 0,37 30,67 67,67 37,0 67,-30 67,-67 0,-37 -30,-67 -67,-67 -37,0 -67,30 -67,67 z M 0,363 c 157,0 332,-176 332,-366 0,-9 -10,-15 -19,-15 -9,0 -17,5 -19,18 C 268,148 148,262 0,262 -148,262 -268,148 -294,0 c -2,-13 -10,-18 -19,-18 -9,0 -19,6 -19,15 0,190 175,366 332,366 z"
+         transform="matrix(0.004,0,0,-0.004,10.5358,1.452)" />
+    </a>
+  </g>
+</svg>

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -286,15 +286,11 @@ def menu_lilypond_generated_files(mainwindow):
 def menu_tools(mainwindow):
     m = Menu(_('menu title', '&Tools'), mainwindow)
 
-    ac = documentactions.get(mainwindow).actionCollection
-    m.addAction(ac.tools_indent_auto)
-    m.addAction(ac.tools_indent_indent)
-    m.addAction(ac.tools_reformat)
-    m.addAction(ac.tools_remove_trailing_whitespace)
-    m.addSeparator()
     ac = autocomplete.CompleterManager.instance(mainwindow).actionCollection
     m.addAction(ac.autocomplete)
     m.addAction(ac.popup_completions)
+    m.addSeparator()
+    m.addMenu(menu_tools_format(mainwindow))
     m.addSeparator()
     m.addMenu(menu_tools_pitch(mainwindow))
     m.addMenu(menu_tools_rest(mainwindow))
@@ -308,6 +304,17 @@ def menu_tools(mainwindow):
     m.addAction(mainwindow.actionCollection.file_open_command_prompt)
     m.addSeparator()
     panelmanager.manager(mainwindow).addActionsToMenu(m)
+    return m
+
+
+def menu_tools_format(mainwindow):
+    m = Menu(_('submenu title', "Code &Formatting"), mainwindow)
+    m.setIcon(icons.get('document-edit'))
+    ac = documentactions.get(mainwindow).actionCollection
+    m.addAction(ac.tools_indent_auto)
+    m.addAction(ac.tools_indent_indent)
+    m.addAction(ac.tools_reformat)
+    m.addAction(ac.tools_remove_trailing_whitespace)
     return m
 
 
@@ -434,5 +441,3 @@ def menu_help(mainwindow):
     m.addSeparator()
     m.addAction(ac.help_about)
     return m
-
-

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -312,6 +312,7 @@ def menu_tools_format(mainwindow):
 
 def menu_tools_transform(mainwindow):
     m = Menu(_('submenu title', "Musical &Transformations"), mainwindow)
+    m.setIcon(icons.get('Audio-x-generic'))
     m.addMenu(menu_tools_pitch(mainwindow))
     m.addMenu(menu_tools_rest(mainwindow))
     m.addMenu(menu_tools_rhythm(mainwindow))
@@ -390,8 +391,7 @@ def menu_tools_rhythm(mainwindow):
 
 def menu_tools_directions(mainwindow):
     m = Menu(_('submenu title', "&Directions"), mainwindow)
-# TODO: Find/make a suitable icon
-#    m.setIcon(icons.get('edit-clear'))
+    m.setIcon(icons.get('music-directions'))
     ac = documentactions.DocumentActions.instance(mainwindow).actionCollection
     m.addAction(ac.tools_directions_force_up)
     m.addAction(ac.tools_directions_force_neutral)

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -291,12 +291,7 @@ def menu_tools(mainwindow):
     m.addAction(ac.popup_completions)
     m.addSeparator()
     m.addMenu(menu_tools_format(mainwindow))
-    m.addSeparator()
-    m.addMenu(menu_tools_pitch(mainwindow))
-    m.addMenu(menu_tools_rest(mainwindow))
-    m.addMenu(menu_tools_rhythm(mainwindow))
-    m.addMenu(menu_tools_lyrics(mainwindow))
-    m.addMenu(menu_tools_quick_remove(mainwindow))
+    m.addMenu(menu_tools_transform(mainwindow))
     m.addSeparator()
     ac = documentactions.get(mainwindow).actionCollection
     m.addAction(ac.tools_convert_ly)
@@ -317,6 +312,14 @@ def menu_tools_format(mainwindow):
     m.addAction(ac.tools_remove_trailing_whitespace)
     return m
 
+def menu_tools_transform(mainwindow):
+    m = Menu(_('submenu title', "Musical &Transformations"), mainwindow)
+    m.addMenu(menu_tools_pitch(mainwindow))
+    m.addMenu(menu_tools_rest(mainwindow))
+    m.addMenu(menu_tools_rhythm(mainwindow))
+    m.addMenu(menu_tools_lyrics(mainwindow))
+    m.addMenu(menu_tools_quick_remove(mainwindow))
+    return m
 
 def menu_tools_lyrics(mainwindow):
     m = Menu(_('submenu title', "&Lyrics"), mainwindow)

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -274,7 +274,6 @@ def menu_lilypond(mainwindow):
     m.addSeparator()
     m.addMenu(menu_lilypond_generated_files(mainwindow))
     m.addSeparator()
-    m.addAction(ac.engrave_open_lilypond_datadir)
     m.addAction(ac.engrave_show_available_fonts)
     return m
 
@@ -295,8 +294,7 @@ def menu_tools(mainwindow):
     dac = documentactions.get(mainwindow).actionCollection
     m.addAction(dac.tools_convert_ly)
     m.addSeparator()
-    m.addAction(mainwindow.actionCollection.file_open_current_directory)
-    m.addAction(mainwindow.actionCollection.file_open_command_prompt)
+    m.addMenu(menu_tools_directories(mainwindow))
     m.addSeparator()
     panelmanager.manager(mainwindow).addActionsToMenu(m)
     return m
@@ -406,6 +404,15 @@ def menu_tools_quick_remove(mainwindow):
     m.addAction(ac.tools_quick_remove_markup)
     return m
 
+def menu_tools_directories(mainwindow):
+    m = Menu(_('submenu title', "&Directories"), mainwindow)
+    m.setIcon(icons.get('folder-open'))
+    m.addAction(mainwindow.actionCollection.file_open_current_directory)
+    m.addAction(mainwindow.actionCollection.file_open_command_prompt)
+    m.addSeparator()
+    ac = engrave.engraver(mainwindow).actionCollection
+    m.addAction(ac.engrave_open_lilypond_datadir)
+    return m
 
 def menu_document(mainwindow):
     return documentmenu.DocumentMenu(mainwindow)

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -292,9 +292,9 @@ def menu_tools(mainwindow):
     m.addSeparator()
     m.addMenu(menu_tools_format(mainwindow))
     m.addMenu(menu_tools_transform(mainwindow))
+    dac = documentactions.get(mainwindow).actionCollection
+    m.addAction(dac.tools_convert_ly)
     m.addSeparator()
-    ac = documentactions.get(mainwindow).actionCollection
-    m.addAction(ac.tools_convert_ly)
     m.addAction(mainwindow.actionCollection.file_open_current_directory)
     m.addAction(mainwindow.actionCollection.file_open_command_prompt)
     m.addSeparator()

--- a/frescobaldi_app/panelmanager.py
+++ b/frescobaldi_app/panelmanager.py
@@ -60,6 +60,10 @@ class PanelManager(plugin.MainWindowPlugin):
                 'menu': QMenu(_('&Structure')),
                 'panels': []
             }),
+            ('midi', {
+                'menu': QMenu(_('&MIDI')),
+                'panels': []
+            }),
             ])
 
         # add the the panel stubs here
@@ -68,14 +72,14 @@ class PanelManager(plugin.MainWindowPlugin):
         self.loadPanel("viewers.manuscript.ManuscriptViewPanel", "viewers")
         self.loadPanel("docbrowser.HelpBrowser", "viewers")
         self.loadPanel("logtool.LogTool", "viewers")
+        self.loadPanel("layoutcontrol.LayoutControlOptions", "viewers")
         self.loadPanel("quickinsert.QuickInsertPanel", "coding")
         self.loadPanel("charmap.CharMap", "coding")
         self.loadPanel("snippet.tool.SnippetTool", "coding")
         self.loadPanel("doclist.DocumentList", "structure")
         self.loadPanel("outline.OutlinePanel", "structure")
-        self.loadPanel("miditool.MidiTool")
-        self.loadPanel("midiinput.tool.MidiInputTool")
-        self.loadPanel("layoutcontrol.LayoutControlOptions")
+        self.loadPanel("miditool.MidiTool", "midi")
+        self.loadPanel("midiinput.tool.MidiInputTool", "midi")
 
         # The Object editor is highly experimental and should be
         # commented out for stable releases.

--- a/frescobaldi_app/panelmanager.py
+++ b/frescobaldi_app/panelmanager.py
@@ -91,7 +91,6 @@ class PanelManager(plugin.MainWindowPlugin):
         mainwindow.tabifyDockWidget(self.musicview, self.docbrowser)
         mainwindow.tabifyDockWidget(self.musicview, self.svgview)
 
-        print(self._submenus)
 
     def loadPanel(self, name, submenu=None):
         """Loads the named Panel.

--- a/frescobaldi_app/panelmanager.py
+++ b/frescobaldi_app/panelmanager.py
@@ -23,8 +23,10 @@ Manages the Panels (Tools).
 
 
 import sys
+import collections
 
 from PyQt5.QtCore import QSettings
+from PyQt5.QtWidgets import QMenu
 
 import actioncollection
 import actioncollectionmanager
@@ -45,33 +47,49 @@ class PanelManager(plugin.MainWindowPlugin):
 
         """
         self._panels = []
+        self._submenus = collections.OrderedDict([
+            ('viewers', {
+                'menu': QMenu(_('&Viewers')),
+                'panels': []
+            }),
+            ('coding', {
+                'menu': QMenu(_('&Coding')),
+                'panels': []
+            }),
+            ('structure', {
+                'menu': QMenu(_('&Structure')),
+                'panels': []
+            }),
+            ])
 
         # add the the panel stubs here
-        self.loadPanel("quickinsert.QuickInsertPanel")
-        self.loadPanel("musicview.MusicViewPanel")
-        self.loadPanel("svgview.SvgViewPanel")
-        self.loadPanel("viewers.manuscript.ManuscriptViewPanel")
-        self.loadPanel("logtool.LogTool")
-        self.loadPanel("docbrowser.HelpBrowser")
-        self.loadPanel("snippet.tool.SnippetTool")
+        self.loadPanel("musicview.MusicViewPanel", "viewers")
+        self.loadPanel("svgview.SvgViewPanel", "viewers")
+        self.loadPanel("viewers.manuscript.ManuscriptViewPanel", "viewers")
+        self.loadPanel("docbrowser.HelpBrowser", "viewers")
+        self.loadPanel("logtool.LogTool", "viewers")
+        self.loadPanel("quickinsert.QuickInsertPanel", "coding")
+        self.loadPanel("charmap.CharMap", "coding")
+        self.loadPanel("snippet.tool.SnippetTool", "coding")
+        self.loadPanel("doclist.DocumentList", "structure")
+        self.loadPanel("outline.OutlinePanel", "structure")
         self.loadPanel("miditool.MidiTool")
         self.loadPanel("midiinput.tool.MidiInputTool")
-        self.loadPanel("charmap.CharMap")
-        self.loadPanel("doclist.DocumentList")
-        self.loadPanel("outline.OutlinePanel")
         self.loadPanel("layoutcontrol.LayoutControlOptions")
 
         # The Object editor is highly experimental and should be
         # commented out for stable releases.
         if app.is_git_controlled() or QSettings().value("experimental-features", False, bool):
-            self.loadPanel("objecteditor.ObjectEditor")
+            self.loadPanel("objecteditor.ObjectEditor", "coding")
         self.createActions()
 
         # make some default arrangements
         mainwindow.tabifyDockWidget(self.musicview, self.docbrowser)
         mainwindow.tabifyDockWidget(self.musicview, self.svgview)
 
-    def loadPanel(self, name):
+        print(self._submenus)
+
+    def loadPanel(self, name, submenu=None):
         """Loads the named Panel.
 
         The name consists of a module name and the class name of the Panel
@@ -90,6 +108,8 @@ class PanelManager(plugin.MainWindowPlugin):
         panel = cls(self.mainwindow())
         self._panels.append((attribute_name, panel))
         setattr(self, attribute_name, panel)
+        if submenu:
+            self._submenus[submenu]['panels'].append(panel)
 
     def createActions(self):
         self.actionCollection = Actions(self)
@@ -97,8 +117,18 @@ class PanelManager(plugin.MainWindowPlugin):
 
     def addActionsToMenu(self, menu):
         """Adds all toggleViewActions to the given menu."""
+        added_panels = []
+
+        for submenu in self._submenus:
+            sm = self._submenus[submenu]
+            for panel in sm['panels']:
+                sm['menu'].addAction(panel.toggleViewAction())
+                added_panels.append(panel)
+            menu.addMenu(sm['menu'])
+
         for name, panel in self._panels:
-            menu.addAction(panel.toggleViewAction())
+            if not panel in added_panels:
+                menu.addAction(panel.toggleViewAction())
 
     def panels_at(self, area):
         """Return the list of panels at the specified Qt.DockWidgetArea.
@@ -124,5 +154,3 @@ class Actions(actioncollection.ActionCollection):
         # add the actions for the plugins
         for name, panel in manager._panels:
             setattr(self, 'panel_' + name, panel.toggleViewAction())
-
-


### PR DESCRIPTION
The Tools menu is becoming too long IMO, so I think we should introduce additional submenus, even if that requires one more level to access some options. This PR introduces the following changes:

* New "Code Formatting" submenu with reformat, indent etc.  
  I have some ideas to add more "linting" commands that would further extend that list of commands, which is an additional incentive to move them in a submenu
* Submenus for Tools Panels

To be discussed:

* Naming of the panels submenus
* organization of panels in these submenus
* should the remaining tools also be moved to submenus, if so, what should they be called like
* If that is accepted the mnemonics for the panels can be reconsidered because they have to be unique only in their submenus
* Should the section from "Pitch" to "Quick Remove" also be moved to a submenu? That would be consistent but may move some regularly used commands one level deeper
* Should "Update with convert-ly" be moved to either the new "Code Formatting" submenu or to the LilyPond menu?
