### PR TITLE
Fix ruff check E713, 'not in' warnings

### DIFF
--- a/frescobaldi/extensions/__init__.py
+++ b/frescobaldi/extensions/__init__.py
@@ -599,7 +599,7 @@ class Extensions(QObject):
         """
 
         inactive = self.inactive_extensions()
-        active = [key for key in self._infos.keys() if not key in inactive]
+        active = [key for key in self._infos.keys() if key not in inactive]
         inactive_dependencies = []
         missing_dependencies = []
         infos = self._infos
@@ -682,11 +682,11 @@ class Extensions(QObject):
     def load_extensions(self):
         """Load active extensions in topological order."""
         root = self.root_directory()
-        if not root in sys.path:
+        if root not in sys.path:
             sys.path.append(root)
 
         for ext in [ext for ext  in self._extensions_ordered
-            if not ext in self.inactive_extensions()]:
+            if ext not in self.inactive_extensions()]:
             try:
                 # measure loading time
                 start = perf_counter()
@@ -882,7 +882,7 @@ class Extensions(QObject):
     def set_inactive(self, extension, state=True):
         """Set one extension to active/inactive"""
         if state:
-            if not extension in self._inactive_extensions:
+            if extension not in self._inactive_extensions:
                 self._inactive_extensions.append(extension)
         else:
             if extension in self._inactive_extensions:
@@ -905,7 +905,7 @@ class Extensions(QObject):
             inactive_changed = True
         else:
             for ext in inactive:
-                if not ext in self._inactive_extensions:
+                if ext not in self._inactive_extensions:
                     inactive_changed = True
                     break
         self.reset_inactive(inactive)

--- a/frescobaldi/extensions/settings.py
+++ b/frescobaldi/extensions/settings.py
@@ -58,7 +58,7 @@ class ExtensionSettings(QObject):
     def get(self, key):
         """Retrieve a setting.
         Raises a KeyError if non-existent key is requested."""
-        if not key in self._defaults.keys():
+        if key not in self._defaults.keys():
             raise KeyError(
                 _("Trying to retrieve unknown setting '{setting}' "
                   "in extension '{extension}'").format(
@@ -78,7 +78,7 @@ class ExtensionSettings(QObject):
         Check type before and raise an exception if necessary."""
         extension_name = (self.extension().display_name()
             or self.extension().name())
