### PR TITLE
#1088 Autocompleter: Don't treat dot like ENTER

### DIFF
--- a/frescobaldi_app/widgets/completer.py
+++ b/frescobaldi_app/widgets/completer.py
@@ -56,7 +56,7 @@ class Completer(QCompleter):
             # a key was pressed while the popup is visible
             cur = self.textCursor()
             modifier = QApplication.keyboardModifiers()
-            if ev.key() in (Qt.Key_Return, Qt.Key_Enter) or ev.text() == '.':
+            if ev.key() in (Qt.Key_Return, Qt.Key_Enter):
                 # insert the highlighted completion
                 self.setCurrentRow(self.popup().currentIndex().row())
                 self.insertCompletion(self.currentIndex())
@@ -180,7 +180,7 @@ class Completer(QCompleter):
         prefix_len = len(self.completionPrefix())
         cursor.setPosition(cursor.position() - prefix_len - sel_len, cursor.KeepAnchor)
         cursor.insertText(self.completionModel().data(index, Qt.EditRole))
-       
+
     def insertPartialCompletion(self, index):
         """Called when a tab key is pressed. Here index in current index item selected
 
@@ -217,7 +217,7 @@ class Completer(QCompleter):
                         break
                     elif j == len(rows) - 1:
                         string = string + ch
-            
+
             if string != '':
                 cur = self.textCursor()
                 pos = cur.position()
@@ -226,7 +226,7 @@ class Completer(QCompleter):
                 cur.setPosition(pos + len(string), cur.KeepAnchor)
                 self.widget().setTextCursor(cur)
                 self.showCompletionPopup()
-        
+
     def acceptPartialCompletion(self):
         # if some text is selected it's a previous partial completion
         # "accept" by clearing selection and move cursor to the end.


### PR DESCRIPTION
#1088 describes how the fact that entering a dot makes editing harder
in cases when there is no completion intended (`\tweak Beam.` should
*not* complete to `beam-thickness`)

This commit removes the link from Enter/Return to `.`. That means that
entering the dot will *not* automatically complete to the first match
in the completer popup. If that is wanted one would now have to enter
ENTER plus the dot. This need for one more keystroke seems more than
worth it, considering less unintended completions.