### PR TITLE
PanelManager: Add panel_by_name() function

### DIFF
--- a/frescobaldi_app/panelmanager.py
+++ b/frescobaldi_app/panelmanager.py
@@ -148,6 +148,13 @@ class PanelManager(plugin.MainWindowPlugin):
                 result.append((name, panel))
         return result
 
+    def panel_by_name(self, name):
+        """Return the panel with the given name."""
+        for panel_name, panel in self._panels:
+            if name == panel_name:
+                return panel
+        return None
+
 
 class Actions(actioncollection.ActionCollection):
     """Manages the keyboard shortcuts to hide/show the plugins."""


### PR DESCRIPTION
This function is helpful to access any panels from anywhere else.

I think it is pretty lightweight - except if there's another way already present that I didn't see.


(relates to #1090)

Usage example:

```python
import panelmanager
manuscript_viewer = panelmanager.manager().panel_by_name('manuscript')
```