### PR TITLE
Show last 5 traceback frames in bug report, not 5 first frames

### DIFF
--- a/frescobaldi_app/exception.py
+++ b/frescobaldi_app/exception.py
@@ -49,7 +49,7 @@ class ExceptionDialog(QDialog):
         # _tblimited is the traceback, truncated to 5 frames max.
         # We do this because of size limits on what you can pass to GitHub
         # in a URL.
-        tblimited = traceback.format_exception(exctype, excvalue, exctb, limit=5)
+        tblimited = traceback.format_exception(exctype, excvalue, exctb, limit=-5)
         self._tblimited = ''.join(tblimited)
 
         self._ext_maintainer = app.extensions().is_extension_exception(tbfull)


### PR DESCRIPTION
Having the bottom of the traceback (the innermost frames) is more useful since it pinpoints the exact error location.

The origin of this patch is that I noticed https://github.com/frescobaldi/frescobaldi/issues/1636 had the top of the traceback only. My original intent when writing this code was the behavior implemented here.