### PR TITLE
Avoid extraneous document when creating file from command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the Frescobaldi project are documented in this file.
 - Fix error when changing the application language in the preferences (#1540)
 - Linux: fix menus sometimes detached from its parent on Wayland (#1541)
 - Ignore never-saved files when reloading (#1542)
+- Fix extraneous document when opening new file from the command line (#1556)
 
 ### Changed
 
@@ -1593,4 +1594,3 @@ README-translations.
 [3.1.1]: https://github.com/frescobaldi/frescobaldi/compare/v3.1...v3.1.1
 [3.1]: https://github.com/frescobaldi/frescobaldi/compare/v3.0.0...v3.1
 [3.0.0]: https://github.com/frescobaldi/frescobaldi/compare/v2.20.0...v3.0.0
-

--- a/frescobaldi_app/document.py
+++ b/frescobaldi_app/document.py
@@ -84,9 +84,13 @@ class AbstractDocument(QTextDocument):
         if loading the contents fails.
 
         """
+        # Do this first, raises IOError if not found, without creating the document.
+        if not url.isEmpty():
+            data = cls.load_data(url, encoding)
+        # If this did not raise, proceed to create a new document.
         d = cls(url, encoding)
         if not url.isEmpty():
-            d.setPlainText(cls.load_data(url, encoding))
+            d.setPlainText(data)
             d.setModified(False)
         return d
 


### PR DESCRIPTION
AbstractDocument.new_from_url is documented as "intended to open a new Document without instantiating one if loading the contents fails", but failed to do so, causing "frescobaldi nonexistent-document.ly" to open *two* new tabs with a new document for creating nonexistent-document.ly.

Fixes #1552