### PR TITLE
Reduce link cache memory usage

### DIFF
--- a/frescobaldi/musicview/pointandclick.py
+++ b/frescobaldi/musicview/pointandclick.py
@@ -34,8 +34,6 @@ import util
 import textedit
 import pointandclick
 
-from PyQt6.QtCore import QPointF, QRectF
-
 
 # cache point and click handlers for PDF documents
 _cache = weakref.WeakKeyDictionary()
@@ -57,8 +55,7 @@ def links(document):
                         t = textedit.link(link.url)
                         if t:
                             filename = util.normpath(t.filename)
-                            area = QRectF(QPointF(*link.area[0:2]), QPointF(*link.area[2:4]))
-                            l.add_link(filename, t.line, t.column, (num, area))
+                            l.add_link(filename, t.line, t.column, (num, link.area))
         return l
 
 

--- a/frescobaldi/musicview/widget.py
+++ b/frescobaldi/musicview/widget.py
@@ -27,7 +27,8 @@ import collections
 import itertools
 import os
 
-from PyQt6.QtCore import pyqtSignal, QMargins, QPoint, QRect, QSettings, Qt, QUrl
+from PyQt6.QtCore import (pyqtSignal, QMargins, QPoint, QPointF, QRect, QRectF,
+                          QSettings, Qt, QUrl)
 from PyQt6.QtGui import QCursor, QTextCharFormat
 from PyQt6.QtWidgets import QToolTip, QVBoxLayout, QWidget
 
@@ -235,7 +236,8 @@ class MusicView(QWidget):
         areas = collections.defaultdict(list)
         for dest in links.destinations()[s]:
             for pageNum, rect in dest:
-                areas[layout[pageNum]].append(rect)
+                areas[layout[pageNum]].append(
+                    QRectF(QPointF(*rect[0:2]), QPointF(*rect[2:4])))
 
         if scroll:
             # compute the bounding rect


### PR DESCRIPTION
Previously link areas were cached as QRectF objects, which carry a lot of overhead. This patch reduces memory usage by caching them as plain tuples and only converting them to QRectF when needed.

This may help with the memory leak identified in #2159.