### PR TITLE
Rename LilyPondInfo and Versions "auto" attributes

### DIFF
--- a/frescobaldi_app/lilypondinfo.py
+++ b/frescobaldi_app/lilypondinfo.py
@@ -119,7 +119,7 @@ def suitable(version):
     Otherwise the most recent LilyPond version is returned.
 
     """
-    infos_ = [i for i in infos() if i.auto]
+    infos_ = [i for i in infos() if i.autoVersionIncluded]
     if infos_:
         infos_.sort(key=lambda i: i.version())
         for i in infos_:
@@ -158,7 +158,7 @@ class LilyPondInfo(object):
 
     def __init__(self, command):
         self._command = command
-        self.auto = True
+        self.autoVersionIncluded = True
         self.name = "LilyPond"
         self._lytools = {}
 
@@ -383,7 +383,7 @@ class LilyPondInfo(object):
         if cmd:
             info = cls(cmd)
             if info.abscommand.wait():
-                info.auto = settings.value("auto", True, bool)
+                info.autoVersionIncluded = settings.value("auto", True, bool)
                 info.name = settings.value("name", "LilyPond", str)
                 for name in cls.ly_tool_names:
                     info.set_ly_tool(name, settings.value(name, name, str))
@@ -401,7 +401,7 @@ class LilyPondInfo(object):
         settings.setValue("datadir", self.datadir() or "")
         if self.abscommand():
             settings.setValue("mtime", int(os.path.getmtime(self.abscommand())))
-        settings.setValue("auto", self.auto)
+        settings.setValue("auto", self.autoVersionIncluded)
         settings.setValue("name", self.name)
         for name in self.ly_tool_names:
             value = self._lytools.get(name, name)

--- a/frescobaldi_app/preferences/lilypond.py
+++ b/frescobaldi_app/preferences/lilypond.py
@@ -71,8 +71,8 @@ class Versions(preferences.Group):
         self.instances.changed.connect(self.changed)
         self.instances.defaultButton.clicked.connect(self.defaultButtonClicked)
         layout.addWidget(self.instances)
-        self.auto = QCheckBox(clicked=self.changed)
-        layout.addWidget(self.auto)
+        self.autoVersion = QCheckBox(clicked=self.changed)
+        layout.addWidget(self.autoVersion)
         app.translateUI(self)
         userguide.openWhatsThis(self)
 
@@ -84,18 +84,18 @@ class Versions(preferences.Group):
 
     def translateUI(self):
         self.setTitle(_("LilyPond versions to use"))
-        self.auto.setText(_("Automatically choose LilyPond version from document"))
-        self.auto.setToolTip(_(
+        self.autoVersion.setText(_("Automatically choose LilyPond version from document"))
+        self.autoVersion.setToolTip(_(
             "If checked, the document's version determines the LilyPond version to use.\n"
             "See \"What's This\" for more information."))
-        self.auto.setWhatsThis(userguide.html("prefs_lilypond_autoversion") +
+        self.autoVersion.setWhatsThis(userguide.html("prefs_lilypond_autoversion") +
             _("See also {link}.").format(link=userguide.link("prefs_lilypond")))
 
     def loadSettings(self):
         s = settings()
         default = lilypondinfo.default()
         self._defaultCommand = s.value("default", default.command, str)
-        self.auto.setChecked(s.value("autoversion", False, bool))
+        self.autoVersion.setChecked(s.value("autoversion", False, bool))
         infos = sorted(lilypondinfo.infos(), key=lambda i: i.version())
         if not infos:
             infos = [default]
@@ -119,7 +119,7 @@ class Versions(preferences.Group):
             self._defaultCommand = infos[0].command
         s = settings()
         s.setValue("default", self._defaultCommand)
-        s.setValue("autoversion", self.auto.isChecked())
+        s.setValue("autoversion", self.autoVersion.isChecked())
         lilypondinfo.setinfos(infos)
         lilypondinfo.saveinfos()
 
@@ -217,8 +217,8 @@ class InfoDialog(QDialog):
         vbox.addWidget(l)
         vbox.addWidget(self.lilypond)
 
-        self.auto = QCheckBox()
-        vbox.addWidget(self.auto)
+        self.autoVersionIncluded = QCheckBox()
+        vbox.addWidget(self.autoVersionIncluded)
         vbox.addStretch(1)
 
         # toolcommands tab
@@ -263,7 +263,7 @@ class InfoDialog(QDialog):
         self.lilynameLabel.setToolTip(_("How this version of LilyPond will be displayed."))
         self.lilypondLabel.setText(_("LilyPond Command:"))
         self.lilypond.lineEdit.setToolTip(_("Name or full path of the LilyPond program."))
-        self.auto.setText(_("Include in automatic version selection"))
+        self.autoVersionIncluded.setText(_("Include in automatic version selection"))
         self.tab.setTabText(0, _("General"))
         self.tab.setTabText(1, _("Tool Commands"))
         for name, gui in self.toolnames():
@@ -273,7 +273,7 @@ class InfoDialog(QDialog):
         """Takes over settings for the dialog from the LilyPondInfo object."""
         self.lilyname.setText(info.name)
         self.lilypond.setPath(info.command)
-        self.auto.setChecked(info.auto)
+        self.autoVersionIncluded.setChecked(info.autoVersionIncluded)
         for name, gui in self.toolnames():
             self.ly_tool_widgets[name][1].setText(info.ly_tool(name))
 
@@ -286,7 +286,7 @@ class InfoDialog(QDialog):
             info = lilypondinfo.LilyPondInfo(self.lilypond.path())
         if self.lilyname.text() and not self.lilyname.text().isspace():
             info.name = self.lilyname.text()
-        info.auto = self.auto.isChecked()
+        info.autoVersionIncluded = self.autoVersionIncluded.isChecked()
         for name, gui in self.toolnames():
             info.set_ly_tool(name, self.ly_tool_widgets[name][1].text())
         return info


### PR DESCRIPTION
This prepares for introducing "auto-installed versions", which could be confused with these attributes related to automatic version selection.

(The patch for #313 is going to be a little large, so I will try to submit related changes like this piecemeal.)