### PR TITLE
Don't try to get sip version

### DIFF
--- a/frescobaldi_app/debuginfo.py
+++ b/frescobaldi_app/debuginfo.py
@@ -47,14 +47,6 @@ def app_version():
     return appinfo.version
 
 @_catch_unknown
-def sip_version():
-    try:
-        import sip
-    except ImportError:
-        import PyQt5.sip as sip
-    return sip.SIP_VERSION_STR
-
-@_catch_unknown
 def pyqt_version():
     import PyQt5.QtCore
     return PyQt5.QtCore.PYQT_VERSION_STR
@@ -122,7 +114,6 @@ def version_info_named():
     yield "python-ly", ly_version()
     yield "Qt", qt_version()
     yield "PyQt", pyqt_version()
-    yield "sip", sip_version()
     yield "qpageview", qpageview_version()
     yield "poppler", poppler_version()
     yield "python-poppler-qt", python_poppler_version()


### PR DESCRIPTION
This doesn't really make sense, since sip is used for building python-poppler-qt5 but is not used at runtime.  If the user happens to have sip installed, it may be a different version than the one used to build python-poppler-qt5. As far as I understand, the PyQt5.sip module is generated by sip and does include the version of sip that was used to build PyQt5, but even that does not tell which sip version was used for building python-poppler-qt5, which may be a different one.

Fixes #1332