### PR TITLE
#1105: Fix external file import

### DIFF
--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -206,7 +206,7 @@ class Dialog(QDialog):
                 k, v = job.lilypond.parse_d_option(t)
                 j.set_d_option(k, v)
             else:
-                j.add_additional_arg(t)
+                j.add_argument(t)
 
         # Set environment variables for the job
         if self.englishCheck.isChecked():

--- a/frescobaldi_app/file_import/abc.py
+++ b/frescobaldi_app/file_import/abc.py
@@ -40,9 +40,6 @@ class Dialog(toly_dialog.ToLyDialog):
 
     def __init__(self, parent=None):
 
-        self.imp_prgm = "abc2ly"
-        self.userg = "abc_import"
-
         self.nobeamCheck = QCheckBox()
 
         self.impChecks = [self.nobeamCheck]
@@ -51,12 +48,13 @@ class Dialog(toly_dialog.ToLyDialog):
 
         self.impExtra = []
 
-        super(Dialog, self).__init__(parent)
+        super(Dialog, self).__init__(
+            parent,
+            imp_prgm='abc2ly',
+            userg='abc_import')
 
         app.translateUI(self)
         qutil.saveDialogSize(self, "abc_import/dialog/size", QSize(480, 160))
-
-        self.makeCommandLine()
 
         self.loadSettings()
 
@@ -67,29 +65,10 @@ class Dialog(toly_dialog.ToLyDialog):
 
         super(Dialog, self).translateUI()
 
-    def makeCommandLine(self):
-        """Reads the widgets and builds a command line."""
-        cmd = ["$abc2ly"]
+    def configure_job(self):
+        super(Dialog, self).configure_job()
         if self.nobeamCheck.isChecked():
