### PR TITLE
Minor cleanup: use platform.system() consistently

### DIFF
--- a/README-development
+++ b/README-development
@@ -101,10 +101,10 @@ Case:   ClassName, module_name, methodname() (or methodName() for classes that
         inherit from Qt classes). Instance attributes that are not meant to be
         used from outside an instance are prefixed with an underscore, e.g.
         self._document.
-        
+
         There is a habit, inspired by Qt, to use setters and getters for such
         attributes: obj.setDocument(document) and obj.document().
-        
+
         Names for actions (e.g. file_open) and QSettings keys should always be
         lowercase and use underscores where needed.
 
@@ -126,19 +126,13 @@ package. The different groups separated by a blank line:
     from . import widget            # imports from current package
 
 Avoid platform specific code, but when it is really needed, you can test
-for Windows:
+for them:
 
-    if sys.platform.startswith('win'):
+    if platform.system() == "Linux":
         ...
-
-or:
-
-    if os.name == "nt":
+    elif platform.system() == "Darwin": # macOS
         ...
-
-Testing for Mac OS X can be done using:
-
-    if sys.platform.startswith('darwin'):
+    elif platform.system() == "Windows":
         ...
 
 
@@ -227,9 +221,9 @@ of testing and development, you don't even need to install Python at all.
 
 6. go to the frescobaldi directory and copy all the files from the installed
    version, except for the frescobaldi_app directory:
-   
+
    cd frescobaldi
