### PR TITLE
Fix translateUI() memory management

### DIFF
--- a/frescobaldi_app/actioncollection.py
+++ b/frescobaldi_app/actioncollection.py
@@ -140,6 +140,8 @@ class ActionCollection(ActionCollectionBase):
         self._actions = dict(i for i in self.__dict__.items() if not i[0].startswith('_'))
         self.storeDefaults()
         self.load(False) # load the shortcuts without resettings defaults
+        # N.B. This relies on the ActionCollection's QActions not getting
+        # deleted in C++ other than through being garbage-collected in Python.
         app.translateUI(self)
 
     def createActions(self, parent=None):
@@ -358,5 +360,3 @@ class ShortcutCollection(ActionCollectionBase):
                 self.others[self.name].remove(ref)
             elif other is not self:
                 other.load()
-
-


### PR DESCRIPTION
Before, the translateUI() function connected a signal to its parameter's
translateUI() method, and never disconnected it. This had two
undesirable consequences: first, this would completely prevent garbage
collection for these objects, and second, it went wrong in case the
underlying C++ object behind a PyQt widget was deleted and the signal
later tried to retranslate it. Instead, translateUI() only stores weak
references now, allowing the retranslatable objects to still be
garbage-collected, and for QObjects, it removes the connection to the
signal as soon as the underlying C++ object is deleted.

Fixes https://github.com/frescobaldi/frescobaldi/issues/1505