-        if not key in self._defaults.keys():
+        if key not in self._defaults.keys():
             raise KeyError(
                 _("Trying to store unknown setting '{setting}' "
                   "in extension '{extension}'").format(

--- a/frescobaldi/fonts/textfonts.py
+++ b/frescobaldi/fonts/textfonts.py
@@ -408,7 +408,7 @@ class TextFonts(QObject):
                 else style
             )
 
-        if not family_name in families.keys():
+        if family_name not in families.keys():
             families[family_name] = {}
         family = families[family_name]
         input = input.strip().split(':')
@@ -421,7 +421,7 @@ class TextFonts(QObject):
             # We "unescape" hyphens because this escape is not necessary
             # for our purposes.
             sub_family = input[0].split(',')[-1].replace('\\-', '-')
-            if not sub_family in family.keys():
+            if sub_family not in family.keys():
                 family[sub_family] = []
             qt_styles = self.font_db.styles(sub_family)
             lily_styles = input[1][6:].split(',')
@@ -447,7 +447,7 @@ class TextFonts(QObject):
                         break
                 if not match:
                     match = un_camel(lily_styles[0])
-            if not match in family[sub_family]:
+            if match not in family[sub_family]:
                 family[sub_family].append(match)
         else:
             pass

--- a/frescobaldi/job/__init__.py
+++ b/frescobaldi/job/__init__.py
@@ -124,7 +124,7 @@ class Job:
     def add_argument(self, arg):
         """Append an additional command line argument if it is not
         present already."""
-        if not arg in self._arguments:
+        if arg not in self._arguments:
             self._arguments.append(arg)
 
     def arguments(self):

--- a/frescobaldi/job/lilypond.py
+++ b/frescobaldi/job/lilypond.py
@@ -126,7 +126,7 @@ class LilyPondJob(Job):
     def add_additional_arg(self, arg):
         """Append an additional command line argument if it is not
         present already."""
-        if not arg in self._additional_args:
+        if arg not in self._additional_args:
             self._additional_args.append(arg)
 
     def add_include_path(self, path):

--- a/frescobaldi/lilydoc/manager.py
+++ b/frescobaldi/lilydoc/manager.py
@@ -138,7 +138,7 @@ def urls():
     installed = lilypondinfo.preferred()
     if installed.version():
         remote_url = installed.lilydoc_url()
-        if not remote_url in remote:
+        if remote_url not in remote:
             remote.insert(0, remote_url)
 
     # now find all instances of LilyPond documentation in the local paths

--- a/frescobaldi/panelmanager.py
+++ b/frescobaldi/panelmanager.py
@@ -132,7 +132,7 @@ class PanelManager(plugin.MainWindowPlugin):
             menu.addMenu(submenu)
 
         for name, panel in self._panels:
-            if not panel in added_panels:
+            if panel not in added_panels:
                 menu.addAction(panel.toggleViewAction())
 
     def panels_at(self, area):

--- a/frescobaldi/preferences/import_export.py
+++ b/frescobaldi/preferences/import_export.py
@@ -117,7 +117,7 @@ def importTheme(filename, widget, schemeWidget):
         tfd.defaultStyles[elt.tag] = eltToStyle(elt)
 
     for style in root.find('allStyles'):
-        if not style in tfd.allStyles:
+        if style not in tfd.allStyles:
             tfd.allStyles[style] = {}
         for elt in style:
             tfd.allStyles[style.tag][elt.tag] = eltToStyle(elt)
@@ -133,7 +133,7 @@ def exportShortcut(widget, scheme, schemeName, filename):
     lst = {}
     for item in widget.items():
         col = item.collection.name
-        if not col in lst:
+        if col not in lst:
             lst[col] = {}
         if not item.isDefault(scheme):
             lst[col][item.name] = item.shortcuts(scheme)

--- a/frescobaldi/vbcl/__init__.py
+++ b/frescobaldi/vbcl/__init__.py
@@ -37,7 +37,7 @@ def check_mandatory_keys(d, mandatory_keys):
     if mandatory_keys:
         missing = []
         for key in mandatory_keys:
-            if not key in d.keys():
+            if key not in d.keys():
                 missing.append(key)
         if missing:
             raise ValueError(

--- a/frescobaldi/vcs/__init__.py
+++ b/frescobaldi/vcs/__init__.py
@@ -46,7 +46,7 @@ def is_available(tool):
 
     Any NNNrepo.py module has to implement a function vcs_available()
     """
-    if not tool in _vcs_modules.keys():
+    if tool not in _vcs_modules.keys():
         raise VCSError('Invalid argument for VCS software: {}\nSupported:\n- {}'.format(
             tool,
             "\n- ".join(_vcs_modules.keys())

--- a/frescobaldi/vcs/menu.py
+++ b/frescobaldi/vcs/menu.py
@@ -86,7 +86,7 @@ class GitBranchGroup(plugin.MainWindowPlugin, QActionGroup):
         """
         result = []
         for branch in vcs.app_repo.branches():
-            if not branch in self._acts:
+            if branch not in self._acts:
                 self.addBranch(branch)
             result.append(self._acts[branch])
         return result

--- a/frescobaldi/viewers/__init__.py
+++ b/frescobaldi/viewers/__init__.py
@@ -545,7 +545,7 @@ class ViewdocChooserAction(ComboBoxAction):
         """Load from a list of filenames. Check if the file already exists."""
         viewdocs = []
         for f in files:
-            if not f in self._viewdocFiles():
+            if f not in self._viewdocFiles():
                 doc = pagedview.loadPdf(f)
                 doc.ispresent = os.path.isfile(f)
                 viewdocs.append(doc)


### PR DESCRIPTION
Change `not <element> in <list>` to `<element> not in <list>`.

    $ ruff check --select E713
    All checks passed!

I was able to test all files except `frescobaldi/vbcl/__init__.py`, which has to do with extensions, I think.  I couldn't find any Frescobaldi extensions on the web to add and remove, but the change is a trivial one, so I think we're okay.