-   
+
    cp /c/Program\ Files/Frescobaldi/*.pyd .
    cp /c/Program\ Files/Frescobaldi/frescobaldi.exe .
    cp /c/Program\ Files/Frescobaldi/*.dll .
@@ -253,4 +247,3 @@ Checklist before making a new release:
 - Bump the version in `frescobaldi_app/appinfo.py`.
 - Add the release date in `CHANGELOG.md` and `linux/org.frescobaldi.Frescobaldi.metainfo.xml.in`.
 - Update the list of contributors in `frescobaldi_app/userguide/credits.md`.
-

--- a/frescobaldi_app/__main__.py
+++ b/frescobaldi_app/__main__.py
@@ -35,6 +35,7 @@ toplevel.install()              # Add the path to frescobaldi_app to sys.path
 import checks                   # check whether Frescobaldi really can run
 
 import os
+import platform
 import re
 
 from PyQt5.QtCore import QSettings, QTimer, QUrl
@@ -98,11 +99,11 @@ def parse_commandline():
     args = QApplication.arguments()
 
     # Decode arguments to properly handle Unicode on Windows
-    if os.name == 'nt':
+    if platform.system() == 'Windows':
         args = [os.fsdecode(bytes(arg, 'mbcs')) for arg in args]
 
     # Strip interpreter name and its command line options on Windows
-    if os.name == 'nt':
+    if platform.system() == 'Windows':
         while args:
             if os.path.basename(args[0]).lower().startswith(appinfo.name):
                 break
@@ -217,7 +218,7 @@ def main(debug=False):
     import autocomplete     # auto-complete input
     import wordboundary     # better wordboundary behaviour for the editor
 
-    if sys.platform.startswith('darwin'):
+    if platform.system() == "Darwin":
         import macosx.setup
         macosx.setup.initialize()
 

--- a/frescobaldi_app/app.py
+++ b/frescobaldi_app/app.py
@@ -130,7 +130,7 @@ def instantiate():
     QApplication.setDesktopFileName(appinfo.desktop_file_name)
     QApplication.setOrganizationName(appinfo.name)
     QApplication.setOrganizationDomain(appinfo.domain)
-    if sys.platform.startswith('darwin'):
+    if platform.system() == "Darwin":
         qApp._menubar = QMenuBar()
     appInstantiated()
 

--- a/frescobaldi_app/autocomplete/documentdata.py
+++ b/frescobaldi_app/autocomplete/documentdata.py
@@ -24,6 +24,7 @@ Completions data harvested from a Document.
 
 import itertools
 import os
+import platform
 
 import listmodel
 import plugin
@@ -155,7 +156,7 @@ class DocumentDataSource(plugin.DocumentPlugin):
                 and f.islower()))
 
         # forward slashes on Windows (issue #804)
-        if os.name == "nt":
+        if platform.system() == "Windows":
             names = [name.replace('\\', '/') for name in names]
 
         return listmodel.ListModel(names)

--- a/frescobaldi_app/convert_ly.py
+++ b/frescobaldi_app/convert_ly.py
@@ -25,6 +25,7 @@ Updates a document using convert-ly.
 import difflib
 import textwrap
 import os
+import platform
 import sys
 
 from PyQt5.QtCore import QSettings, QSize
@@ -223,7 +224,7 @@ class Dialog(QDialog):
             j.environment['LC_MESSAGES'] = 'C'
         else:
             j.environment.pop('LC_MESSAGES', None)
-        if sys.platform.startswith('darwin'):
+        if platform.system() == "Darwin":
             import macosx
             if macosx.inside_app_bundle():
                 j.environment['PYTHONPATH'] = None

--- a/frescobaldi_app/file_import/toly_dialog.py
+++ b/frescobaldi_app/file_import/toly_dialog.py
@@ -23,7 +23,7 @@ Generic import dialog. Presuppose a child instance for the specific import.
 
 
 import os
-import sys
+import platform
 
 from PyQt5.QtCore import Qt
 
@@ -154,7 +154,7 @@ class ToLyDialog(QDialog):
             directory=os.path.dirname(self._input),
             encoding='utf-8')
         j._output_file = output
-        if sys.platform.startswith('darwin'):
+        if platform.system() == "Darwin":
             import macosx
             if macosx.inside_app_bundle():
                 j.environment['PYTHONPATH'] = None

--- a/frescobaldi_app/helpers.py
+++ b/frescobaldi_app/helpers.py
@@ -23,6 +23,7 @@ Helper application stuff.
 
 
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -115,9 +116,9 @@ def terminalCommands():
     There is always yielded at least one, which is suitable as default.
 
     """
-    if os.name == "nt":
+    if platform.system() == "Windows":
         yield ['cmd.exe']
-    elif sys.platform == 'darwin':
+    elif platform.system() == "Darwin":
         yield ['open', '-a', 'Terminal', '$f']
     else:
         # find a default linux terminal

--- a/frescobaldi_app/job/__init__.py
+++ b/frescobaldi_app/job/__init__.py
@@ -25,6 +25,7 @@ and capture the output to get it later or to have a log follow it.
 
 import codecs
 import os
+import platform
 import time
 
 from PyQt5.QtCore import QCoreApplication, QProcess, QProcessEnvironment
@@ -266,7 +267,7 @@ class Job(object):
         if self._process:
             self._aborted = True
             self.abort_message()
-            if os.name == "nt":
+            if platform.system() == "Windows":
                 self._process.kill()
             else:
                 self._process.terminate()

--- a/frescobaldi_app/lilypondinfo.py
+++ b/frescobaldi_app/lilypondinfo.py
@@ -25,7 +25,7 @@ Settings stuff and handling for different LilyPond versions.
 import glob
 import codecs
 import os
-import sys
+import platform
 import re
 
 from PyQt5.QtCore import QEventLoop, QSettings, QTimer
@@ -38,7 +38,7 @@ import job.queue
 import util
 import qutil
 
-if sys.platform.startswith('darwin'):
+if platform.system() == "Darwin":
     import macosx
 
 _infos = None   # this can hold a list of configured LilyPondInfo instances
@@ -87,7 +87,7 @@ def default():
     on other platforms simply "lilypond".
 
     """
-    lilypond = "lilypond-windows.exe" if os.name == "nt" else "lilypond"
+    lilypond = "lilypond-windows.exe" if platform.system() == "Windows" else "lilypond"
     return LilyPondInfo(lilypond)
 
 
@@ -101,7 +101,7 @@ def preferred():
     s = QSettings()
     s.beginGroup("lilypond_settings")
     # find default version
-    defaultCommand = "lilypond-windows.exe" if os.name == "nt" else "lilypond"
+    defaultCommand = "lilypond-windows.exe" if platform.system() == "Windows" else "lilypond"
     userDefault = s.value("default", defaultCommand, str)
     if userDefault != defaultCommand:
         for info in infos_:
@@ -169,13 +169,13 @@ class LilyPondInfo(object):
     @CachedProperty.cachedproperty
     def abscommand(self):
         """The absolute path of the command."""
-        if os.name == "nt":
+        if platform.system() == "Windows":
             # on Windows, newer versions of LilyPond don't add themselves to the
             # PATH, so add a probable path here
             path = glob.glob(os.path.join(
                 os.environ.get('ProgramFiles', 'C:\\Program Files'),
                 'LilyPond*', 'usr', 'bin'))
-        elif sys.platform.startswith('darwin'):
+        elif platform.system() == "Darwin":
             # also on Mac OS X, LilyPond is not automatically added to the PATH
             path = [
                 os.path.join('/Applications', 'LilyPond.app', 'Contents', 'Resources', 'bin'),
@@ -230,7 +230,7 @@ class LilyPondInfo(object):
             if command.endswith(outstrip):
                 command=command[:-len(outstrip)]
             macstrip='/Contents/Resources/bin/lilypond'
-            if sys.platform.startswith('darwin') and command.endswith('.app' + macstrip):
+            if platform.system() == "Darwin" and command.endswith('.app' + macstrip):
                 command=command[:-len(macstrip)]
             return util.homify(command)
         else:
@@ -338,7 +338,7 @@ class LilyPondInfo(object):
 
         # on Windows the tool command is not directly executable, but
         # must be started using the LilyPond-provided Python interpreter
-        if os.name == "nt":
+        if platform.system() == "Windows":
             if not os.access(toolpath, os.R_OK) and not toolpath.endswith('.py'):
                 toolpath += '.py'
             command = [self.python(), toolpath]

--- a/frescobaldi_app/mainwindow.py
+++ b/frescobaldi_app/mainwindow.py
@@ -25,7 +25,7 @@ Frescobaldi Main Window.
 
 import itertools
 import os
-import sys
+import platform
 import weakref
 
 from PyQt5.QtCore import (pyqtSignal, QByteArray, QDir, QMimeData, QSettings,
@@ -390,7 +390,8 @@ class MainWindow(QMainWindow):
         self.resize(settings.value("size", defaultSize, QSize))
         self.restoreState(settings.value('state', QByteArray(), QByteArray))
         self.tabBar.setVisible(settings.value('tabbar', True, bool))
-        if os.name != "posix" and settings.value('maximized', False, bool):
+        # DOCME: why only Windows?
+        if platform.system() == "Windows" and settings.value('maximized', False, bool):
             self.showMaximized()
 
     def writeSettings(self):
@@ -1312,7 +1313,7 @@ class ActionCollection(actioncollection.ActionCollection):
         self.edit_replace.setShortcuts(QKeySequence.Replace)
         self.edit_preferences.setShortcuts(QKeySequence.Preferences)
 
-        if sys.platform.startswith('darwin'):
+        if platform.system() == "Darwin":
             self.view_next_document.setShortcut(Qt.META + Qt.Key_Tab)
             self.view_previous_document.setShortcut(Qt.META + Qt.SHIFT + Qt.Key_Tab)
         else:
@@ -1327,7 +1328,7 @@ class ActionCollection(actioncollection.ActionCollection):
         self.help_manual.setShortcuts(QKeySequence.HelpContents)
 
         # Mac OS X-specific roles?
-        if sys.platform.startswith('darwin'):
+        if platform.system() == "Darwin":
             import macosx
             if macosx.use_osx_menu_roles():
                 self.file_quit.setMenuRole(QAction.QuitRole)

--- a/frescobaldi_app/musicview/__init__.py
+++ b/frescobaldi_app/musicview/__init__.py
@@ -35,6 +35,7 @@ All the point & click stuff is handled in the pointandclick module.
 
 import functools
 import os
+import platform
 import sys
 import weakref
 
@@ -157,8 +158,8 @@ class MusicViewPanel(panel.Panel):
             # warn about printing directly with cups on Mac
             s = QSettings()
             if (s.value("printing/directcups",
-                       False if sys.platform.startswith('darwin') else True, bool)
-                and sys.platform.startswith('darwin')):
+                       False if platform.system() == "Darwin" else True, bool)
+                and platform.system() == "Darwin"):
                 from PyQt5.QtCore import QUrl
                 from PyQt5.QtWidgets import QMessageBox
                 result =  QMessageBox.warning(self.mainwindow(),
@@ -426,5 +427,3 @@ class DocumentChooser(QComboBox):
         self.setWhatsThis(_(
             "Choose the PDF document to display or drag the file "
             "to another application or location."))
-
-

--- a/frescobaldi_app/pagedview.py
+++ b/frescobaldi_app/pagedview.py
@@ -26,7 +26,7 @@ This is used throughout Frescobaldi, to obey color settings etc.
 
 import itertools
 import os
-import sys
+import platform
 
 from PyQt5.QtCore import pyqtSignal, QMargins, QSettings, Qt
 from PyQt5.QtWidgets import QMessageBox
@@ -199,7 +199,7 @@ class PagedView(qpageview.widgetoverlay.WidgetOverlayViewMixin, qpageview.View):
         # but its settings are ignored and any choice (including opening the PDF)
         # results in printing to cups' default printer
         if (s.value("printing/directcups",
-                    False if sys.platform.startswith('darwin') else True, bool)
+                    False if platform.system() == "Darwin" else True, bool)
             and isinstance(self.document(), qpageview.poppler.PopplerDocument)
             and os.path.isfile(self.document().filename())
             and not printer.outputFileName()):
@@ -319,5 +319,3 @@ def loadSvgs(filenames):
 def loadImages(filenames):
     """Like qpageview.loadImages(), but uses a preconfigured renderer."""
     return qpageview.loadImages(filenames, getRenderer("image"))
-
-

--- a/frescobaldi_app/portmidi/pm_ctypes.py
+++ b/frescobaldi_app/portmidi/pm_ctypes.py
@@ -4,6 +4,7 @@
 
 
 import os
+import platform
 import sys
 
 from ctypes import (CDLL, CFUNCTYPE, POINTER, Structure, byref, c_char_p,
@@ -16,13 +17,13 @@ _PM_MACOSX_APP = '../Frameworks/libportmidi.dylib'
 
 # the basename of the portmidi/porttime libraries on different platforms
 _PM_DLL = dict(
-    win32 = 'libportmidi-0',
+    Windows = 'libportmidi-0',
 )
 _PT_DLL = dict(
-    win32 = 'libporttime-0',
+    Windows = 'libporttime-0',
 )
 
-if sys.platform.startswith('win'):
+if platform.system() == "Windows":
     # ctypes.util.find_library() does not implement the full Windows DLL search
     # order, so we have to provide it ourselves, so that the PortMidi DLL can
     # be found. See the docstring of the find_library() function for more
@@ -91,12 +92,12 @@ if sys.platform.startswith('win'):
                 return fname
         return None
 
-    dll_name = find_library(_PM_DLL['win32'], [os.path.dirname(__file__)])
-elif sys.platform.startswith('darwin') and macosx.inside_app_bundle() and os.path.exists(_PM_MACOSX_APP):
+    dll_name = find_library(_PM_DLL['Windows'], [os.path.dirname(__file__)])
+elif platform.system() == "Darwin" and macosx.inside_app_bundle() and os.path.exists(_PM_MACOSX_APP):
     dll_name = _PM_MACOSX_APP
 else:
     from ctypes.util import find_library
-    dll_name = find_library(_PM_DLL.get(sys.platform, 'portmidi'))
+    dll_name = find_library(_PM_DLL.get(platform.system(), 'portmidi'))
 if dll_name is None:
     raise ImportError("Couldn't find the PortMidi library.")
 
@@ -106,7 +107,7 @@ libpm = CDLL(dll_name)
 if hasattr(libpm, 'Pt_Time'):
     libpt = libpm
 else:
-    libpt = CDLL(find_library(_PT_DLL.get(sys.platform, 'porttime')))
+    libpt = CDLL(find_library(_PT_DLL.get(platform.system(), 'porttime')))
 
 
 # portmidi.h
@@ -237,4 +238,3 @@ libpt.Pt_Start.argtypes = [c_int32, PtCallback, c_void_p]
 libpt.Pt_Stop.restype = PtError
 libpt.Pt_Started.restype = c_int32
 libpt.Pt_Time.restype = PtTimestamp
-

--- a/frescobaldi_app/preferences/import_export.py
+++ b/frescobaldi_app/preferences/import_export.py
@@ -33,6 +33,8 @@ from PyQt5.QtGui import (
 from PyQt5.QtWidgets import QMessageBox
 
 import os
+import platform
+
 import appinfo
 import textformats
 import app
@@ -101,7 +103,7 @@ def importTheme(filename, widget, schemeWidget):
 
     fontElt = root.find('font')
 
-    defaultfont = "Lucida Console" if os.name == "nt" else "monospace"
+    defaultfont = "Lucida Console" if platform.system() == "Windows" else "monospace"
     if fontElt.get('fontFamily') in QFontDatabase().families():
         fontFamily = fontElt.get('fontFamily')
     else:

--- a/frescobaldi_app/preferences/lilypond.py
+++ b/frescobaldi_app/preferences/lilypond.py
@@ -23,6 +23,7 @@ LilyPond preferences page
 
 
 import os
+import platform
 import sys
 
 from PyQt5.QtCore import QSettings, Qt
@@ -279,7 +280,7 @@ class InfoDialog(QDialog):
 
     def newInfo(self):
         """Returns a new LilyPondInfo instance for our settings."""
-        if sys.platform.startswith('darwin') and self.lilypond.path().endswith('.app'):
+        if platform.system() == "Darwin" and self.lilypond.path().endswith('.app'):
             info = lilypondinfo.LilyPondInfo(
                 self.lilypond.path() + '/Contents/Resources/bin/lilypond')
         else:

--- a/frescobaldi_app/preferences/musicviewers.py
+++ b/frescobaldi_app/preferences/musicviewers.py
@@ -22,8 +22,8 @@ Music View preferences.
 """
 
 
+import platform
 import re
-import sys
 
 from PyQt5.QtCore import QSettings, Qt
 from PyQt5.QtGui import QFont
@@ -196,7 +196,7 @@ class Printing(preferences.Group):
         # see comment in pagedview and warning messages in musicview/__init__
         # and viewers/__init__ for the rationale for the default value
         self.useCups.setChecked(s.value("printing/directcups",
-                False if sys.platform.startswith('darwin') else True,
+                False if platform.system() == "Darwin" else True,
                 bool))
         with qutil.signalsBlocked(self.resolution):
             self.resolution.setEditText(format(s.value("printing/dpi", 300, int)))

--- a/frescobaldi_app/tabbar.py
+++ b/frescobaldi_app/tabbar.py
@@ -22,7 +22,7 @@ The tab bar with the documents.
 """
 
 
-import sys
+import platform
 
 from PyQt5.QtCore import QSettings, Qt, QUrl, pyqtSignal
 from PyQt5.QtWidgets import QMenu, QTabBar
@@ -111,7 +111,7 @@ QTabBar::tab:only-one {
     border-bottom-right-radius: 4px;
 }
 """
-        if sys.platform.startswith('darwin'):
+        if platform.system() == "Darwin":
             self.setStyleSheet(style)
 
     def readSettings(self):

--- a/frescobaldi_app/textformats.py
+++ b/frescobaldi_app/textformats.py
@@ -22,7 +22,7 @@ Loading and defaults for the different textformats used for Syntax Highlighting.
 """
 
 
-import os
+import platform
 
 from PyQt5.QtCore import QSettings
 from PyQt5.QtGui import QColor, QFont, QPalette, QTextCharFormat, QTextFormat
@@ -71,7 +71,7 @@ class TextFormatData(object):
         s.beginGroup("fontscolors/" + scheme)
 
         # load font
-        defaultfont = "Lucida Console" if os.name == "nt" else "monospace"
+        defaultfont = "Lucida Console" if platform.system() == "Windows" else "monospace"
         self.font = QFont(s.value("fontfamily", defaultfont, str))
         self.font.setPointSizeF(s.value("fontsize", 10.0, float))
 
@@ -319,4 +319,3 @@ defaultStyles = (
     'comment',
     'error',
 )
-

--- a/frescobaldi_app/util.py
+++ b/frescobaldi_app/util.py
@@ -27,6 +27,7 @@ import glob
 import itertools
 import io
 import os
+import platform
 import re
 import unicodedata
 
@@ -60,7 +61,7 @@ def findexe(cmd, path=None):
                     return os.path.join(p, cmd)
 
 
-if os.name == 'nt':
+if platform.system() == "Windows":
     def equal_paths(p1, p2):
         """Returns True if the paths are equal (case and separator insensitive)."""
         return p1.lower().replace('\\', '/') == p2.lower().replace('\\', '/')
@@ -71,7 +72,7 @@ else:
 
 
 # Make sure that also on Windows, directory slashes remain forward
-if os.name == 'nt':
+if platform.system() == "Windows":
     def normpath(path):
         """A version of os.path.normpath that keeps slashes forward."""
         return os.path.normpath(path).replace('\\', '/')

--- a/frescobaldi_app/viewers/__init__.py
+++ b/frescobaldi_app/viewers/__init__.py
@@ -33,7 +33,7 @@ This is an abstract base class for different viewer modules.
 
 import functools
 import os
-import sys
+import platform
 import weakref
 
 from PyQt5.QtCore import QSettings, QTimer, Qt, pyqtSignal
@@ -187,8 +187,8 @@ class AbstractViewPanel(panel.Panel):
             # warn about printing directly with cups on Mac
             s = QSettings()
             if (s.value("printing/directcups",
-                       False if sys.platform.startswith('darwin') else True, bool)
-                and sys.platform.startswith('darwin')):
+                       False if platform.system() == "Darwin" else True, bool)
+                and platform.system() == "Darwin"):
                 from PyQt5.QtCore import QUrl
                 from PyQt5.QtWidgets import QMessageBox
                 result =  QMessageBox.warning(self.mainwindow(),

--- a/frescobaldi_app/webenginedummy.py
+++ b/frescobaldi_app/webenginedummy.py
@@ -22,7 +22,7 @@ A QWidget showing a "could not load PyQtWebEngine" message.
 """
 
 
-import sys
+import platform
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QLabel, QLayout, QVBoxLayout, QWidget
@@ -47,7 +47,7 @@ class WebEngineDummy(QWidget):
         message = (_("<b>Could not load PyQtWebEngine, "
                      + "so the {tool} cannot be loaded.</b>").format(
                      tool = self.parentWidget().windowTitle()))
-        if sys.platform.startswith('darwin'):
+        if platform.system() == "Darwin":
             import macosx
             if (macosx.inside_app_bundle()
                     and not macosx.inside_lightweight_app_bundle()):


### PR DESCRIPTION
Instead of a mixture of os.name, sys.platform and platform.system().