### PR TITLE
Rethink (and document) low-DPI options for copy-to-image

### DIFF
--- a/frescobaldi/copy2image.py
+++ b/frescobaldi/copy2image.py
@@ -67,7 +67,9 @@ class Dialog(QDialog):
         self.dpiCombo = QComboBox(insertPolicy=QComboBox.InsertPolicy.NoInsert, editable=True)
         self.dpiCombo.lineEdit().setCompleter(None)
         self.dpiCombo.setValidator(QDoubleValidator(10.0, 1200.0, 4, self.dpiCombo))
-        self.dpiCombo.addItems([format(i) for i in (72, 100, 200, 300, 600, 1200)])
+        # 96 dpi is a standard PC screen; 192 dpi is high-DPI or "Retina"
+        # 300 dpi and up are print resolutions
+        self.dpiCombo.addItems([format(i) for i in (96, 192, 300, 600, 1200)])
 
         self.colorCheck = QCheckBox(checked=False)
         self.colorButton = widgets.colorbutton.ColorButton()


### PR DESCRIPTION
My thought is there are two major use cases for this feature: screenshots, which should match common screen densities, and inserting snippets into documents, which should match common print densities.

This patch adds 96 and 192 dpi as the lower-DPI options for screen use. It removes 72, 100, and 200 dpi as standard options, since they are rarely used now for either screen or print due to their poor quality.