### PR TITLE
Use treble_8 clef by default for classical guitar

### DIFF
--- a/frescobaldi/scorewiz/parts/plucked_strings.py
+++ b/frescobaldi/scorewiz/parts/plucked_strings.py
@@ -343,6 +343,9 @@ class Guitar(TablaturePart):
         layout.addLayout(box)
         self.octaveClef = QCheckBox()
         layout.addWidget(self.octaveClef)
+        # Use treble_8 by default for (classical) Guitar but not derived
+        # types, since it is less common in the styles those are intended for
+        self.octaveClef.setChecked(type(self) is Guitar)
 
     def translateWidgets(self):
         super().translateWidgets()


### PR DESCRIPTION
We have discussed before whether an octave or plain clef is more appropriate for guitar (style guides differ on this point). My impression last time was that octave clefs are more accepted/preferred in the classical guitar world, while plain clefs are more common in popular music. This patch sets the Score Wizard's defaults accordingly for each type of guitar.