### PR TITLE
Fix error on template and snippet import

### DIFF
--- a/frescobaldi/snippet/import_export.py
+++ b/frescobaldi/snippet/import_export.py
@@ -40,6 +40,7 @@ import userguide
 import widgets.dialog
 
 from . import model
+from . import tool
 from . import snippets
 from . import builtin
 
@@ -204,7 +205,7 @@ def load(filename, widget):
     qutil.saveDialogSize(dlg, "snippettool/import/size", QSize(400, 300))
     if not dlg.exec() or not items:
         return
-    ac = model.collection()
+    ac = tool.collection()
     m = model.model()
     with qutil.busyCursor():
         for i in items:

--- a/frescobaldi/snippet/model.py
+++ b/frescobaldi/snippet/model.py
@@ -29,7 +29,6 @@ from PyQt6.QtCore import QAbstractItemModel, QModelIndex, Qt
 from PyQt6.QtGui import QKeySequence
 
 import app
-import actioncollection
 
 from . import snippets, tool
 


### PR DESCRIPTION
I just wanted to import a simple template from another computer and was stuck with #2097 . 
I took a quick look at the existing changes and this patch should solve the issue (at least I managed to import my template)