### PR TITLE
Require Python 3.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ ChangeLog of Frescobaldi, http://www.frescobaldi.org/
 
 Changes in 3.0.1 --
 
+* Requirement changes:
+  - Frescobaldi now requires Python3.3+
 * New features:
   - New "First System Only" option in Custom Engrave
   - Goto Line command (#927, feature request #676)

--- a/frescobaldi
+++ b/frescobaldi
@@ -1,6 +1,23 @@
 #!/usr/bin/env python3
 import sys
 
+required_python_version = (3, 3)
+if sys.version_info < required_python_version:
+    import os
+    from PyQt5.QtWidgets import QApplication, QMessageBox
+    _ = QApplication([])
+    box = QMessageBox()
+    box.setIcon(QMessageBox.Critical)
+    box.setWindowTitle("Frescobaldi")
+    box.setText("Python version too old")
+    box.setInformativeText(
+        "Frescobaldi is started with Python {}.{} "
+        "but requires at least version {}.{}.".format(
+          sys.version_info[0], sys.version_info[1],
+          required_python_version[0], required_python_version[1]))
+    box.exec()
+    sys.exit(1)
+
 from frescobaldi_app import toplevel
 toplevel.install()
 
@@ -13,4 +30,3 @@ main.main()                     # Parse command line, create windows etc
 sys.excepthook = app.excepthook # Show Python errors in a bugreport window
 
 sys.exit(app.run())
-

--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -110,10 +110,7 @@ def findDocument(url):
 def instantiate():
     """Instantiate the global QApplication object."""
     global qApp
-    args = [os.path.abspath(sys.argv[0])] + sys.argv[1:]
-    ### on Python3, QApplication args must be byte strings
-    if sys.version_info >= (3, 0):
-        args = list(map(os.fsencode, args))
+    args = list(map(os.fsencode, [os.path.abspath(sys.argv[0])] + sys.argv[1:]))
     qApp = QApplication(args)
     QApplication.setApplicationName(appinfo.name)
     QApplication.setApplicationVersion(appinfo.version)

--- a/frescobaldi_app/main.py
+++ b/frescobaldi_app/main.py
@@ -112,41 +112,6 @@ def url(arg):
         return QUrl.fromLocalFile(os.path.abspath(arg))
 
 
-def patch_pyqt():
-    """Patch PyQt classes to strip trailing null characters on Python 2
-
-    It works around a bug triggered by Unicode characters above 0xFFFF.
-    """
-    if sys.version_info >= (3, 3):
-        return
-
-    old_toLocalFile = QUrl.toLocalFile
-    QUrl.toLocalFile = lambda url: old_toLocalFile(url).rstrip('\0')
-
-    old_toString = QUrl.toString
-    QUrl.toString = lambda *args: old_toString(*args).rstrip('\0')
-
-    old_path = QUrl.path
-    QUrl.path = lambda self: old_path(self).rstrip('\0')
-
-    old_arguments = QApplication.arguments
-    QApplication.arguments = staticmethod(
-        lambda: [arg.rstrip('\0') for arg in old_arguments()])
-
-    from PyQt5.QtWidgets import QFileDialog
-    old_getOpenFileNames = QFileDialog.getOpenFileNames
-    QFileDialog.getOpenFileNames = staticmethod(
-        lambda *args: [f.rstrip('\0') for f in old_getOpenFileNames(*args)])
-
-    old_getOpenFileName = QFileDialog.getOpenFileName
-    QFileDialog.getOpenFileName = staticmethod(
-        lambda *args: old_getOpenFileName(*args).rstrip('\0'))
-
-    old_getSaveFileName = QFileDialog.getSaveFileName
-    QFileDialog.getSaveFileName = staticmethod(
-        lambda *args: old_getSaveFileName(*args).rstrip('\0'))
-
-
 def check_ly():
     """Check if ly is installed and has the correct version.
 
@@ -198,7 +163,6 @@ def main():
         sys.path.insert(1, args.python_ly)
 
     check_ly()
-    patch_pyqt()
 
     if args.list_sessions:
         import sessions

--- a/frescobaldi_app/midifile/parser.py
+++ b/frescobaldi_app/midifile/parser.py
@@ -37,9 +37,6 @@ import struct
 from . import event
 
 
-PY2 = sys.version_info[0] == 2
-
-
 unpack_midi_header = struct.Struct(b'>hhh').unpack
 unpack_int = struct.Struct(b'>i').unpack
 
@@ -107,9 +104,6 @@ def parse_midi_events(s, factory=None):
         factory = event.EventFactory()
 
     running_status = None
-
-    if PY2:
-        s = bytearray(s)
 
     pos = 0
     while pos < len(s):
@@ -220,6 +214,3 @@ if __name__ == '__main__':
         except Exception as e:
             print('error in:', f)
             print(e)
-
-
-

--- a/frescobaldi_app/snippet/insert.py
+++ b/frescobaldi_app/snippet/insert.py
@@ -161,10 +161,7 @@ def insert_python(text, cursor, name, view):
     }
     try:
         code = compile(text, "<snippet>", "exec")
-        if sys.version_info < (3, 0):
-            exec("exec code in namespace")
-        else:
-            exec(code, namespace)
+        exec(code, namespace)
         if 'main' in namespace:
             return namespace['main']()
     except Exception:
@@ -279,5 +276,3 @@ def handle_exception(name, view):
         block = textedit.document().findBlockByNumber(lineno-1)
         if block.isValid():
             textedit.setTextCursor(QTextCursor(block))
-
-


### PR DESCRIPTION
I stumbled over [`main.patch_pyqt`](https://github.com/wbsoft/frescobaldi/blob/master/frescobaldi_app/main.py#L115-L147) and think this can/should be dropped. Essentially this was necessary for Python2 and should *not* be necessary for Python3 anymore.

Based on the code in the function this "patch" was necessary until Python 3.2, but given the fact that Python 3.3 was released in 2013 and has "reached end-of-life" (see https://www.python.org/download/releases/3.3.3/) I think it's safe to drop it altogether and bump the requirement to Python 3.3.

This is also related to #1126.

I'm pretty sure there's no problem with this but wanted to ask for feedback anyway.