### PR TITLE
Add the vcs-browser URL to the metainfo file

### DIFF
--- a/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
+++ b/linux/org.frescobaldi.Frescobaldi.metainfo.xml.in
@@ -70,6 +70,7 @@
 
   <url type="homepage">https://www.frescobaldi.org/</url>
   <url type="bugtracker">https://github.com/frescobaldi/frescobaldi/issues</url>
+  <url type="vcs-browser">https://github.com/frescobaldi/frescobaldi</url>
   <url type="contact">https://groups.google.com/g/frescobaldi</url>
 
   <launchable type="desktop-id">org.frescobaldi.Frescobaldi.desktop</launchable>


### PR DESCRIPTION
Flathub linter considers this missing tag only a warning now, but warnings can be promoted to errors in the future. Let's fix it.
