### PR TITLE
Fix redundant Shift modifier in shortcuts for symbol keys

### DIFF
--- a/frescobaldi/widgets/keysequencewidget.py
+++ b/frescobaldi/widgets/keysequencewidget.py
@@ -161,6 +161,11 @@ class KeySequenceButton(QPushButton):
             # change Shift+Backtab into Shift+Tab
             if key == Qt.Key.Key_Backtab and modifiers & Qt.KeyboardModifier.ShiftModifier:
                 key = QKeyCombination(modifiers, Qt.Key.Key_Tab)
+            # if a symbol key is already transformed by Shift (e.g. ';' to ':'),
+            # remove the redundant Shift modifier to avoid ambiguous shortcuts
+            elif ev.text() and not ( Qt.Key.Key_A <= key <= Qt.Key.Key_Z):
+                modifiers &= ~Qt.KeyboardModifier.ShiftModifier
+                key = QKeyCombination(modifiers, key)
             else:
                 key = QKeyCombination(modifiers, key)
 


### PR DESCRIPTION
When a symbol key is transformed by the Shift modifier (e.g., ';' to ':'), Qt includes both the Shift modifier and the resulting key in the sequence. This leads to 'ambiguous shortcut' errors (e.g., 'Ctrl+Shift+:').