### PR TITLE
Remove warnings that -dembed-source-code requires LilyPond 2.19.39+

### DIFF
--- a/frescobaldi_app/engrave/custom.py
+++ b/frescobaldi_app/engrave/custom.py
@@ -135,7 +135,7 @@ class Dialog(QDialog):
         self.modeCombo.setItemText(2, _("First System Only"))
         self.modeCombo.setItemText(3, _("Layout Control"))
         self.deleteCheck.setText(_("Delete intermediate output files"))
-        self.embedSourceCodeCheck.setText(_("Embed Source Code (LilyPond >= 2.19.39)"))
+        self.embedSourceCodeCheck.setText(_("Embed Source Code"))
         self.englishCheck.setText(_("Run LilyPond with English messages"))
         self.commandLineLabel.setText(_("Additional Command Line Options:"))
         self.buttons.button(QDialogButtonBox.Ok).setText(_("Run LilyPond"))

--- a/frescobaldi_app/preferences/lilypond.py
+++ b/frescobaldi_app/preferences/lilypond.py
@@ -337,8 +337,7 @@ class Running(preferences.Group):
         self.embedSourceCode.setText(_("Embed Source Code files in publish mode"))
         self.embedSourceCode.setToolTip(_(
             "If checked, the LilyPond source files will be embedded in the PDF\n"
-            "when LilyPond is started in publish mode.\n"
-            "This feature is available since LilyPond 2.19.39."))
+            "when LilyPond is started in publish mode."))
         self.noTranslation.setText(_("Run LilyPond with English messages"))
         self.noTranslation.setToolTip(_(
             "If checked, LilyPond's output messages will be in English.\n"
@@ -411,5 +410,3 @@ class Target(preferences.Group):
             target = "pdf"
         s.setValue("default_output_target", target)
         s.setValue("open_default_view", self.openDefaultView.isChecked())
-
-


### PR DESCRIPTION
This version is old enough by now that it should be safe to assume the
user has a later version.