### PR TITLE
#1066: Respect Logtool font size setting

### DIFF
--- a/frescobaldi_app/log.py
+++ b/frescobaldi_app/log.py
@@ -120,8 +120,6 @@ class Log(QTextBrowser):
 
         output = QTextCharFormat()
         output.setFont(outputFont)
-        # enable zooming the log font size
-        output.setProperty(QTextFormat.FontSizeAdjustment, 0)
 
         stdout = QTextCharFormat(output)
         stdout.setForeground(stdoutColor)
@@ -131,7 +129,7 @@ class Log(QTextBrowser):
         link.setForeground(linkColor)
         link.setFontUnderline(True)
 
-        status = QTextCharFormat()
+        status = QTextCharFormat(output)
         status.setFontWeight(QFont.Bold)
 
         neutral = QTextCharFormat(status)


### PR DESCRIPTION
Closes #1066

There seems to be a conflict between letting the log font be zoomed
and respecting the Preference for font size.

So this makes the Log Tool consistent with how font sizes are managed
in the document editor. But the ability to *zoom* the log with the
mouse or keyboard shortcuts (?) is removed by that commit.

@mmeyn 