### PR TITLE
Change mouse pointer to "waiting" while opening documents

### DIFF
--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -26,7 +26,7 @@ The global things in Frescobaldi.
 import os
 import sys
 
-from PyQt5.QtCore import QSettings, QThread
+from PyQt5.QtCore import QSettings, QThread, Qt
 from PyQt5.QtWidgets import QApplication
 
 import appinfo
@@ -78,6 +78,7 @@ def openUrl(url, encoding=None):
     If there is already a document with that url, it is returned.
 
     """
+    qApp.setOverrideCursor(Qt.WaitCursor)
     d = findDocument(url)
     if not d:
         # special case if there is only one document:
@@ -92,8 +93,12 @@ def openUrl(url, encoding=None):
             if not url.isEmpty():
                 d.load(url)
         else:
+            #FIXME: Here no "time" is used, so the mouse pointer is
+            # restored prematurely. Somehow restoring should be
+            # postponed until syntax hinglighting is completed.
             import document
             d = document.EditorDocument.new_from_url(url, encoding)
+    qApp.restoreOverrideCursor()
     return d
 
 def findDocument(url):


### PR DESCRIPTION
Relates to #1109 

When loading large documents there may be a significant moment of
seeming inactivity. This commit changes the mouse pointer to "wait"
during that time.

**NOTE:** This only works when opening a document into the *first* tab.
Obviously *some* code inside AbstractDocument.load() must take
care of this (i.e. returning only when the document is *fully* loaded).
Therefore this pull request should *not* be merged yet.

@fedelibre please test this both with large original files and in conjunction with file import.