### PR TITLE
Use modern syntax when creating scores and adding breathe marks

### DIFF
--- a/frescobaldi_app/quickinsert/barlines.py
+++ b/frescobaldi_app/quickinsert/barlines.py
@@ -121,7 +121,7 @@ class BreatheGroup(buttongroup.ButtonGroup):
             self.insertText('\\breathe')
         else:
             glyph = name[8:].replace('_', '.')
-            text = ("\\once \\override BreathingSign #'text = "
+            text = ("\\once \\override BreathingSign.text = "
                     '#(make-musicglyph-markup "scripts.{}")\n'
                     "\\breathe").format(glyph)
             self.insertText(text, blankline=True)

--- a/frescobaldi_app/scorewiz/build.py
+++ b/frescobaldi_app/scorewiz/build.py
@@ -466,7 +466,7 @@ class Builder:
         if self.smartNeutralDirection:
             ctxt_voice = ly.dom.Context('Voice', layout)
             ly.dom.Line('\\consists "Melody_engraver"', ctxt_voice)
-            ly.dom.Line("\\override Stem #'neutral-direction = #'()", ctxt_voice)
+            ly.dom.Line("\\override Stem.neutral-direction = #'()", ctxt_voice)
 
         if len(layout):
             doc.append(layout)

--- a/frescobaldi_app/scorewiz/parts/percussion.py
+++ b/frescobaldi_app/scorewiz/parts/percussion.py
@@ -244,10 +244,10 @@ class Drums(_base.Part):
             v = ('drums', 'timbales', 'congas', 'bongos', 'percussion')[i]
             p.getWith()['drumStyleTable'] = ly.dom.Scheme(v + '-style')
             v = (5, 2, 2, 2, 1)[i]
-            ly.dom.Line(f"\\override StaffSymbol #'line-count = #{v}", p.getWith())
+            ly.dom.Line(f"\\override StaffSymbol.line-count = #{v}", p.getWith())
         if self.drumStems.isChecked():
-            ly.dom.Line("\\override Stem #'stencil = ##f", p.getWith())
-            ly.dom.Line("\\override Stem #'length = #3  % " + _("keep some distance"),
+            ly.dom.Line("\\override Stem.stencil = ##f", p.getWith())
+            ly.dom.Line("\\override Stem.length = #3  % " + _("keep some distance"),
                 p.getWith())
         data.nodes.append(p)
 

--- a/frescobaldi_app/scorewiz/parts/strings.py
+++ b/frescobaldi_app/scorewiz/parts/strings.py
@@ -101,8 +101,8 @@ class BassoContinuo(Cello):
         a = data.assign('bcFigures')
         b = ly.dom.FigureMode(a)
         ly.dom.Identifier(data.globalName, b)
-        ly.dom.Line("\\override Staff.BassFigureAlignmentPositioning "
-                    "#'direction = #DOWN", b)
+        ly.dom.Line("\\override Staff.BassFigureAlignmentPositioning"
+                    ".direction = #DOWN", b)
         ly.dom.LineComment(_("Figures follow here."), b)
         ly.dom.BlankLine(b)
         figbass = ly.dom.FiguredBass()

--- a/frescobaldi_app/scorewiz/parts/vocal.py
+++ b/frescobaldi_app/scorewiz/parts/vocal.py
@@ -384,8 +384,8 @@ class Choir(VocalPart):
         # a function to set staff affinity (in LilyPond 2.13.4 and above):
         if builder.lyVersion >= (2, 13, 4):
             def setStaffAffinity(context, affinity):
-                ly.dom.Line("\\override VerticalAxisGroup "
-                     "#'staff-affinity = #" + affinity, context.getWith())
+                ly.dom.Line("\\override VerticalAxisGroup.staff-affinity = #" +
+                            affinity, context.getWith())
         else:
             def setStaffAffinity(lyricsContext, affinity):
                 pass
@@ -517,7 +517,7 @@ class Choir(VocalPart):
                     ambitusContext = (s if numVoices == 1 else v).getWith()
                     ly.dom.Line('\\consists "Ambitus_engraver"', ambitusContext)
                     if voiceNum > 1:
-                        ly.dom.Line("\\override Ambitus #'X-offset = #{}".format(
+                        ly.dom.Line("\\override Ambitus.X-offset = #{}".format(
                                  (voiceNum - 1) * 2.0), ambitusContext)
 
                 pianoReduction[voice].append(a.name)
@@ -583,7 +583,7 @@ class Choir(VocalPart):
 
             # Make the piano part somewhat smaller
             ly.dom.Line("fontSize = #-1", piano.getWith())
-            ly.dom.Line("\\override StaffSymbol #'staff-space = #(magstep -1)",
+            ly.dom.Line("\\override StaffSymbol.staff-space = #(magstep -1)",
                 piano.getWith())
 
             # Nice to add Mark engravers


### PR DESCRIPTION
Fix issue #1717. 

Use dot syntax instead of `#'` between grob name and property.  `scorewiz/scoreproperties.py` was *not* modified because there is a test to see if the LilyPond is >= 2.11.44, so the old syntax is correct in that case.  There are also many `ly` example files with the old syntax, but I confined this patch to Python programs. 