-            cmd.append('-b')
-
-        cmd.append("$filename")
-        self.commandLine.setText(' '.join(cmd))
-
-    def run_command(self):
-        """ABC import needs a specific solution because it always writes
-        results to a file."""
-        j = super().run_command(output_file='document.ly')
-        if j.success:
-            temp_file = os.path.join(
-                os.path.dirname(self._document), 'document.ly')
-            with open(temp_file) as abc:
-                content = abc.read()
-            j.stdout = lambda: content
-            os.remove(temp_file)
-        else:
-            j.stdout = lambda: (_('Failed to import ABC')
-        return j
+            self._job.add_argument('-b')
 
     def loadSettings(self):
         """Get users previous settings."""

--- a/frescobaldi_app/file_import/midi.py
+++ b/frescobaldi_app/file_import/midi.py
@@ -38,9 +38,6 @@ class Dialog(toly_dialog.ToLyDialog):
 
     def __init__(self, parent=None):
 
-        self.imp_prgm = "midi2ly"
-        self.userg = "midi_import"
-
         self.useAbsCheck = QCheckBox()
 
         self.impChecks = [self.useAbsCheck]
@@ -49,12 +46,13 @@ class Dialog(toly_dialog.ToLyDialog):
 
         self.impExtra = []
 
-        super(Dialog, self).__init__(parent)
+        super(Dialog, self).__init__(
+            parent,
+            imp_prgm='midi2ly',
+            userg='midi_import')
 
         app.translateUI(self)
         qutil.saveDialogSize(self, "midi_import/dialog/size", QSize(480, 260))
-
-        self.makeCommandLine()
 
         self.loadSettings()
 
@@ -65,14 +63,10 @@ class Dialog(toly_dialog.ToLyDialog):
 
         super(Dialog, self).translateUI()
 
-    def makeCommandLine(self):
-        """Reads the widgets and builds a command line."""
-        cmd = ["$midi2ly"]
+    def configure_job(self):
+        super(Dialog, self).configure_job()
         if self.useAbsCheck.isChecked():
-            cmd.append('-a')
-
-        cmd.append("$filename")
-        self.commandLine.setText(' '.join(cmd))
+            self._job.add_argument('-a')
 
     def loadSettings(self):
         """Get users previous settings."""

--- a/frescobaldi_app/file_import/musicxml.py
+++ b/frescobaldi_app/file_import/musicxml.py
@@ -29,6 +29,7 @@ from PyQt5.QtWidgets import (QCheckBox, QComboBox, QDialogButtonBox, QLabel)
 
 import app
 import qutil
+import job
 
 from . import toly_dialog
 
@@ -51,9 +52,6 @@ _langlist = [
 class Dialog(toly_dialog.ToLyDialog):
 
     def __init__(self, parent=None):
-
-        self.imp_prgm = "musicxml2ly"
-        self.userg = "musicxml_import"
 
         self.noartCheck = QCheckBox()
         self.norestCheck = QCheckBox()
@@ -84,13 +82,13 @@ class Dialog(toly_dialog.ToLyDialog):
 
         self.impExtra = [self.langLabel, self.langCombo]
 
-        super(Dialog, self).__init__(parent)
+        super(Dialog, self).__init__(
+            parent,
+            imp_prgm="musicxml2ly",
+            userg="musicxml_import")
 
-        self.langCombo.currentIndexChanged.connect(self.makeCommandLine)
         app.translateUI(self)
-        qutil.saveDialogSize(self, "musicxml_import/dialog/size", QSize(480, 260))
-
-        self.makeCommandLine()
+        qutil.saveDialogSize(self, "musicxml_import/dialog/size", QSize(480, 800))
 
         self.loadSettings()
 
@@ -110,27 +108,24 @@ class Dialog(toly_dialog.ToLyDialog):
 
         super(Dialog, self).translateUI()
 
-    def makeCommandLine(self):
-        """Reads the widgets and builds a command line."""
-        cmd = ["$musicxml2ly"]
+    def configure_job(self):
+        super(Dialog, self).configure_job()
+        j = self._job
         if self.useAbsCheck.isChecked():
-            cmd.append('-a')
+            j.add_argument('-a')
         if not self.noartCheck.isChecked():
-            cmd.append('--nd')
+            j.add_argument('--nd')
         if not self.norestCheck.isChecked():
-            cmd.append('--nrp')
+            j.add_argument('--nrp')
         if not self.nolayoutCheck.isChecked():
-            cmd.append('--npl')
+            j.add_argument('--npl')
         if not self.nobeamCheck.isChecked():
-            cmd.append('--no-beaming')
+            j.add_argument('--no-beaming')
         if not self.commMidiCheck.isChecked():
-            cmd.append('-m')
+            j.add_argument('-m')
         index = self.langCombo.currentIndex()
         if index > 0:
-            cmd.append('--language=' + _langlist[index - 1])
-
-        cmd.append("$filename")
-        self.commandLine.setText(' '.join(cmd))
+            j.add_argument('--language=' + _langlist[index - 1])
 
     def loadSettings(self):
         """Get users previous settings."""

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -24,6 +24,8 @@ Generic import dialog. Presuppose a child instance for the specific import.
 
 import os
 
+from PyQt5.QtCore import Qt
+
 from PyQt5.QtWidgets import (QCheckBox, QDialog, QDialogButtonBox,
     QGridLayout, QLabel, QTabWidget, QTextEdit, QWidget)
 
@@ -35,13 +37,31 @@ import job
 
 
 class ToLyDialog(QDialog):
+    """Dialog base class for all file import jobs.
 
-    def __init__(self, parent=None):
+    Basically the whole dialog is identical for all file types, the only
+    part of the dialog that is specific is the widget with *input* options.
+    These are created in a subclass's __init__ function and added to the
+    self.impChecks list. Only then super() is called.
+    """
+
+    def __init__(self,
+                 parent=None,
+                 job_class=job.Job,
+                 imp_prgm='',
+                 input=None,
+                 userg=''):
         super(ToLyDialog, self).__init__(parent)
         self._info = None
-        self._document = None
+        self._imp_prgm = imp_prgm
+        self._userg = userg
+        self._input = input
         self._path = None
+        self._job_class = job_class
+        self._job = None
 
+        self.addAction(parent.actionCollection.help_whatsthis)
+        self.setWindowModality(Qt.WindowModal)
         mainLayout = QGridLayout()
         self.setLayout(mainLayout)
 
@@ -53,8 +73,8 @@ class ToLyDialog(QDialog):
         itabLayout = QGridLayout(import_tab)
         ptabLayout = QGridLayout(post_tab)
 
-        tabs.addTab(import_tab, self.imp_prgm)
-        tabs.addTab(post_tab, "after import")
+        tabs.addTab(import_tab, self._imp_prgm)
+        tabs.addTab(post_tab, _("After Import"))
 
         self.formatCheck = QCheckBox()
         self.trimDurCheck = QCheckBox()
@@ -69,9 +89,6 @@ class ToLyDialog(QDialog):
         self.versionLabel = QLabel()
         self.lilyChooser = lilychooser.LilyChooser()
 
-        self.commandLineLabel = QLabel()
-        self.commandLine = QTextEdit(acceptRichText=False)
-
         self.formatCheck.setObjectName("reformat")
         self.trimDurCheck.setObjectName("trim-durations")
         self.removeScalesCheck.setObjectName("remove-scaling")
@@ -79,13 +96,12 @@ class ToLyDialog(QDialog):
 
         self.buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        userguide.addButton(self.buttons, self.userg)
+        userguide.addButton(self.buttons, self._userg)
 
         row = 0
         for r, w in enumerate(self.impChecks):
             row += r
             itabLayout.addWidget(w, row, 0, 1, 2)
-            w.toggled.connect(self.makeCommandLine)
         row += 1
         for r, w in enumerate(self.impExtra):
             row += r
@@ -94,73 +110,68 @@ class ToLyDialog(QDialog):
         itabLayout.addWidget(widgets.Separator(), row + 1, 0, 1, 2)
         itabLayout.addWidget(self.versionLabel, row + 2, 0, 1, 0)
         itabLayout.addWidget(self.lilyChooser, row + 3, 0, 1, 2)
-        itabLayout.addWidget(widgets.Separator(), row + 4, 0, 1, 2)
-        itabLayout.addWidget(self.commandLineLabel, row + 5, 0, 1, 2)
-        itabLayout.addWidget(self.commandLine, row + 6, 0, 1, 2)
+        itabLayout.setRowStretch(row + 4, 10)
 
         ptabLayout.addWidget(self.formatCheck, 0, 0, 1, 2)
         ptabLayout.addWidget(self.trimDurCheck, 1, 0, 1, 2)
         ptabLayout.addWidget(self.removeScalesCheck, 2, 0, 1, 2)
         ptabLayout.addWidget(self.runEngraverCheck, 3, 0, 1, 2)
-        ptabLayout.setRowStretch(4, 10)
+        ptabLayout.setRowStretch(4, 6)
 
-        mainLayout.addWidget(tabs, 0, 0, 9, 2)
-        mainLayout.addWidget(self.buttons, 10, 0, 1, 2)
+        mainLayout.addWidget(tabs, 0, 0, 6, 2)
+        mainLayout.addWidget(self.buttons, 7, 0, 1, 2)
 
-        self.buttons.accepted.connect(self.accept)
+        self.buttons.accepted.connect(self.about_to_accept)
         self.buttons.rejected.connect(self.reject)
 
-        self.lilyChooser.currentIndexChanged.connect(self.slotLilyPondVersionChanged)
-        self.slotLilyPondVersionChanged()
+        self.lilyChooser.currentIndexChanged.connect(self.slot_lilypond_version_changed)
+        self.slot_lilypond_version_changed()
 
     def translateUI(self):
         self.versionLabel.setText(_("LilyPond version:"))
-        self.commandLineLabel.setText(_("Command line:"))
         self.formatCheck.setText(_("Reformat source"))
         self.trimDurCheck.setText(_("Trim durations (Make implicit per line)"))
         self.removeScalesCheck.setText(_("Remove fraction duration scaling"))
         self.runEngraverCheck.setText(_("Engrave directly"))
 
-    def setDocument(self, path):
-        """Set the full path to the MusicXML document."""
-        self._document = path
+    def about_to_accept(self):
+        """Configure the job and close the dialog."""
+        self.configure_job()
+        self.accept()
 
-    def slotLilyPondVersionChanged(self):
-        self._info = self.lilyChooser.lilyPondInfo()
-
-    def getCmd(self, outputname='-'):
-        """Returns the command line."""
-        cmd = []
-        for t in self.commandLine.toPlainText().split():
-            if t == '$musicxml2ly':
-                cmd.extend(self._info.toolcommand('musicxml2ly'))
-            elif t == '$midi2ly':
-                cmd.extend(self._info.toolcommand('midi2ly'))
-            elif t == '$abc2ly':
-                cmd.extend(self._info.toolcommand('abc2ly'))
-            elif t == '$filename':
-                cmd.append(self._document)
-            else:
-                cmd.append(t)
-        cmd.extend(['--output', outputname])
-        return cmd
-
-    def run_command(self, output_file=None):
-        """Run command line."""
-        j = job.Job(command=self.getCmd(output_file),
-            directory=os.path.dirname(self._document),
+    def configure_job(self):
+        """Create and configure the job to be run.
+        Has to be completed by the subclasses."""
+        output = os.path.splitext(
+            os.path.join(util.tempdir(), os.path.basename(self._input))
+            )[0] + '.ly'
+        self._job = j = self._job_class(
+            command=self._info.toolcommand(self._imp_prgm),
+            input=self._input,
+            output='--output={}'.format(output),
+            directory=os.path.dirname(self._input),
             encoding='utf-8')
-        j.start()
-        if not j._process.waitForFinished(3000):
-            raise OSError("Process didn't complete in time")
-        return j
+        j._output_file = output
 
-    def getPostSettings(self):
+    def get_post_settings(self):
         """Returns settings in the post import tab."""
         post = []
         for p in self.postChecks:
             post.append(p.isChecked())
         return post
+
+    def job(self):
+        """Return the current job."""
+        if not self._job:
+            self.configure_job()
+        return self._job
+
+    def set_input(self, path):
+        """Set the full path to the input document."""
+        self._input = path
+
+    def slot_lilypond_version_changed(self):
+        self._info = self.lilyChooser.lilyPondInfo()
 
     def loadSettings(self):
         """Get users previous settings."""

--- a/frescobaldi_app/job/__init__.py
+++ b/frescobaldi_app/job/__init__.py
@@ -85,9 +85,20 @@ class Job(object):
     done = signals.Signal()
     title_changed = signals.Signal() # title (string)
 
-    def __init__(self, command=[], directory="", environment={},
-                 title="", decode_errors='strict', encoding='latin1'):
-        self.command = command
+    def __init__(self,
+        command=[],
+        args=None,
+        directory="",
+        environment={},
+        title="",
+        input="",
+        output="",
+        decode_errors='strict',
+        encoding='latin1'):
+        self.command = command if type(command) == list else [command]
+        self._input = input
+        self._output = output
+        self._arguments = args if args else []
         self.directory = directory
         self.environment = {}
         self._encoding = encoding
@@ -103,6 +114,18 @@ class Job(object):
         self.decoder_stderr = self.create_decoder(STDERR)
         self.decode_errors = decode_errors  # codecs error handling
 
+    def add_argument(self, arg):
+        """Append an additional command line argument if it is not
+        present already."""
+        if not arg in self._arguments:
+            self._arguments.append(arg)
+
+    def arguments(self):
+        """Additional (custom) arguments, will be inserted between
+        the -d options and the include paths. May for example stem
+        from the manual part of the Engrave Custom dialog."""
+        return self._arguments
+
     def create_decoder(self, channel):
         """Return a decoder for the given channel (STDOUT/STDERR).
 
@@ -117,6 +140,26 @@ class Job(object):
 
         """
         return codecs.getdecoder(self._encoding)
+
+    def filename(self):
+        """File name of the job's input document.
+        May be overridden for 'empty' jobs."""
+        return self._input
+
+    def set_input(self, filename):
+        self._input = filename
+
+    def set_input_file(self):
+        """configure the command to add an input file if one is specified."""
+        filename = self.filename()
+        if filename:
+            self.command.append(filename)
+
+    def output_argument(self):
+        return self._output
+
+    def output_file(self):
+        return self._output_file
 
     def title(self):
         """Return the job title, as set with set_title().
@@ -152,14 +195,29 @@ class Job(object):
             self._process.setWorkingDirectory(self.directory)
         if self.environment:
             self._update_process_environment()
+        print(self.command)
         self._process.start(self.command[0], self.command[1:])
 
     def configure_command(self):
         """Process the command if necessary.
         In a LilyPondJob this is the essential part of composing
         the command line from the job options.
+        This implementation simply creates a list from the main
+        command, any present arguments, the input and the output
+        (if present).
         """
-        pass
+        self.command.extend(self._arguments)
+        if self._input:
+            if type(self._input) == list:
+                self.command.extend(self._input)
+            else:
+                self.command.append(self._input)
+        if self._output:
+            if type(self._output) == list:
+                self.command.extend(self._output)
+            else:
+                self.command.append(self._output)
+        print(self.command)
 
     def start_time(self):
         """Return the time this job was started.

--- a/frescobaldi_app/job/__init__.py
+++ b/frescobaldi_app/job/__init__.py
@@ -195,7 +195,6 @@ class Job(object):
             self._process.setWorkingDirectory(self.directory)
         if self.environment:
             self._update_process_environment()
-        print(self.command)
         self._process.start(self.command[0], self.command[1:])
 
     def configure_command(self):
@@ -217,7 +216,6 @@ class Job(object):
                 self.command.extend(self._output)
             else:
                 self.command.append(self._output)
-        print(self.command)
 
     def start_time(self):
         """Return the time this job was started.

--- a/frescobaldi_app/job/dialog.py
+++ b/frescobaldi_app/job/dialog.py
@@ -1,0 +1,74 @@
+# This file is part of the Frescobaldi project, http://www.frescobaldi.org/
+#
+# Copyright (c) 2008 - 2015 by Wilbert Berendsen
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+# See http://www.gnu.org/licenses/ for more information.
+
+"""
+A Dialog to run an external command and simply show the log.
+"""
+
+from PyQt5.QtCore import Qt, QSize
+
+import log
+import qutil
+import signals
+import widgets.dialog
+
+class Dialog(widgets.dialog.Dialog):
+    """Dialog to run arbitrary external job.Job commands and show the log."""
+
+    job_done = signals.Signal()
+
+    def __init__(self, parent, auto_accept=False):
+        super(Dialog, self).__init__(
+            parent,
+            buttons=('cancel', 'ok',)
+        )
+        self.setWindowModality(Qt.WindowModal)
+        self.setIconSize(32)
+        self.auto_accept = auto_accept
+        self.log = log.Log(self)
+        self.job = None
+        self.setMainWidget(self.log)
+        qutil.saveDialogSize(self, "job-dialog/dialog/size", QSize(480, 800))
+
+    def abort_job(self):
+        self.job.abort()
+        self.reject()
+
+    def run(self, j, msg=_("Run external command")):
+        """Run the given job."""
+        self.job = j
+        self.job.done.connect(self.slot_job_done)
+        self.log.connectJob(j)
+        self.setWindowTitle(j.title())
+        self.setMessage(msg)
+        self.button('ok').setEnabled(False)
+        self.button('cancel').clicked.connect(self.abort_job)
+        j.start()
+        self.exec()
+
+    def slot_job_done(self):
+        if self.job.success:
+            if self.auto_accept:
+                self.accept()
+            self.button('ok').setEnabled(True)
+        else:
+            self.setMessage(_("Job failed! Please inspect log"))
+            self.setIcon('critical')
+        self.button('cancel').clicked.connect(self.reject)
+        self.job_done.emit()

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -91,10 +91,6 @@ class LilyPondJob(Job):
         self._backend_args = []
         self._input, self.includepath = (
             docinfo.jobinfo(True) if document else ('', []))
-        print("Document")
-        print(document)
-        print("File name")
-        print(self._input)
         self.directory = os.path.dirname(self._input)
         self.environment['LD_LIBRARY_PATH'] = self.lilypond_info.libdir()
         self.decode_errors = 'replace'  # codecs error handling

--- a/frescobaldi_app/job/lilypond.py
+++ b/frescobaldi_app/job/lilypond.py
@@ -83,16 +83,19 @@ class LilyPondJob(Job):
     """
 
     def __init__(self, document, args=None):
-        super(LilyPondJob, self).__init__(encoding='utf-8')
+        super(LilyPondJob, self).__init__(encoding='utf-8', args=args)
         self.document = document
         self.document_info = docinfo = documentinfo.info(document)
         self.lilypond_info = docinfo.lilypondinfo()
         self._d_options = {}
-        self._additional_args = args if args else []
         self._backend_args = []
-        self.filename, self.includepath = (
+        self._input, self.includepath = (
             docinfo.jobinfo(True) if document else ('', []))
-        self.directory = os.path.dirname(self.filename)
+        print("Document")
+        print(document)
+        print("File name")
+        print(self._input)
+        self.directory = os.path.dirname(self._input)
         self.environment['LD_LIBRARY_PATH'] = self.lilypond_info.libdir()
         self.decode_errors = 'replace'  # codecs error handling
 
@@ -111,18 +114,6 @@ class LilyPondJob(Job):
             os.path.basename(self.lilypond_info.command),
             self.lilypond_info.versionString(), document.documentName()))
 
-    def add_additional_arg(self, arg):
-        """Append an additional command line argument if it is not
-        present already."""
-        if not arg in self._additional_args:
-            self._additional_args.append(arg)
-
-    def additional_args(self):
-        """Additional (custom) arguments, will be inserted between
-        the -d options and the include paths. May for example stem
-        from the manual part of the Engrave Custom dialog."""
-        return self._additional_args
-
     def backend_args(self):
         """Determine the target/backend type and produce appropriate args."""
         result = self._backend_args
@@ -133,7 +124,7 @@ class LilyPondJob(Job):
                 result.append('-dbackend=svg')
             else:
                 # engrave to PDF
-                if not self.additional_args():
+                if not self.arguments():
                     # publish mode
                     if self.embed_source_code and self.lilypond_version >= (2, 19, 39):
                         result.append('-dembed-source-code')
@@ -143,21 +134,16 @@ class LilyPondJob(Job):
     def configure_command(self):
         """Compose the command line for a LilyPond job using all options.
         Individual steps may be overridden in subclasses."""
-        cmd = [self.lilypond_info.abscommand() or self.lilypond_info.command]
+        self.command = cmd = (
+            [self.lilypond_info.abscommand() or self.lilypond_info.command])
         cmd.extend(serialize_d_options(self._d_options))
-        cmd.extend(self.additional_args())
+        cmd.extend(self.arguments())
         cmd.extend(self.paths(self.includepath))
         cmd.extend(self.backend_args())
-        cmd.append(self.input_file())
-        self.command = cmd
+        self.set_input_file()
 
     def d_option(self, key):
         return self._d_options.get(key, None)
-
-    def input_file(self):
-        """File name of the job's document.
-        May be overridden for 'empty' jobs."""
-        return self.filename
 
     def paths(self, includepath):
         """Ensure paths have trailing slashes for Windows compatibility."""

--- a/frescobaldi_app/menu.py
+++ b/frescobaldi_app/menu.py
@@ -129,7 +129,7 @@ def menu_file_import(mainwindow):
     m = Menu(_("submenu title", "&Import"), mainwindow)
     ac = file_import.FileImport.instance(mainwindow).actionCollection
 
-    m.addAction(ac.import_all)
+    m.addAction(ac.import_any)
     m.addSeparator()
     m.addAction(ac.import_musicxml)
     m.addAction(ac.import_midi)


### PR DESCRIPTION
This closes #1105, but not only by removing the limitation to the import timeout but by a complete review of the way file imports are structured.

In terms of implementation much redundancy has been removed and the code streamlined.

For the user interface external imports are now displayed with the help of a (new) dialog running external jobs and displaying the logs.

Additionally the import now fails properly when the underlying import script fails (previously a truncated `.ly` file had been produced without giving any warning).