### PR TITLE
Ensure includepaths have trailing slashes

### DIFF
--- a/frescobaldi_app/engrave/command.py
+++ b/frescobaldi_app/engrave/command.py
@@ -39,6 +39,13 @@ def info(document):
     return lilypondinfo.preferred()
 
 
+def paths(includepath):
+    """Ensure paths have trailing slashes for Windows compatibility."""
+    result = []
+    for path in includepath:
+        result.append('-I' + path.rstrip('/') + '/')
+
+    
 def defaultJob(document, args=None):
     """Return a default job for the document.
 
@@ -80,7 +87,7 @@ def defaultJob(document, args=None):
         command.append('--pdf')
 
 
-    command.extend('-I' + path for path in includepath)
+    command.extend(paths(includepath))
     j.directory = os.path.dirname(filename)
     command.append(filename)
     j.command = command

--- a/frescobaldi_app/engrave/command.py
+++ b/frescobaldi_app/engrave/command.py
@@ -44,8 +44,9 @@ def paths(includepath):
     result = []
     for path in includepath:
         result.append('-I' + path.rstrip('/') + '/')
+    return result
 
-    
+
 def defaultJob(document, args=None):
     """Return a default job for the document.
 


### PR DESCRIPTION
Closes #1094

It seems LilyPond on Windows requires a trailing slash while Linux
doesn't care about this.

I don't know about Mac, though, so the PR should be tested on Mac
before that.