### PR TITLE
Stop crash when selecting text

### DIFF
--- a/frescobaldi/view.py
+++ b/frescobaldi/view.py
@@ -323,5 +323,6 @@ class View(QPlainTextEdit):
     def createMimeDataFromSelection(self):
         """Reimplemented to only copy plain text."""
         m = QMimeData()
+        m.setParent(self)
         m.setText(self.textCursor().selection().toPlainText())
         return m


### PR DESCRIPTION
A per @mitya57, set parent of m before selecting text to prevent crash.  Fixes issue #2126
