### PR TITLE
Workaround for Qt 6.10.1 macOS crash

### DIFF
--- a/frescobaldi/icons/__init__.py
+++ b/frescobaldi/icons/__init__.py
@@ -23,6 +23,7 @@ Icons.
 
 
 import os
+import sys
 
 from PyQt6.QtCore import QDir, QFile, QFileInfo, QSettings, QSize
 from PyQt6.QtGui import QIcon
@@ -86,6 +87,13 @@ def initialize():
 
 def update_theme():
     """Change the theme for icon lookup after change of style preference"""
+    if sys.platform == "darwin":
+        # On macOS, QAppleIconEngine (SF Symbols) crashes with zero-dimension
+        # rects in PyQt6 6.10.1+ due to integer division in actualSize().
+        # Always use our bundled theme to avoid the crash. See:
+        # https://bugreports.qt.io/browse/QTBUG-TBD
+        QIcon.setThemeName("TangoExt")
+        return
     s = QSettings()
     if s.value("system_icons", True, bool):
         QIcon.setThemeName(s.value("guistyle", "", str))

--- a/frescobaldi/icons/__init__.py
+++ b/frescobaldi/icons/__init__.py
@@ -23,7 +23,7 @@ Icons.
 
 
 import os
-import sys
+import platform
 
 from PyQt6.QtCore import QDir, QFile, QFileInfo, QSettings, QSize
 from PyQt6.QtGui import QIcon
@@ -87,7 +87,7 @@ def initialize():
 
 def update_theme():
     """Change the theme for icon lookup after change of style preference"""
-    if sys.platform == "darwin":
+    if platform.system() == "Darwin":
         # On macOS, QAppleIconEngine (SF Symbols) crashes with zero-dimension
         # rects in PyQt6 6.10.1+ due to integer division in actualSize().
         # Always use our bundled theme to avoid the crash. See:

--- a/frescobaldi/preferences/general.py
+++ b/frescobaldi/preferences/general.py
@@ -22,6 +22,8 @@ Keyboard shortcuts settings page.
 """
 
 
+import sys
+
 from PyQt6.QtCore import QSettings
 from PyQt6.QtWidgets import (
     QApplication,
@@ -92,12 +94,20 @@ class General(preferences.Group):
 
         self.systemIcons = QCheckBox(toggled=self.changed)
         grid.addWidget(self.systemIcons, 2, 0, 1, 3)
+        self.systemIconsWarning = QLabel()
+        self.systemIconsWarning.setWordWrap(True)
+        if sys.platform == "darwin":
+            self.systemIcons.setEnabled(False)
+            self.systemIconsWarning.setVisible(True)
+        else:
+            self.systemIconsWarning.setVisible(False)
+        grid.addWidget(self.systemIconsWarning, 3, 0, 1, 3)
         self.tabsClosable = QCheckBox(toggled=self.changed)
-        grid.addWidget(self.tabsClosable, 3, 0, 1, 3)
+        grid.addWidget(self.tabsClosable, 4, 0, 1, 3)
         self.splashScreen = QCheckBox(toggled=self.changed)
-        grid.addWidget(self.splashScreen, 4, 0, 1, 3)
+        grid.addWidget(self.splashScreen, 5, 0, 1, 3)
         self.allowRemote = QCheckBox(toggled=self.changed)
-        grid.addWidget(self.allowRemote, 5, 0, 1, 3)
+        grid.addWidget(self.allowRemote, 6, 0, 1, 3)
 
         grid.setColumnStretch(2, 1)
 
@@ -163,6 +173,11 @@ class General(preferences.Group):
         self.systemIcons.setToolTip(_(
             "If checked, icons of the desktop icon theme "
             "will be used instead of the bundled icons."))
+        if sys.platform == "darwin":
+            self.systemIconsWarning.setText(_(
+                "System icons are disabled on macOS due to a crash in "
+                "PyQt6 6.10.1+. The bundled icon theme is "
+                "used instead."))
         self.splashScreen.setText(_("Show Splash Screen on Startup"))
         self.tabsClosable.setText(_("Show Close Button on Document tabs"))
         self.allowRemote.setText(_("Open Files in Running Instance"))

--- a/frescobaldi/preferences/general.py
+++ b/frescobaldi/preferences/general.py
@@ -22,8 +22,6 @@ Keyboard shortcuts settings page.
 """
 
 
