### PR TITLE
Downgrade PyQt6 to 6.9 for macOS packages + re-enable macOS signing

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout PR repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout Flathub manifest
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: flathub/org.frescobaldi.Frescobaldi
           path: flathub-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["Windows"]
-        # macOS disabled until we have a new certificate
-        #target: ["Windows", "macOS", "macOS-Intel"]
+        target: ["Windows", "macOS", "macOS-Intel"]
         include:
           - target: "Windows"
             platform: "windows"
@@ -63,19 +61,19 @@ jobs:
             runs-on: "windows-latest"
             filename: dist/*.msi
 
-          # - target: "macOS"
-          #   platform: "macOS"
-          #   output-format: "app"
-          #   runs-on: "macos-latest"
-          #   briefcase-package-args: '--identity "$CERTIFICATE_ID"'
-          #   filename: dist/*.dmg
+          - target: "macOS"
+            platform: "macOS"
+            output-format: "app"
+            runs-on: "macos-latest"
+            briefcase-package-args: '--identity "$CERTIFICATE_ID"'
+            filename: dist/*.dmg
 
-          # - target: "macOS-Intel"
-          #   platform: "macOS"
-          #   output-format: "app"
-          #   runs-on: "macos-latest"
-          #   briefcase-package-args: '--identity "$CERTIFICATE_ID"'
-          #   filename: dist/*.dmg
+          - target: "macOS-Intel"
+            platform: "macOS"
+            output-format: "app"
+            runs-on: "macos-latest"
+            briefcase-package-args: '--identity "$CERTIFICATE_ID"'
+            filename: dist/*.dmg
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Import signing certificate on macOS
         if: ${{ (matrix.target == 'macOS') || (matrix.target == 'macOS-Intel') }}
@@ -111,7 +111,7 @@ jobs:
           xcrun notarytool store-credentials "briefcase-macOS-$TEAM_ID" --apple-id "$APPLE_ID" --team-id $TEAM_ID --password $BRIEFCASE_PASSWORD
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -170,7 +170,7 @@ jobs:
           mv dist/Frescobaldi-$VERSION.dmg dist/Frescobaldi-$VERSION-Intel.dmg
 
       - name: Upload Frescobaldi
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frescobaldi-${{ matrix.target }}
           path: dist
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload Log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Log-Failure-${{ matrix.target }}
           path: logs/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,16 +50,6 @@ bundle = "org.frescobaldi"
 # Briefcase does not support dynamic version yet.
 # https://github.com/beeware/briefcase/issues/474
 version = "4.0.7.dev0"
-requires = [
-    "PyQt6==6.11.0",
-    "PyQt6-Qt6==6.11.0",
-    "PyQt6-sip==13.11.1",
-    "PyQt6-WebEngine==6.11.0",
-    "PyQt6-WebEngine-Qt6==6.11.0",
-    "python-ly==0.9.10",
-    "qpageview==1.0.4",
-    "pygame-ce==2.5.7"
-]
 
 [tool.briefcase.app.frescobaldi]
 formal_name = "Frescobaldi"
@@ -67,8 +57,31 @@ description = "Write LilyPond music sheets"
 long_description = "Frescobaldi is an advanced text editor to edit LilyPond sheet music files. It aims to be powerful, yet lightweight and easy to use."
 sources = ['frescobaldi']
 icon = "frescobaldi/icons/org.frescobaldi.Frescobaldi"
+requires = [
+    "python-ly==0.9.10",
+    "qpageview==1.0.4",
+    "pygame-ce==2.5.7"
+]
+
+[tool.briefcase.app.frescobaldi.macos]
+# macOS may crash if PyQt>6.9
+# https://github.com/frescobaldi/frescobaldi/issues/2160
+requires = [
+  "PyQt6==6.9.1",
+  "PyQt6-Qt6==6.9.2",
+  "PyQt6-sip==13.11.0",
+  "PyQt6-WebEngine==6.9.0",
+  "PyQt6-WebEngine-Qt6==6.9.2"
+]
 
 [tool.briefcase.app.frescobaldi.windows]
+requires = [
+  "PyQt6==6.11.0",
+  "PyQt6-Qt6==6.11.0",
+  "PyQt6-sip==13.11.1",
+  "PyQt6-WebEngine==6.11.0",
+  "PyQt6-WebEngine-Qt6==6.11.0"
+]
 use_full_install_path = false
 
 [tool.briefcase.app.frescobaldi.document_type.ly]


### PR DESCRIPTION
We must downgrade PyQt6 for macOS packages to version 6.9 because of a crash discussed in #2160.

This is a quick workaround to that problem, until we have a better understanding of the Qt bug.