-import sys
-
 from PyQt6.QtCore import QSettings
 from PyQt6.QtWidgets import (
     QApplication,
@@ -94,20 +92,12 @@ class General(preferences.Group):
 
         self.systemIcons = QCheckBox(toggled=self.changed)
         grid.addWidget(self.systemIcons, 2, 0, 1, 3)
-        self.systemIconsWarning = QLabel()
-        self.systemIconsWarning.setWordWrap(True)
-        if sys.platform == "darwin":
-            self.systemIcons.setEnabled(False)
-            self.systemIconsWarning.setVisible(True)
-        else:
-            self.systemIconsWarning.setVisible(False)
-        grid.addWidget(self.systemIconsWarning, 3, 0, 1, 3)
         self.tabsClosable = QCheckBox(toggled=self.changed)
-        grid.addWidget(self.tabsClosable, 4, 0, 1, 3)
+        grid.addWidget(self.tabsClosable, 3, 0, 1, 3)
         self.splashScreen = QCheckBox(toggled=self.changed)
-        grid.addWidget(self.splashScreen, 5, 0, 1, 3)
+        grid.addWidget(self.splashScreen, 4, 0, 1, 3)
         self.allowRemote = QCheckBox(toggled=self.changed)
-        grid.addWidget(self.allowRemote, 6, 0, 1, 3)
+        grid.addWidget(self.allowRemote, 5, 0, 1, 3)
 
         grid.setColumnStretch(2, 1)
 
@@ -173,11 +163,6 @@ class General(preferences.Group):
         self.systemIcons.setToolTip(_(
             "If checked, icons of the desktop icon theme "
             "will be used instead of the bundled icons."))
-        if sys.platform == "darwin":
-            self.systemIconsWarning.setText(_(
-                "System icons are disabled on macOS due to a crash in "
-                "PyQt6 6.10.1+. The bundled icon theme is "
-                "used instead."))
         self.splashScreen.setText(_("Show Splash Screen on Startup"))
         self.tabsClosable.setText(_("Show Close Button on Document tabs"))
         self.allowRemote.setText(_("Open Files in Running Instance"))


### PR DESCRIPTION
This PR's workaround addresses a macOS crash reported in: https://github.com/frescobaldi/frescobaldi/issues/2160

Note: I used Claude Code heavily. This is my first time looking at the code for Frescobaldi and Qt. It took a lot of guiding Claude and lldb to root cause and reproduce the bug in C++.

The root cause is a bug in Qt itself. My priority is getting Frescobaldi working on macOS. Later I'll try to submit the C++ reproduction to the Qt bug tracker.

## The workaround

A previous proposal (in #2160) felt more intrusive and hacked. The change here basically does the same thing by disabling the usage of system icons on macOS.

## Demonstration of crash

Here's a reproduction of the crash. Run with PyQt 6.9.1 and it works. I've tested this with PyQt 6.10.1 and it crashes. I have not tried this bug reproduction with 6.11.1 (but Frescobaldi with 6.11.1 crashes with a similar if not same stack). Note: The following was written completely by Claude Code.

```py
"""
Minimal PyQt6 reproducer for QAppleIconEngine crash in Qt 6.10.1 on macOS.

Root cause: QAppleIconEngine::actualSize() uses integer division
(size.width() / size.height()) instead of floating-point division.
When width >> height for a non-square SF Symbol, the result truncates
to a zero-width size, which crashes AppKit's symbol rep provider.

Run with PyQt6 linked against Qt 6.10.1 to trigger the crash.
"""

import sys
from PyQt6.QtWidgets import QApplication
from PyQt6.QtGui import QIcon
from PyQt6.QtCore import QSize

def main():
    app = QApplication(sys.argv)

    # "edit-paste" maps to SF Symbol "document.on.clipboard" (native {17, 18}).
    # Any non-square SF Symbol icon should work.
    icon = QIcon.fromTheme("edit-paste")
    if icon.isNull():
        print("edit-paste icon not found (not on macOS or no SF Symbols?)")
        sys.exit(1)

    print("Requesting pixmap at size (11, 1) — this triggers the crash on Qt 6.10.1")
    print("  actualSize({11, 1}) does integer division: 11/1 = 11")
    print("  11 > 0.944 (icon aspect ratio) → rwidth = 1 * 0.944 = 0 (int truncation)")
    print("  Result: {0, 1} → paint() calls [NSImage setSize:{0,1}] → NaN → crash")

    # This is the crash trigger.
    pm = icon.pixmap(QSize(11, 1))

    print(f"No crash — bug is not present. Pixmap result: {pm.size().width()}x{pm.size().height()}")

if __name__ == "__main__":
    main()
```